### PR TITLE
[DOC] doc sync stay consistent with the site

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -19,4 +19,4 @@ apache/incubator-fury-site@main:
   - source: docs/guide/
     dest: docs/guide/
   - source: docs/benchmarks/
-    dest: public/benchmarks/
+    dest: static/img/benchmarks/

--- a/docs/guide/DEVELOPMENT.md
+++ b/docs/guide/DEVELOPMENT.md
@@ -1,6 +1,7 @@
 <!-- fury_frontmatter --
 title: Development
-order: 6
+sidebar_position: 6
+id: development
 -- fury_frontmatter -->
 # How to build to Fury
 

--- a/docs/guide/graalvm_guide.md
+++ b/docs/guide/graalvm_guide.md
@@ -1,6 +1,7 @@
 <!-- fury_frontmatter --
 title: GraalVM Guide
-order: 6
+sidebar_position: 6
+id: graalvm_guide
 -- fury_frontmatter -->
 
 # GraalVM Native Image
@@ -130,7 +131,7 @@ When Fury compression is enabled:
 - Struct: Fury is `24x speed, 31% size` compared to JDK.
 - Pojo: Fury is `12x speed, 48% size` compared to JDK.
 
-See [[Benchmark.java](../../integration_tests/graalvm_tests/src/main/java/org/apache/fury/graalvm/Benchmark.java)] for benchmark code.
+See [[Benchmark.java](https://github.com/apache/incubator-fury/blob/main/integration_tests/graalvm_tests/src/main/java/org/apache/fury/graalvm/Benchmark.java)] for benchmark code.
 
 ### Struct Benchmark
 #### Class Fields

--- a/docs/guide/java_object_graph_guide.md
+++ b/docs/guide/java_object_graph_guide.md
@@ -1,6 +1,7 @@
 <!-- fury_frontmatter --
 title: Java Object Graph Guide
-order: 0
+sidebar_position: 0
+id: java_object_graph_guide
 -- fury_frontmatter -->
 
 # Java object graph serialization

--- a/docs/guide/row_format_guide.md
+++ b/docs/guide/row_format_guide.md
@@ -1,6 +1,7 @@
 <!-- fury_frontmatter --
 title: Row Format Guide
-order: 1
+sidebar_position: 1
+id: row_format_guide
 -- fury_frontmatter -->
 
 ## Row format protocol

--- a/docs/guide/scala_guide.md
+++ b/docs/guide/scala_guide.md
@@ -1,6 +1,7 @@
 <!-- fury_frontmatter --
 title: Scala Serialization Guide
-order: 4
+sidebar_position: 4
+id: scala_guide
 -- fury_frontmatter -->
 
 # Scala serialization

--- a/docs/guide/xlang_object_graph_guide.md
+++ b/docs/guide/xlang_object_graph_guide.md
@@ -1,6 +1,7 @@
 <!-- fury_frontmatter --
 title: Xlang Object Graph Guide
-order: 2
+sidebar_position: 2
+id: xlang_object_graph_guide
 -- fury_frontmatter -->
 
 ## Cross-language object graph serialization


### PR DESCRIPTION
The structure and frontmatter of the site has some changes, so it is necessary to ensure that the results synced over remain consistent