### PR TITLE
[C++] Windows build support

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -18,6 +18,7 @@ test --build_tests_only
 test --cache_test_results=no
 test --test_output=all
 
-build:linux --cxxopt="-std=c++17"
-build:macos --cxxopt="-std=c++17"
+build:linux --cxxopt="-std=c++17" --linkopt="-pthread"
+build:macos --cxxopt="-std=c++17" --linkopt="-pthread"
 build:clang-cl --cxxopt="-std=c++17"
+build:windows --cxxopt="/std:c++17"

--- a/BUILD
+++ b/BUILD
@@ -1,6 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 load("@com_github_grpc_grpc//bazel:cython_library.bzl", "pyx_library")
-load("//bazel:fury.bzl", "COPTS")
 
 
 pyx_library(
@@ -12,7 +11,6 @@ pyx_library(
         "python/pyfury/__init__.py",
     ]),
     cc_kwargs = dict(
-        copts = COPTS,
         linkstatic = 1,
     ),
     deps = [
@@ -28,7 +26,6 @@ pyx_library(
         "python/pyfury/lib/mmh3/__init__.py",
     ]),
     cc_kwargs = dict(
-        copts = COPTS,
         linkstatic = 1,
     ),
     deps = [
@@ -45,7 +42,6 @@ pyx_library(
         "python/pyfury/__init__.py",
     ]),
     cc_kwargs = dict(
-        copts = COPTS,
         linkstatic = 1,
     ),
     deps = [
@@ -66,7 +62,6 @@ pyx_library(
         "python/pyfury/format/*.pxi",
     ]),
     cc_kwargs = dict(
-        copts = COPTS,
         linkstatic = 1,
     ),
     deps = [

--- a/bazel/fury.bzl
+++ b/bazel/fury.bzl
@@ -1,1 +1,0 @@
-COPTS = ["-pthread","-std=c++17"]

--- a/src/fury/BUILD
+++ b/src/fury/BUILD
@@ -1,9 +1,7 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
-load("//bazel:fury.bzl", "COPTS")
 
 cc_library(
     name = "fury",
-    copts = COPTS,
     deps = [
       "@local_config_pyarrow//:arrow",
       "//src/fury/row:fury_row_format",

--- a/src/fury/columnar/BUILD
+++ b/src/fury/columnar/BUILD
@@ -1,12 +1,10 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
-load("//bazel:fury.bzl", "COPTS")
 
 cc_library(
     name = "fury_columnar_format",
     srcs = ["arrow_writer.cc"],
     hdrs = ["arrow_writer.h"],
     strip_include_prefix = "/src",
-    copts = COPTS,
     deps = [
       "@local_config_pyarrow//:arrow", "//src/fury/util:fury_util", "//src/fury/row:fury_row_format"
     ],
@@ -18,7 +16,6 @@ cc_test(
     srcs = [
         "arrow_writer_test.cc",
     ],
-    copts = COPTS,
     deps = [
         ":fury_columnar_format",
         "@com_google_googletest//:gtest",
@@ -30,7 +27,6 @@ cc_test(
     srcs = [
         "convert_test.cc",
     ],
-    copts = COPTS,
     deps = [
         ":fury_columnar_format",
         "@com_google_googletest//:gtest",

--- a/src/fury/encoder/BUILD
+++ b/src/fury/encoder/BUILD
@@ -1,5 +1,4 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
-load("//bazel:fury.bzl", "COPTS")
 
 cc_library(
     name = "fury_encoder",
@@ -11,14 +10,12 @@ cc_library(
       "//src/fury/row:fury_row_format",
       "//src/fury/meta:fury_meta"
     ],
-    copts = COPTS,
     visibility = ["//visibility:public"],
 )
 
 cc_test(
     name = "row_encoder_test",
     srcs = glob(["*_test.cc"]),
-    copts = COPTS,
     deps = [
         ":fury_encoder",
         "@com_google_googletest//:gtest",

--- a/src/fury/meta/BUILD
+++ b/src/fury/meta/BUILD
@@ -1,19 +1,16 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
-load("//bazel:fury.bzl", "COPTS")
 
 cc_library(
     name = "fury_meta",
     srcs = glob(["*.cc"], exclude=["*test.cc"]),
     hdrs = glob(["*.h"]),
     strip_include_prefix = "/src",
-    copts = COPTS,
     visibility = ["//visibility:public"],
 )
 
 cc_test(
     name = "preprocessor_test",
     srcs = ["preprocessor_test.cc"],
-    copts = COPTS,
     deps = [
         ":fury_meta",
         "@com_google_googletest//:gtest",
@@ -23,7 +20,6 @@ cc_test(
 cc_test(
     name = "field_info_test",
     srcs = ["field_info_test.cc"],
-    copts = COPTS,
     deps = [
         ":fury_meta",
         "@com_google_googletest//:gtest",
@@ -33,7 +29,6 @@ cc_test(
 cc_test(
     name = "type_traits_test",
     srcs = ["type_traits_test.cc"],
-    copts = COPTS,
     deps = [
         ":fury_meta",
         "@com_google_googletest//:gtest",

--- a/src/fury/row/BUILD
+++ b/src/fury/row/BUILD
@@ -1,5 +1,4 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
-load("//bazel:fury.bzl", "COPTS")
 
 cc_library(
     name = "fury_row_format",
@@ -9,14 +8,12 @@ cc_library(
     deps = [
       "@local_config_pyarrow//:arrow", "//src/fury/util:fury_util"
     ],
-    copts = COPTS,
     visibility = ["//visibility:public"],
 )
 
 cc_test(
     name = "row_test",
     srcs = ["row_test.cc"],
-    copts = COPTS,
     deps = [
         ":fury_row_format",
         "@com_google_googletest//:gtest",

--- a/src/fury/thirdparty/BUILD
+++ b/src/fury/thirdparty/BUILD
@@ -1,12 +1,10 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
-load("//bazel:fury.bzl", "COPTS")
 
 cc_library(
     name = "libmmh3",
     srcs = ["MurmurHash3.cc"],
     hdrs = ["MurmurHash3.h"],
     strip_include_prefix = "/src",
-    copts = COPTS,
     alwayslink=True,
     linkstatic=True,
     visibility = ["//visibility:public"],

--- a/src/fury/util/BUILD
+++ b/src/fury/util/BUILD
@@ -1,13 +1,11 @@
 
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
-load("//bazel:fury.bzl", "COPTS")
 
 cc_library(
     name = "fury_util",
     srcs = glob(["*.cc"], exclude=["*test.cc"]),
     hdrs = glob(["*.h"]),
     strip_include_prefix = "/src",
-    copts = COPTS,
     alwayslink=True,
     linkstatic=True,
     deps = [
@@ -23,7 +21,6 @@ cc_library(
 cc_test(
     name = "time_util_test",
     srcs = ["time_util_test.cc"],
-    copts = COPTS,
     deps = [
         ":fury_util",
         "@com_google_googletest//:gtest",
@@ -33,7 +30,6 @@ cc_test(
 cc_test(
     name = "logging_test",
     srcs = ["logging_test.cc"],
-    copts = COPTS,
     deps = [
         ":fury_util",
         "@com_google_googletest//:gtest",
@@ -43,7 +39,6 @@ cc_test(
 cc_test(
     name = "status_test",
     srcs = ["status_test.cc"],
-    copts = COPTS,
     deps = [
         ":fury_util",
         "@com_google_googletest//:gtest",
@@ -53,7 +48,6 @@ cc_test(
 cc_test(
     name = "buffer_test",
     srcs = ["buffer_test.cc"],
-    copts = COPTS,
     deps = [
         ":fury_util",
         "@com_google_googletest//:gtest",


### PR DESCRIPTION
When compiled using Windows bazel, the following error occurs:

```
cl: 命令行 warning D9002 :忽略未知选项“-pthread”
cl: 命令行 warning D9002 :忽略未知选项“-std=c++17”
time_util.cc
src/fury/util/time_util.cc(43): warning C4477: “snprintf”: 格式字符串“%03ld”需要类型“long”的参数，但可变参数 1 拥有了类型“_Rep”        with
        [
            _Rep=__int64
        ]
src/fury/util/time_util.cc(43): note: 请考虑在格式字符串中使用“%lld”
src/fury/util/time_util.cc(43): note: 请考虑在格式字符串中使用“%Id”
src/fury/util/time_util.cc(43): note: 请考虑在格式字符串中使用“%I64d”
INFO: From Compiling absl/debugging/failure_signal_handler.cc:
failure_signal_handler.cc
INFO: From Compiling absl/strings/str_replace.cc:
str_replace.cc
INFO: From Compiling absl/strings/match.cc:
match.cc
INFO: From Compiling absl/strings/internal/stringify_sink.cc:
stringify_sink.cc
ERROR: C:/users/sui/desktop/incubator-fury/src/fury/util/BUILD:5:11: Compiling src/fury/util/buffer.cc failed: (Exit 2): cl.exe failed: error executing CppCompile command (from target //src/fury/util:fury_util) C:\Program Files (x86)\Microsoft Visual 
Studio\2022\BuildTools\VC\Tools\MSVC\14.38.33130\bin\HostX64\x64\cl.exe @bazel-out/x64_windows-opt/bin/src/fury/util/_objs/fury_util/buffer.obj.params
cl: 命令行 warning D9002 :忽略未知选项“-pthread”
cl: 命令行 warning D9002 :忽略未知选项“-std=c++17”
buffer.cc
bazel-out/x64_windows-opt/bin/src/fury/meta/_virtual_includes/fury_meta\fury/meta/type_traits.h(31): error C7525: 内联变量至少
需要 "/std:c++17"
bazel-out/x64_windows-opt/bin/src/fury/meta/_virtual_includes/fury_meta\fury/meta/type_traits.h(50): error C3533: 参数不能为包 
含“auto”的类型
bazel-out/x64_windows-opt/bin/src/fury/meta/_virtual_includes/fury_meta\fury/meta/type_traits.h(50): note: 非类型模板参数中的“auto”至少需要“/std:c++17”
bazel-out/x64_windows-opt/bin/src/fury/meta/_virtual_includes/fury_meta\fury/meta/type_traits.h(50): error C3533: 参数不能为包 
含“auto”的类型
bazel-out/x64_windows-opt/bin/src/fury/meta/_virtual_includes/fury_meta\fury/meta/type_traits.h(50): note: 非类型模板参数中的“auto”至少需要“/std:c++17”
bazel-out/x64_windows-opt/bin/src/fury/meta/_virtual_includes/fury_meta\fury/meta/type_traits.h(51): error C7525: 内联变量至少 
需要 "/std:c++17"
bazel-out/x64_windows-opt/bin/src/fury/meta/_virtual_includes/fury_meta\fury/meta/type_traits.h(55): error C3533: 参数不能为包 
含“auto”的类型
bazel-out/x64_windows-opt/bin/src/fury/meta/_virtual_includes/fury_meta\fury/meta/type_traits.h(55): note: 非类型模板参数中的“auto”至少需要“/std:c++17”
bazel-out/x64_windows-opt/bin/src/fury/meta/_virtual_includes/fury_meta\fury/meta/type_traits.h(55): error C3533: 参数不能为包 
含“auto”的类型
bazel-out/x64_windows-opt/bin/src/fury/meta/_virtual_includes/fury_meta\fury/meta/type_traits.h(55): note: 非类型模板参数中的“auto”至少需要“/std:c++17”
bazel-out/x64_windows-opt/bin/src/fury/meta/_virtual_includes/fury_meta\fury/meta/type_traits.h(56): error C7525: 内联变量至少 
需要 "/std:c++17"
bazel-out/x64_windows-opt/bin/src/fury/meta/_virtual_includes/fury_meta\fury/meta/type_traits.h(59): error C3533: 参数不能为包 
含“auto”的类型
bazel-out/x64_windows-opt/bin/src/fury/meta/_virtual_includes/fury_meta\fury/meta/type_traits.h(59): note: 非类型模板参数中的“auto”至少需要“/std:c++17”
bazel-out/x64_windows-opt/bin/src/fury/meta/_virtual_includes/fury_meta\fury/meta/type_traits.h(61): error C3533: 参数不能为包 
含“auto”的类型
bazel-out/x64_windows-opt/bin/src/fury/meta/_virtual_includes/fury_meta\fury/meta/type_traits.h(61): note: 非类型模板参数中的“auto”至少需要“/std:c++17”
bazel-out/x64_windows-opt/bin/src/fury/meta/_virtual_includes/fury_meta\fury/meta/type_traits.h(61): error C3533: 参数不能为包 
含“auto”的类型
bazel-out/x64_windows-opt/bin/src/fury/meta/_virtual_includes/fury_meta\fury/meta/type_traits.h(61): note: 非类型模板参数中的“auto”至少需要“/std:c++17”
bazel-out/x64_windows-opt/bin/src/fury/meta/_virtual_includes/fury_meta\fury/meta/type_traits.h(66): error C3533: 参数不能为包 
含“auto”的类型
bazel-out/x64_windows-opt/bin/src/fury/meta/_virtual_includes/fury_meta\fury/meta/type_traits.h(66): note: 非类型模板参数中的“auto”至少需要“/std:c++17”
bazel-out/x64_windows-opt/bin/src/fury/meta/_virtual_includes/fury_meta\fury/meta/type_traits.h(97): error C7525: 内联变量至少 
需要 "/std:c++17"
bazel-out/x64_windows-opt/bin/src/fury/meta/_virtual_includes/fury_meta\fury/meta/type_traits.h(105): error C7525: 内联变量至少
需要 "/std:c++17"
bazel-out/x64_windows-opt/bin/src/fury/meta/_virtual_includes/fury_meta\fury/meta/type_traits.h(108): error C7525: 内联变量至少
需要 "/std:c++17"
bazel-out/x64_windows-opt/bin/src/fury/meta/_virtual_includes/fury_meta\fury/meta/type_traits.h(120): error C7525: 内联变量至少
需要 "/std:c++17"
Target //src/fury/util:fury_util failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 13.649s, Critical Path: 2.07s
INFO: 42 processes: 6 internal, 36 local.
ERROR: Build did NOT complete successfully
```


The root cause is that in Windows, specifying C++17 requires the use of `/std:c++17`, while in unix/linux systems, use `-std=c++17`.
Since the operating system name cannot be determined in fury.bzl to dynamically set COPTS, so I moved them to .bazelrc.

Later, I will solve the warnings generated by compiling in windows, for example `src/fury/util/time_util.cc(43): note: 请考虑在格式字符串中使用“%lld”`.