### PR TITLE
[Java] remove vague desc in drop-in replacement jdk serialization libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ https://fury.apache.org
 
 In addition to cross-language serialization, Fury also features at:
 
-- Drop-in replace Java serialization frameworks such as JDK/Kryo/Hessian, but 100x faster, which can greatly improve 
+- Drop-in replace Java serialization frameworks such as JDK/Kryo/Hessian, but 100x faster at most, which can greatly improve 
  the efficiency of high-performance RPC calls, data transfer, and object persistence.
 - **100% compatible** with JDK serialization API with much faster implementation: supporting JDK `writeObject/readObject/writeReplace/readResolve/readObjectNoData/Externalizable` API. 
 - Supports **Java 8~21**, Java 17+ `record` is supported too.

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ https://fury.apache.org
 
 In addition to cross-language serialization, Fury also features at:
 
-- Drop-in replace Java serialization frameworks such as JDK/Kryo/Hessian without modifying any code, but 100x faster. 
-  It can greatly improve the efficiency of high-performance RPC calls, data transfer, and object persistence.
+- Drop-in replace Java serialization frameworks such as JDK/Kryo/Hessian, but 100x faster, which can greatly improve 
+ the efficiency of high-performance RPC calls, data transfer, and object persistence.
 - **100% compatible** with JDK serialization API with much faster implementation: supporting JDK `writeObject/readObject/writeReplace/readResolve/readObjectNoData/Externalizable` API. 
 - Supports **Java 8~21**, Java 17+ `record` is supported too.
 - Support [AOT compilation serialization](docs/guide/graalvm_guide.md) for **GraalVM native image**, and no reflection/serialization json config are needed.


### PR DESCRIPTION
Many users have been asking if it's possible to use Fury without modifying any code. Our original doc was that no additional code changes would be required, but it is still necessary to replace the serialization calls with Fury. Therefore, our previous description was ambiguous. This PR removes such ambiguity from our document.

