### PR TITLE
[JAVA] remove license header from MurmurHash3

### DIFF
--- a/java/fury-core/src/main/java/org/apache/fury/util/MurmurHash3.java
+++ b/java/fury-core/src/main/java/org/apache/fury/util/MurmurHash3.java
@@ -1,28 +1,11 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.apache.fury.util;
 
 // Derived from
 // https://github.com/yonik/java_util/blob/435ae306d2f2c077d981ab4de5c9ac3c45f92a4b/src/util/hash/MurmurHash3.java.
 
-// This implementtion is 3.5x faster than Guava's Hashing.murmur3_128.
+// yonik/java_util file has no license header
+
+// This implementation is 3.5x faster than Guava's Hashing.murmur3_128.
 
 /**
  * The MurmurHash3 algorithm was created by Austin Appleby and placed in the public domain. This

--- a/licenserc.toml
+++ b/licenserc.toml
@@ -42,6 +42,7 @@ excludes = [
     "java/fury-core/src/main/java/org/apache/fury/io/ClassLoaderObjectInputStream.java",
     "java/fury-core/src/main/java/org/apache/fury/memory/MemoryBuffer.java",
     "java/fury-core/src/main/java/org/apache/fury/type/Generics.java",
+    "java/fury-core/src/main/java/org/apache/fury/util/MurmurHash3.java",
     "java/fury-core/src/main/java/org/apache/fury/util/Platform.java",
     "java/fury-core/src/test/java/org/apache/fury/type/GenericsTest.java",
     "java/fury-format/src/main/java/org/apache/fury/format/vectorized/ArrowWriter.java",


### PR DESCRIPTION
feels wrong to add an ASL when the code is borrowed and the source is not Apache licensed