### PR TITLE
Keep head metadata as is in docs

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -27,10 +27,6 @@ jobs:
     runs-on: ubuntu-latest    
     steps:    
       - uses: actions/checkout@v4
-      - name: Replace Front Matter
-        run: |
-          sed -i 's/<!-- fury_frontmatter --/---/g' `grep fury_frontmatter -rl`
-          sed -i 's/-- fury_frontmatter -->/---/g' `grep fury_frontmatter -rl`
       - name: Sync files
         uses: BetaHuhn/repo-file-sync-action@v1
         with:

--- a/docs/guide/DEVELOPMENT.md
+++ b/docs/guide/DEVELOPMENT.md
@@ -1,8 +1,9 @@
-<!-- fury_frontmatter --
+---
 title: Development
 sidebar_position: 6
 id: development
--- fury_frontmatter -->
+---
+
 # How to build to Fury
 
 ## Get the source code

--- a/docs/guide/graalvm_guide.md
+++ b/docs/guide/graalvm_guide.md
@@ -1,8 +1,8 @@
-<!-- fury_frontmatter --
+---
 title: GraalVM Guide
 sidebar_position: 6
 id: graalvm_guide
--- fury_frontmatter -->
+---
 
 # GraalVM Native Image
 GraalVM `native image` can compile java code into native code ahead to build faster, smaller, leaner applications.

--- a/docs/guide/java_object_graph_guide.md
+++ b/docs/guide/java_object_graph_guide.md
@@ -1,8 +1,8 @@
-<!-- fury_frontmatter --
+---
 title: Java Object Graph Guide
 sidebar_position: 0
 id: java_object_graph_guide
--- fury_frontmatter -->
+---
 
 # Java object graph serialization
 

--- a/docs/guide/row_format_guide.md
+++ b/docs/guide/row_format_guide.md
@@ -1,8 +1,8 @@
-<!-- fury_frontmatter --
+---
 title: Row Format Guide
 sidebar_position: 1
 id: row_format_guide
--- fury_frontmatter -->
+---
 
 ## Row format protocol
 ### Java

--- a/docs/guide/scala_guide.md
+++ b/docs/guide/scala_guide.md
@@ -1,8 +1,8 @@
-<!-- fury_frontmatter --
+---
 title: Scala Serialization Guide
 sidebar_position: 4
 id: scala_guide
--- fury_frontmatter -->
+---
 
 # Scala serialization
 Fury supports all scala object serialization:

--- a/docs/guide/xlang_object_graph_guide.md
+++ b/docs/guide/xlang_object_graph_guide.md
@@ -1,8 +1,8 @@
-<!-- fury_frontmatter --
+---
 title: Xlang Object Graph Guide
 sidebar_position: 2
 id: xlang_object_graph_guide
--- fury_frontmatter -->
+---
 
 ## Cross-language object graph serialization
 


### PR DESCRIPTION
We can just keep these head metadata as it is instead of replacing with html comments.

It will display in a normal manner on GitHub.