### PR TITLE
Add maven badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 [![Build Status](https://img.shields.io/github/actions/workflow/status/apache/incubator-fury/ci.yml?branch=main&style=for-the-badge&label=GITHUB%20ACTIONS&logo=github)](https://github.com/apache/incubator-fury)
 [![Twitter](https://img.shields.io/twitter/follow/fury_community?logo=twitter&style=for-the-badge)](https://twitter.com/fury_community)
+[![Maven Version](https://img.shields.io/maven-central/v/org.furyio/fury-core?style=for-the-badge)](https://search.maven.org/#search|gav|1|g:"org.furyio"%20AND%20a:"fury-core")
+
 
 
 Apache Fury (incubating) is a blazing-fast multi-language serialization framework powered by **JIT** (just-in-time compilation) and **zero-copy**, providing up to 170x performance and ultimate ease of use.


### PR DESCRIPTION
* Add maven badge for users to see more intuitively.
* Now the maven group is 'org.furyio', we can update after 1st apache version is released.

Preview:

![image](https://github.com/apache/incubator-fury/assets/6711230/9cef04de-7669-4656-a3f0-fe05caab0074)
