### PR TITLE
[C++] Use python3 instead of python in bazel build

### DIFF
--- a/bazel/arrow/pyarrow_configure.bzl
+++ b/bazel/arrow/pyarrow_configure.bzl
@@ -171,7 +171,7 @@ def _symlink_genrule_for_dir(
     )
     return genrule
 
-def _get_pyarrow_include(repository_ctx, python_bin="python"):
+def _get_pyarrow_include(repository_ctx, python_bin="python3"):
     """Gets the pyarrow include path."""
     result = _execute(
         repository_ctx, [
@@ -183,7 +183,7 @@ def _get_pyarrow_include(repository_ctx, python_bin="python"):
             + python_bin + ".) " + "Is distutils installed?"))
     return result.stdout.splitlines()[0]
 
-def _get_pyarrow_shared_library(repository_ctx, library_name, python_bin="python"):
+def _get_pyarrow_shared_library(repository_ctx, library_name, python_bin="python3"):
     """Gets the pyarrow shared library path."""
     code = """import pyarrow, os, glob;print(glob.glob(os.path.join(""" +\
         """os.path.dirname(pyarrow.__file__), 'lib{}.*'))[0])""".format(library_name)
@@ -198,7 +198,7 @@ def _get_pyarrow_shared_library(repository_ctx, library_name, python_bin="python
     return result.stdout.splitlines()[0]
 
 #python numpy include
-def _get_python_numpy_include(repository_ctx, python_bin="python"):
+def _get_python_numpy_include(repository_ctx, python_bin="python3"):
     """Gets the python numpy include path."""
     result = _execute(
         repository_ctx, [


### PR DESCRIPTION
Some linux distributions do not have `python` by default, and some make `python` point to python2 instead of python3.