### PR TITLE
chore(C++): Remove unused bazel rulers

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,4 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 load("@com_github_grpc_grpc//bazel:cython_library.bzl", "pyx_library")
 
 

--- a/src/fury/BUILD
+++ b/src/fury/BUILD
@@ -1,4 +1,4 @@
-load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+load("@rules_cc//cc:defs.bzl", "cc_library")
 
 cc_library(
     name = "fury",

--- a/src/fury/columnar/BUILD
+++ b/src/fury/columnar/BUILD
@@ -1,4 +1,4 @@
-load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+load("@rules_cc//cc:defs.bzl",  "cc_library", "cc_test")
 
 cc_library(
     name = "fury_columnar_format",

--- a/src/fury/encoder/BUILD
+++ b/src/fury/encoder/BUILD
@@ -1,4 +1,4 @@
-load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 
 cc_library(
     name = "fury_encoder",

--- a/src/fury/meta/BUILD
+++ b/src/fury/meta/BUILD
@@ -1,4 +1,4 @@
-load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 
 cc_library(
     name = "fury_meta",

--- a/src/fury/row/BUILD
+++ b/src/fury/row/BUILD
@@ -1,4 +1,4 @@
-load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 
 cc_library(
     name = "fury_row_format",

--- a/src/fury/thirdparty/BUILD
+++ b/src/fury/thirdparty/BUILD
@@ -1,4 +1,4 @@
-load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+load("@rules_cc//cc:defs.bzl", "cc_library")
 
 cc_library(
     name = "libmmh3",

--- a/src/fury/util/BUILD
+++ b/src/fury/util/BUILD
@@ -1,5 +1,4 @@
-
-load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 
 cc_library(
     name = "fury_util",


### PR DESCRIPTION
Remove unused bazel rulers, e.g. `cc_binary`.