### PR TITLE
[Java] Clean-up of tmp files created in CrossLanguageTest

### DIFF
--- a/java/fury-format/src/test/java/org/apache/fury/format/CrossLanguageTest.java
+++ b/java/fury-format/src/test/java/org/apache/fury/format/CrossLanguageTest.java
@@ -29,7 +29,6 @@ import java.io.IOException;
 import java.nio.channels.Channels;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -100,7 +99,7 @@ public class CrossLanguageTest {
     RowEncoder<A> encoder = Encoders.bean(A.class);
     System.out.println("Schema: " + encoder.schema());
     Assert.assertEquals(a, encoder.decode(encoder.encode(a)));
-    Path dataFile = Files.createTempFile("foo", "tmp" );
+    Path dataFile = Files.createTempFile("foo", "tmp");
     dataFile.toFile().deleteOnExit();
     {
       Files.write(dataFile, encoder.encode(a));

--- a/java/fury-format/src/test/java/org/apache/fury/format/CrossLanguageTest.java
+++ b/java/fury-format/src/test/java/org/apache/fury/format/CrossLanguageTest.java
@@ -100,8 +100,8 @@ public class CrossLanguageTest {
     RowEncoder<A> encoder = Encoders.bean(A.class);
     System.out.println("Schema: " + encoder.schema());
     Assert.assertEquals(a, encoder.decode(encoder.encode(a)));
-    Files.deleteIfExists(Paths.get("foo"));
-    Path dataFile = Files.createFile(Paths.get("foo"));
+    Path dataFile = Files.createTempFile("foo", "tmp" );
+    dataFile.toFile().deleteOnExit();
     {
       Files.write(dataFile, encoder.encode(a));
       ImmutableList<String> command =


### PR DESCRIPTION
## What do these changes do?
Once the test is completed, this change deletes the temporary file created in CrossLanguageTest.

## Related issue number
https://github.com/apache/incubator-fury/issues/1276