### PR TITLE
fix(java): fix polymorphic array serialization

### DIFF
--- a/java/fury-core/src/main/java/org/apache/fury/builder/BaseObjectCodecBuilder.java
+++ b/java/fury-core/src/main/java/org/apache/fury/builder/BaseObjectCodecBuilder.java
@@ -572,7 +572,7 @@ public abstract class BaseObjectCodecBuilder extends CodecBuilder {
       classInfoRef = Tuple2.of(fieldRef(name, classInfoTypeToken), false);
     } else {
       classInfoExpr = inlineInvoke(classResolverRef, "nilClassInfo", classInfoTypeToken);
-      String name = ctx.newName(StringUtils.uncapitalize(cls.getSimpleName()) + "ClassInfo");
+      String name = ctx.newName(cls, "ClassInfo");
       ctx.addField(false, ctx.type(ClassInfo.class), name, classInfoExpr);
       // Can't use fieldRef, since the field is not final.
       classInfoRef = Tuple2.of(new Reference(name, classInfoTypeToken), true);
@@ -584,7 +584,7 @@ public abstract class BaseObjectCodecBuilder extends CodecBuilder {
   protected Reference addClassInfoHolderField(Class<?> cls) {
     // Final type need to write classinfo when meta share enabled.
     String key;
-    if (Modifier.isFinal(cls.getModifiers())) {
+    if (ReflectionUtils.isFinal(cls)) {
       key = "classInfoHolder:" + cls;
     } else {
       key = "classInfoHolder:" + cls + walkPath;
@@ -608,7 +608,7 @@ public abstract class BaseObjectCodecBuilder extends CodecBuilder {
   }
 
   protected Expression readClassInfo(Class<?> cls, Expression buffer, boolean inlineReadClassInfo) {
-    if (Modifier.isFinal(cls.getModifiers())) {
+    if (ReflectionUtils.isFinal(cls)) {
       Reference classInfoRef = addClassInfoField(cls).f0;
       if (inlineReadClassInfo) {
         return inlineInvoke(

--- a/java/fury-core/src/main/java/org/apache/fury/builder/CodecBuilder.java
+++ b/java/fury-core/src/main/java/org/apache/fury/builder/CodecBuilder.java
@@ -345,12 +345,12 @@ public abstract class CodecBuilder {
     if (duplicatedFields.contains(fieldName) || !sourcePublicAccessible(beanClass)) {
       return unsafeSetField(bean, d, value);
     }
-    if (!Modifier.isFinal(d.getModifiers()) && Modifier.isPublic(d.getModifiers())) {
+    if (!ReflectionUtils.isFinal(d.getRawType()) && Modifier.isPublic(d.getModifiers())) {
       return new Expression.SetField(bean, fieldName, value);
     } else if (d.getWriteMethod() != null && Modifier.isPublic(d.getWriteMethod().getModifiers())) {
       return new Invoke(bean, d.getWriteMethod().getName(), value);
     } else {
-      if (!Modifier.isFinal(d.getModifiers()) && !Modifier.isPrivate(d.getModifiers())) {
+      if (!ReflectionUtils.isFinal(d.getRawType()) && !Modifier.isPrivate(d.getModifiers())) {
         if (AccessorHelper.defineSetter(d.getField())) {
           Class<?> accessorClass = AccessorHelper.getAccessorClass(d.getField());
           if (!value.type().equals(d.getTypeToken())) {

--- a/java/fury-core/src/main/java/org/apache/fury/builder/CodecBuilder.java
+++ b/java/fury-core/src/main/java/org/apache/fury/builder/CodecBuilder.java
@@ -345,12 +345,13 @@ public abstract class CodecBuilder {
     if (duplicatedFields.contains(fieldName) || !sourcePublicAccessible(beanClass)) {
       return unsafeSetField(bean, d, value);
     }
-    if (!ReflectionUtils.isFinal(d.getRawType()) && Modifier.isPublic(d.getModifiers())) {
+    if (!ReflectionUtils.isMonomorphic(d.getRawType()) && Modifier.isPublic(d.getModifiers())) {
       return new Expression.SetField(bean, fieldName, value);
     } else if (d.getWriteMethod() != null && Modifier.isPublic(d.getWriteMethod().getModifiers())) {
       return new Invoke(bean, d.getWriteMethod().getName(), value);
     } else {
-      if (!ReflectionUtils.isFinal(d.getRawType()) && !Modifier.isPrivate(d.getModifiers())) {
+      if (!ReflectionUtils.isMonomorphic(d.getRawType())
+          && !Modifier.isPrivate(d.getModifiers())) {
         if (AccessorHelper.defineSetter(d.getField())) {
           Class<?> accessorClass = AccessorHelper.getAccessorClass(d.getField());
           if (!value.type().equals(d.getTypeToken())) {

--- a/java/fury-core/src/main/java/org/apache/fury/builder/CodecBuilder.java
+++ b/java/fury-core/src/main/java/org/apache/fury/builder/CodecBuilder.java
@@ -345,12 +345,12 @@ public abstract class CodecBuilder {
     if (duplicatedFields.contains(fieldName) || !sourcePublicAccessible(beanClass)) {
       return unsafeSetField(bean, d, value);
     }
-    if (!ReflectionUtils.isMonomorphic(d.getRawType()) && Modifier.isPublic(d.getModifiers())) {
+    if (!d.isFinalField() && Modifier.isPublic(d.getModifiers())) {
       return new Expression.SetField(bean, fieldName, value);
     } else if (d.getWriteMethod() != null && Modifier.isPublic(d.getWriteMethod().getModifiers())) {
       return new Invoke(bean, d.getWriteMethod().getName(), value);
     } else {
-      if (!ReflectionUtils.isMonomorphic(d.getRawType()) && !Modifier.isPrivate(d.getModifiers())) {
+      if (!d.isFinalField() && !Modifier.isPrivate(d.getModifiers())) {
         if (AccessorHelper.defineSetter(d.getField())) {
           Class<?> accessorClass = AccessorHelper.getAccessorClass(d.getField());
           if (!value.type().equals(d.getTypeToken())) {

--- a/java/fury-core/src/main/java/org/apache/fury/builder/CodecBuilder.java
+++ b/java/fury-core/src/main/java/org/apache/fury/builder/CodecBuilder.java
@@ -350,8 +350,7 @@ public abstract class CodecBuilder {
     } else if (d.getWriteMethod() != null && Modifier.isPublic(d.getWriteMethod().getModifiers())) {
       return new Invoke(bean, d.getWriteMethod().getName(), value);
     } else {
-      if (!ReflectionUtils.isMonomorphic(d.getRawType())
-          && !Modifier.isPrivate(d.getModifiers())) {
+      if (!ReflectionUtils.isMonomorphic(d.getRawType()) && !Modifier.isPrivate(d.getModifiers())) {
         if (AccessorHelper.defineSetter(d.getField())) {
           Class<?> accessorClass = AccessorHelper.getAccessorClass(d.getField());
           if (!value.type().equals(d.getTypeToken())) {

--- a/java/fury-core/src/main/java/org/apache/fury/builder/CompatibleCodecBuilder.java
+++ b/java/fury-core/src/main/java/org/apache/fury/builder/CompatibleCodecBuilder.java
@@ -78,6 +78,7 @@ import org.apache.fury.type.Descriptor;
 import org.apache.fury.type.TypeUtils;
 import org.apache.fury.util.Platform;
 import org.apache.fury.util.Preconditions;
+import org.apache.fury.util.ReflectionUtils;
 import org.apache.fury.util.function.SerializableSupplier;
 import org.apache.fury.util.record.RecordUtils;
 
@@ -136,7 +137,7 @@ public class CompatibleCodecBuilder extends BaseObjectCodecBuilder {
 
   @Override
   protected boolean isFinal(Class<?> clz) {
-    return Modifier.isFinal(clz.getModifiers());
+    return ReflectionUtils.isFinal(clz);
   }
 
   private Descriptor createDescriptor(FieldInfo fieldInfo) {
@@ -315,7 +316,7 @@ public class CompatibleCodecBuilder extends BaseObjectCodecBuilder {
                                                 buffer, mapFieldInfo.getValueType()));
                                       }
                                       Class<?> clz = descriptor.getRawType();
-                                      if (Modifier.isFinal(clz.getModifiers())) {
+                                      if (ReflectionUtils.isFinal(clz)) {
                                         // serializeForNotNull won't write field type if it's final,
                                         // but the type is useful if peer doesn't have this field.
                                         writeFieldValue.add(writeFinalClassInfo(buffer, clz));
@@ -837,7 +838,7 @@ public class CompatibleCodecBuilder extends BaseObjectCodecBuilder {
                       skipFinalClassInfo(((MapFieldInfo) fieldInfo).getValueType(), buffer));
                 }
                 Class<?> clz = getRawType(typeToken);
-                if (Modifier.isFinal(clz.getModifiers())) {
+                if (ReflectionUtils.isFinal(clz)) {
                   // deserializeForNotNull won't read field type if it's final
                   deserializedValue.add(skipFinalClassInfo(clz, buffer));
                 }
@@ -870,14 +871,14 @@ public class CompatibleCodecBuilder extends BaseObjectCodecBuilder {
   }
 
   protected Expression getFinalClassInfo(Class<?> cls) {
-    Preconditions.checkArgument(Modifier.isFinal(cls.getModifiers()));
+    Preconditions.checkArgument(ReflectionUtils.isFinal(cls));
     Tuple2<Reference, Boolean> classInfoRef = addClassInfoField(cls);
     Preconditions.checkArgument(!classInfoRef.f1);
     return classInfoRef.f0;
   }
 
   protected Expression writeFinalClassInfo(Expression buffer, Class<?> cls) {
-    Preconditions.checkArgument(Modifier.isFinal(cls.getModifiers()));
+    Preconditions.checkArgument(ReflectionUtils.isFinal(cls));
     ClassInfo classInfo = visitFury(f -> f.getClassResolver().getClassInfo(cls, false));
     if (classInfo != null && classInfo.getClassId() != ClassResolver.NO_CLASS_ID) {
       return fury.getClassResolver().writeClassExpr(buffer, classInfo.getClassId());
@@ -887,7 +888,7 @@ public class CompatibleCodecBuilder extends BaseObjectCodecBuilder {
   }
 
   protected Expression skipFinalClassInfo(Class<?> cls, Expression buffer) {
-    Preconditions.checkArgument(Modifier.isFinal(cls.getModifiers()));
+    Preconditions.checkArgument(ReflectionUtils.isFinal(cls));
     ClassInfo classInfo = visitFury(f -> f.getClassResolver().getClassInfo(cls, false));
     if (classInfo != null && classInfo.getClassId() != ClassResolver.NO_CLASS_ID) {
       return fury.getClassResolver().skipRegisteredClassExpr(buffer);

--- a/java/fury-core/src/main/java/org/apache/fury/builder/ObjectCodecBuilder.java
+++ b/java/fury-core/src/main/java/org/apache/fury/builder/ObjectCodecBuilder.java
@@ -128,8 +128,8 @@ public class ObjectCodecBuilder extends BaseObjectCodecBuilder {
 
   /** Mark non-inner registered final types as non-final to write class def for those types. */
   @Override
-  protected boolean isFinal(Class<?> clz) {
-    return visitFury(f -> f.getClassResolver().isFinal(clz));
+  protected boolean isMonomorphic(Class<?> clz) {
+    return visitFury(f -> f.getClassResolver().isMonomorphic(clz));
   }
 
   /**

--- a/java/fury-core/src/main/java/org/apache/fury/builder/ObjectCodecOptimizer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/builder/ObjectCodecOptimizer.java
@@ -95,8 +95,8 @@ public class ObjectCodecOptimizer extends ExpressionOptimizer {
     // Note get field value also took some byte code if not public.
     List<Descriptor> primitiveDescriptorsList =
         new ArrayList<>(descriptorGrouper.getPrimitiveDescriptors());
-    while (primitiveDescriptorsList.size() > 0) {
-      int endIndex = Math.min(24, primitiveDescriptorsList.size());
+    while (!primitiveDescriptorsList.isEmpty()) {
+      int endIndex = Math.min(20, primitiveDescriptorsList.size());
       primitiveGroups.add(primitiveDescriptorsList.subList(0, endIndex));
       primitiveDescriptorsList =
           primitiveDescriptorsList.subList(endIndex, primitiveDescriptorsList.size());

--- a/java/fury-core/src/main/java/org/apache/fury/resolver/ClassResolver.java
+++ b/java/fury-core/src/main/java/org/apache/fury/resolver/ClassResolver.java
@@ -515,17 +515,11 @@ public class ClassResolver {
    */
   public boolean isMonomorphic(Class<?> clz) {
     if (fury.getConfig().shareMetaContext()) {
-      if (!ReflectionUtils.isMonomorphic(clz)) {
-        return false;
-      }
-      boolean isInnerClass = isInnerClass(clz);
-      if (!isInnerClass) {
-        return false;
-      } else {
-        // can't create final map/collection type using TypeUtils.mapOf(TypeToken<K>,
-        // TypeToken<V>)
-        return !Map.class.isAssignableFrom(clz) && !Collection.class.isAssignableFrom(clz);
-      }
+      // can't create final map/collection type using TypeUtils.mapOf(TypeToken<K>,
+      // TypeToken<V>)
+      return ReflectionUtils.isMonomorphic(clz)
+          && isInnerClass(clz)
+          && (!Map.class.isAssignableFrom(clz) && !Collection.class.isAssignableFrom(clz));
     }
     return ReflectionUtils.isMonomorphic(clz);
   }

--- a/java/fury-core/src/main/java/org/apache/fury/resolver/ClassResolver.java
+++ b/java/fury-core/src/main/java/org/apache/fury/resolver/ClassResolver.java
@@ -514,24 +514,20 @@ public class ClassResolver {
    * non-final to write class def, so that it can be deserialized by the peer still..
    */
   public boolean isMonomorphic(Class<?> clz) {
-    if (clz.isArray()) {
-      return isMonomorphic(clz.getComponentType());
-    }
-    if (ReflectionUtils.isMonomorphic(clz)) {
-      if (fury.getConfig().shareMetaContext()) {
-        boolean isInnerClass = isInnerClass(clz);
-        if (!isInnerClass) {
-          return false;
-        } else {
-          // can't create final map/collection type using TypeUtils.mapOf(TypeToken<K>,
-          // TypeToken<V>)
-          return !Map.class.isAssignableFrom(clz) && !Collection.class.isAssignableFrom(clz);
-        }
+    if (fury.getConfig().shareMetaContext()) {
+      if (!ReflectionUtils.isMonomorphic(clz)) {
+        return false;
+      }
+      boolean isInnerClass = isInnerClass(clz);
+      if (!isInnerClass) {
+        return false;
       } else {
-        return true;
+        // can't create final map/collection type using TypeUtils.mapOf(TypeToken<K>,
+        // TypeToken<V>)
+        return !Map.class.isAssignableFrom(clz) && !Collection.class.isAssignableFrom(clz);
       }
     }
-    return false;
+    return ReflectionUtils.isMonomorphic(clz);
   }
 
   /** Returns true if <code>cls</code> is fury inner registered class. */

--- a/java/fury-core/src/main/java/org/apache/fury/resolver/ClassResolver.java
+++ b/java/fury-core/src/main/java/org/apache/fury/resolver/ClassResolver.java
@@ -515,6 +515,9 @@ public class ClassResolver {
    * non-final to write class def, so that it can be deserialized by the peer still..
    */
   public boolean isFinal(Class<?> clz) {
+    if (clz.isArray()) {
+      return isFinal(clz.getComponentType());
+    }
     if (Modifier.isFinal(clz.getModifiers())) {
       if (fury.getConfig().shareMetaContext()) {
         boolean isInnerClass = isInnerClass(clz);

--- a/java/fury-core/src/main/java/org/apache/fury/resolver/ClassResolver.java
+++ b/java/fury-core/src/main/java/org/apache/fury/resolver/ClassResolver.java
@@ -34,7 +34,6 @@ import java.io.Externalizable;
 import java.io.IOException;
 import java.io.Serializable;
 import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -514,11 +513,11 @@ public class ClassResolver {
    * a class is registered but not an inner class with inner serializer, it will still be taken as
    * non-final to write class def, so that it can be deserialized by the peer still..
    */
-  public boolean isFinal(Class<?> clz) {
+  public boolean isMonomorphic(Class<?> clz) {
     if (clz.isArray()) {
-      return isFinal(clz.getComponentType());
+      return isMonomorphic(clz.getComponentType());
     }
-    if (Modifier.isFinal(clz.getModifiers())) {
+    if (ReflectionUtils.isMonomorphic(clz)) {
       if (fury.getConfig().shareMetaContext()) {
         boolean isInnerClass = isInnerClass(clz);
         if (!isInnerClass) {
@@ -1755,9 +1754,9 @@ public class ClassResolver {
         typeToken.getType(),
         t -> {
           if (t.getClass() == Class.class) {
-            return isFinal((Class<?>) t);
+            return isMonomorphic((Class<?>) t);
           } else {
-            return isFinal(getRawType(t));
+            return isMonomorphic(getRawType(t));
           }
         });
   }
@@ -1767,9 +1766,9 @@ public class ClassResolver {
         type,
         t -> {
           if (t.getClass() == Class.class) {
-            return isFinal((Class<?>) t);
+            return isMonomorphic((Class<?>) t);
           } else {
-            return isFinal(getRawType(t));
+            return isMonomorphic(getRawType(t));
           }
         });
   }

--- a/java/fury-core/src/main/java/org/apache/fury/resolver/FieldResolver.java
+++ b/java/fury-core/src/main/java/org/apache/fury/resolver/FieldResolver.java
@@ -744,7 +744,7 @@ public class FieldResolver {
         TypeToken<?> elementTypeToken =
             TypeUtils.getElementType(TypeToken.of(field.getGenericType()));
         byte fieldType =
-            Modifier.isFinal(getRawType(elementTypeToken).getModifiers())
+            ReflectionUtils.isFinal(getRawType(elementTypeToken))
                 ? FieldTypes.COLLECTION_ELEMENT_FINAL
                 : FieldTypes.OBJECT;
         return new CollectionFieldInfo(
@@ -755,12 +755,12 @@ public class FieldResolver {
         TypeToken<?> keyTypeToken = kvType.f0;
         TypeToken<?> valueTypeToken = kvType.f1;
         byte fieldType;
-        if (Modifier.isFinal(getRawType(keyTypeToken).getModifiers())
-            && Modifier.isFinal(getRawType(valueTypeToken).getModifiers())) {
+        if (ReflectionUtils.isFinal(getRawType(keyTypeToken))
+            && ReflectionUtils.isFinal(getRawType(valueTypeToken))) {
           fieldType = FieldTypes.MAP_KV_FINAL;
-        } else if (Modifier.isFinal(getRawType(keyTypeToken).getModifiers())) {
+        } else if (ReflectionUtils.isFinal(getRawType(keyTypeToken))) {
           fieldType = FieldTypes.MAP_KEY_FINAL;
-        } else if (Modifier.isFinal(getRawType(valueTypeToken).getModifiers())) {
+        } else if (ReflectionUtils.isFinal(getRawType(valueTypeToken))) {
           fieldType = FieldTypes.MAP_VALUE_FINAL;
         } else {
           fieldType = FieldTypes.OBJECT;
@@ -930,10 +930,10 @@ public class FieldResolver {
       this.keyTypeToken = keyTypeToken;
       this.valueTypeToken = valueTypeToken;
       keyType = getRawType(keyTypeToken);
-      isKeyTypeFinal = Modifier.isFinal(keyType.getModifiers());
+      isKeyTypeFinal = ReflectionUtils.isFinal(keyType);
       keyClassInfoHolder = classResolver.nilClassInfoHolder();
       valueType = getRawType(valueTypeToken);
-      isValueTypeFinal = Modifier.isFinal(valueType.getModifiers());
+      isValueTypeFinal = ReflectionUtils.isFinal(valueType);
       valueClassInfoHolder = classResolver.nilClassInfoHolder();
     }
 

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/ArraySerializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/ArraySerializers.java
@@ -20,7 +20,6 @@
 package org.apache.fury.serializer;
 
 import java.lang.reflect.Array;
-import java.lang.reflect.Modifier;
 import java.util.IdentityHashMap;
 import org.apache.fury.Fury;
 import org.apache.fury.memory.MemoryBuffer;
@@ -35,6 +34,7 @@ import org.apache.fury.type.Type;
 import org.apache.fury.type.TypeUtils;
 import org.apache.fury.util.Platform;
 import org.apache.fury.util.Preconditions;
+import org.apache.fury.util.ReflectionUtils;
 
 /** Serializers for array types. */
 public class ArraySerializers {
@@ -64,7 +64,7 @@ public class ArraySerializers {
       this.dimension = dimension;
       this.innerType = (Class<T>) innerType;
       Class<?> componentType = cls.getComponentType();
-      if (Modifier.isFinal(componentType.getModifiers())) {
+      if (ReflectionUtils.isMonomorphic(componentType)) {
         this.componentTypeSerializer = fury.getClassResolver().getSerializer(componentType);
       } else {
         // TODO add ClassInfo cache for non-final component type.

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/MetaSharedSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/MetaSharedSerializer.java
@@ -73,7 +73,7 @@ public class MetaSharedSerializer<T> extends Serializer<T> {
   /**
    * Whether write class def for non-inner final types.
    *
-   * @see ClassResolver#isFinal(Class)
+   * @see ClassResolver#isMonomorphic(Class)
    */
   private final boolean[] isFinal;
 

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/ObjectSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/ObjectSerializer.java
@@ -74,7 +74,7 @@ public final class ObjectSerializer<T> extends Serializer<T> {
   /**
    * Whether write class def for non-inner final types.
    *
-   * @see ClassResolver#isFinal(Class)
+   * @see ClassResolver#isMonomorphic(Class)
    */
   private final boolean[] isFinal;
 
@@ -149,7 +149,7 @@ public final class ObjectSerializer<T> extends Serializer<T> {
     boolean[] isFinal = new boolean[finalFields.length];
     for (int i = 0; i < isFinal.length; i++) {
       ClassInfo classInfo = finalFields[i].classInfo;
-      isFinal[i] = classInfo != null && fury.getClassResolver().isFinal(classInfo.getCls());
+      isFinal[i] = classInfo != null && fury.getClassResolver().isMonomorphic(classInfo.getCls());
     }
     cnt = 0;
     GenericTypeField[] otherFields = new GenericTypeField[grouper.getOtherDescriptors().size()];

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/collection/AbstractCollectionSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/collection/AbstractCollectionSerializer.java
@@ -116,7 +116,7 @@ public abstract class AbstractCollectionSerializer<T> extends Serializer<T> {
     GenericType elemGenericType = getElementGenericType(fury);
     if (elemGenericType != null) {
       boolean trackingRef = elemGenericType.trackingRef(fury.getClassResolver());
-      if (elemGenericType.isFinal()) {
+      if (elemGenericType.isMonomorphic()) {
         if (trackingRef) {
           buffer.writeByte(CollectionFlags.TRACKING_REF);
           return CollectionFlags.TRACKING_REF;
@@ -242,7 +242,7 @@ public abstract class AbstractCollectionSerializer<T> extends Serializer<T> {
   }
 
   /**
-   * Element type is not final by {@link ClassResolver#isFinal}, need to write element type.
+   * Element type is not final by {@link ClassResolver#isMonomorphic}, need to write element type.
    * Elements ref tracking is disabled, write whether any elements is null.
    */
   @CodegenInvoke
@@ -355,7 +355,7 @@ public abstract class AbstractCollectionSerializer<T> extends Serializer<T> {
     }
     // Note: ObjectSerializer should mark `FinalElemType` in `Collection<FinalElemType>`
     // as non-final to write class def when meta share is enabled.
-    if (elemGenericType.isFinal()) {
+    if (elemGenericType.isMonomorphic()) {
       Serializer serializer = elemGenericType.getSerializer(fury.getClassResolver());
       writeSameTypeElements(fury, buffer, serializer, flags, collection);
     } else {
@@ -450,7 +450,7 @@ public abstract class AbstractCollectionSerializer<T> extends Serializer<T> {
       if (hasGenericParameters) {
         fury.getGenerics().pushGenericType(elemGenericType);
       }
-      if (elemGenericType.isFinal()) {
+      if (elemGenericType.isMonomorphic()) {
         Serializer elemSerializer = elemGenericType.getSerializer(fury.getClassResolver());
         for (Object elem : value) {
           fury.xwriteRef(buffer, elem, elemSerializer);
@@ -586,7 +586,7 @@ public abstract class AbstractCollectionSerializer<T> extends Serializer<T> {
     if (hasGenericParameters) {
       fury.getGenerics().pushGenericType(elemGenericType);
     }
-    if (elemGenericType.isFinal()) {
+    if (elemGenericType.isMonomorphic()) {
       Serializer serializer = elemGenericType.getSerializer(fury.getClassResolver());
       readSameTypeElements(fury, buffer, serializer, flags, collection, numElements);
     } else {
@@ -686,7 +686,7 @@ public abstract class AbstractCollectionSerializer<T> extends Serializer<T> {
       if (hasGenericParameters) {
         fury.getGenerics().pushGenericType(elemGenericType);
       }
-      if (elemGenericType.isFinal()) {
+      if (elemGenericType.isMonomorphic()) {
         Serializer elemSerializer = elemGenericType.getSerializer(fury.getClassResolver());
         for (int i = 0; i < numElements; i++) {
           Object elem = fury.xreadRefByNullableSerializer(buffer, elemSerializer);

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/collection/AbstractMapSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/collection/AbstractMapSerializer.java
@@ -188,8 +188,8 @@ public abstract class AbstractMapSerializer<T> extends Serializer<T> {
       // generics.pushGenericType(keyGenericType);
       // fury.setDepth(depth);
       // generics.pushGenericType(valueGenericType);
-      boolean keyGenericTypeFinal = keyGenericType.isFinal();
-      boolean valueGenericTypeFinal = valueGenericType.isFinal();
+      boolean keyGenericTypeFinal = keyGenericType.isMonomorphic();
+      boolean valueGenericTypeFinal = valueGenericType.isMonomorphic();
       if (keyGenericTypeFinal && valueGenericTypeFinal) {
         javaKVTypesFinalWrite(fury, buffer, map, keyGenericType, valueGenericType, generics);
       } else if (keyGenericTypeFinal) {
@@ -453,8 +453,8 @@ public abstract class AbstractMapSerializer<T> extends Serializer<T> {
         keyGenericType = kvGenericType.f0;
         valueGenericType = kvGenericType.f1;
       }
-      boolean keyGenericTypeFinal = keyGenericType.isFinal();
-      boolean valueGenericTypeFinal = valueGenericType.isFinal();
+      boolean keyGenericTypeFinal = keyGenericType.isMonomorphic();
+      boolean valueGenericTypeFinal = valueGenericType.isMonomorphic();
       if (keyGenericTypeFinal && valueGenericTypeFinal) {
         javaKVTypesFinalRead(fury, buffer, map, keyGenericType, valueGenericType, generics, size);
       } else if (keyGenericTypeFinal) {

--- a/java/fury-core/src/main/java/org/apache/fury/type/ClassDef.java
+++ b/java/fury-core/src/main/java/org/apache/fury/type/ClassDef.java
@@ -479,7 +479,12 @@ public class ClassDef implements Serializable {
 
     @Override
     public String toString() {
-      return "RegisteredFieldType{" + "isMonomorphic=" + isMonomorphic() + ", classId=" + classId + '}';
+      return "RegisteredFieldType{"
+          + "isMonomorphic="
+          + isMonomorphic()
+          + ", classId="
+          + classId
+          + '}';
     }
   }
 
@@ -530,7 +535,12 @@ public class ClassDef implements Serializable {
 
     @Override
     public String toString() {
-      return "CollectionFieldType{" + "elementType=" + elementType + ", isFinal=" + isMonomorphic() + '}';
+      return "CollectionFieldType{"
+          + "elementType="
+          + elementType
+          + ", isFinal="
+          + isMonomorphic()
+          + '}';
     }
   }
 

--- a/java/fury-core/src/main/java/org/apache/fury/type/ClassDef.java
+++ b/java/fury-core/src/main/java/org/apache/fury/type/ClassDef.java
@@ -366,14 +366,14 @@ public class ClassDef implements Serializable {
   }
 
   public abstract static class FieldType implements Serializable {
-    public FieldType(boolean isFinal) {
-      this.isFinal = isFinal;
+    public FieldType(boolean isMonomorphic) {
+      this.isMonomorphic = isMonomorphic;
     }
 
-    private final boolean isFinal;
+    private final boolean isMonomorphic;
 
-    public boolean isFinal() {
-      return isFinal;
+    public boolean isMonomorphic() {
+      return isMonomorphic;
     }
 
     /**
@@ -394,16 +394,16 @@ public class ClassDef implements Serializable {
         return false;
       }
       FieldType fieldType = (FieldType) o;
-      return isFinal == fieldType.isFinal;
+      return isMonomorphic == fieldType.isMonomorphic;
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(isFinal);
+      return Objects.hash(isMonomorphic);
     }
 
     public void write(MemoryBuffer buffer) {
-      buffer.writeBoolean(isFinal);
+      buffer.writeBoolean(isMonomorphic);
       if (this instanceof RegisteredFieldType) {
         buffer.writeByte(0);
         buffer.writeShort(((RegisteredFieldType) this).getClassId());
@@ -479,7 +479,7 @@ public class ClassDef implements Serializable {
 
     @Override
     public String toString() {
-      return "RegisteredFieldType{" + "isFinal=" + isFinal() + ", classId=" + classId + '}';
+      return "RegisteredFieldType{" + "isMonomorphic=" + isMonomorphic() + ", classId=" + classId + '}';
     }
   }
 
@@ -530,7 +530,7 @@ public class ClassDef implements Serializable {
 
     @Override
     public String toString() {
-      return "CollectionFieldType{" + "elementType=" + elementType + ", isFinal=" + isFinal() + '}';
+      return "CollectionFieldType{" + "elementType=" + elementType + ", isFinal=" + isMonomorphic() + '}';
     }
   }
 
@@ -593,7 +593,7 @@ public class ClassDef implements Serializable {
           + ", valueType="
           + valueType
           + ", isFinal="
-          + isFinal()
+          + isMonomorphic()
           + '}';
     }
   }
@@ -607,7 +607,7 @@ public class ClassDef implements Serializable {
 
     @Override
     public TypeToken<?> toTypeToken(ClassResolver classResolver) {
-      return isFinal() ? TypeToken.of(FinalObjectTypeStub.class) : TypeToken.of(Object.class);
+      return isMonomorphic() ? TypeToken.of(FinalObjectTypeStub.class) : TypeToken.of(Object.class);
     }
 
     @Override
@@ -662,7 +662,7 @@ public class ClassDef implements Serializable {
   /** Build field type from generics, nested generics will be extracted too. */
   private static FieldType buildFieldType(ClassResolver classResolver, GenericType genericType) {
     Preconditions.checkNotNull(genericType);
-    boolean isFinal = genericType.isFinal();
+    boolean isFinal = genericType.isMonomorphic();
     if (COLLECTION_TYPE.isSupertypeOf(genericType.typeToken)) {
       return new CollectionFieldType(
           isFinal,

--- a/java/fury-core/src/main/java/org/apache/fury/type/Descriptor.java
+++ b/java/fury-core/src/main/java/org/apache/fury/type/Descriptor.java
@@ -143,6 +143,10 @@ public class Descriptor {
     return modifier;
   }
 
+  public boolean isFinalField() {
+    return Modifier.isFinal(modifier);
+  }
+
   public String getDeclaringClass() {
     return declaringClass;
   }

--- a/java/fury-core/src/main/java/org/apache/fury/type/DescriptorGrouper.java
+++ b/java/fury-core/src/main/java/org/apache/fury/type/DescriptorGrouper.java
@@ -29,6 +29,8 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.TreeSet;
 import java.util.function.Function;
+
+import org.apache.fury.util.ReflectionUtils;
 import org.apache.fury.util.record.RecordUtils;
 
 /**
@@ -163,7 +165,7 @@ public class DescriptorGrouper {
         collectionDescriptors.add(descriptorUpdator.apply(descriptor));
       } else if (TypeUtils.isMap(descriptor.getRawType())) {
         mapDescriptors.add(descriptorUpdator.apply(descriptor));
-      } else if (Modifier.isFinal(descriptor.getRawType().getModifiers())) {
+      } else if (ReflectionUtils.isFinal(descriptor.getRawType())) {
         finalDescriptors.add(descriptorUpdator.apply(descriptor));
       } else {
         otherDescriptors.add(descriptorUpdator.apply(descriptor));

--- a/java/fury-core/src/main/java/org/apache/fury/type/DescriptorGrouper.java
+++ b/java/fury-core/src/main/java/org/apache/fury/type/DescriptorGrouper.java
@@ -22,14 +22,12 @@ package org.apache.fury.type;
 import static org.apache.fury.type.TypeUtils.getSizeOfPrimitiveType;
 
 import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.TreeSet;
 import java.util.function.Function;
-
 import org.apache.fury.util.ReflectionUtils;
 import org.apache.fury.util.record.RecordUtils;
 
@@ -165,7 +163,7 @@ public class DescriptorGrouper {
         collectionDescriptors.add(descriptorUpdator.apply(descriptor));
       } else if (TypeUtils.isMap(descriptor.getRawType())) {
         mapDescriptors.add(descriptorUpdator.apply(descriptor));
-      } else if (ReflectionUtils.isFinal(descriptor.getRawType())) {
+      } else if (ReflectionUtils.isMonomorphic(descriptor.getRawType())) {
         finalDescriptors.add(descriptorUpdator.apply(descriptor));
       } else {
         otherDescriptors.add(descriptorUpdator.apply(descriptor));

--- a/java/fury-core/src/main/java/org/apache/fury/type/GenericType.java
+++ b/java/fury-core/src/main/java/org/apache/fury/type/GenericType.java
@@ -23,7 +23,6 @@ import static org.apache.fury.type.TypeUtils.getRawType;
 
 import com.google.common.reflect.TypeToken;
 import java.lang.reflect.GenericArrayType;
-import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
@@ -42,9 +41,9 @@ public class GenericType {
   static final Predicate<Type> defaultFinalPredicate =
       type -> {
         if (type.getClass() == Class.class) {
-          return ReflectionUtils.isFinal(((Class<?>) type));
+          return ReflectionUtils.isMonomorphic(((Class<?>) type));
         } else {
-          return ReflectionUtils.isFinal((getRawType(type)));
+          return ReflectionUtils.isMonomorphic((getRawType(type)));
         }
       };
 
@@ -55,18 +54,18 @@ public class GenericType {
   final GenericType typeParameter0;
   final GenericType typeParameter1;
   final boolean hasGenericParameters;
-  final boolean isFinal;
+  final boolean isMonomorphic;
   // Used to cache serializer for final class to avoid hash lookup for serializer.
   Serializer<?> serializer;
   private Boolean trackingRef;
 
-  public GenericType(TypeToken<?> typeToken, boolean isFinal, GenericType... typeParameters) {
+  public GenericType(TypeToken<?> typeToken, boolean isMonomorphic, GenericType... typeParameters) {
     this.typeToken = typeToken;
     this.cls = getRawType(typeToken);
     this.typeParameters = typeParameters;
     typeParametersCount = typeParameters.length;
     hasGenericParameters = typeParameters.length > 0;
-    this.isFinal = isFinal;
+    this.isMonomorphic = isMonomorphic;
     if (typeParameters.length > 0) {
       typeParameter0 = typeParameters[0];
     } else {
@@ -188,12 +187,12 @@ public class GenericType {
     return serializer;
   }
 
-  public boolean isFinal() {
-    return isFinal;
+  public boolean isMonomorphic() {
+    return isMonomorphic;
   }
 
   public Serializer<?> getSerializerOrNull(ClassResolver classResolver) {
-    if (isFinal) {
+    if (isMonomorphic) {
       return getSerializer(classResolver);
     } else {
       return null;

--- a/java/fury-core/src/main/java/org/apache/fury/type/GenericType.java
+++ b/java/fury-core/src/main/java/org/apache/fury/type/GenericType.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.function.Predicate;
 import org.apache.fury.resolver.ClassResolver;
 import org.apache.fury.serializer.Serializer;
+import org.apache.fury.util.ReflectionUtils;
 
 /** GenericType for building java generics as a tree and binding with fury serializers. */
 // TODO(chaokunyang) refine generics which can be inspired by spring ResolvableType.
@@ -41,9 +42,9 @@ public class GenericType {
   static final Predicate<Type> defaultFinalPredicate =
       type -> {
         if (type.getClass() == Class.class) {
-          return Modifier.isFinal(((Class<?>) type).getModifiers());
+          return ReflectionUtils.isFinal(((Class<?>) type));
         } else {
-          return Modifier.isFinal((getRawType(type)).getModifiers());
+          return ReflectionUtils.isFinal((getRawType(type)));
         }
       };
 

--- a/java/fury-core/src/main/java/org/apache/fury/util/ReflectionUtils.java
+++ b/java/fury-core/src/main/java/org/apache/fury/util/ReflectionUtils.java
@@ -415,6 +415,9 @@ public class ReflectionUtils {
   }
 
   public static boolean isFinal(Class<?> targetType) {
+    if (targetType.isArray()) {
+      return isFinal(targetType.getComponentType());
+    }
     return Modifier.isFinal(targetType.getModifiers());
   }
 

--- a/java/fury-core/src/main/java/org/apache/fury/util/ReflectionUtils.java
+++ b/java/fury-core/src/main/java/org/apache/fury/util/ReflectionUtils.java
@@ -414,9 +414,18 @@ public class ReflectionUtils {
     return Modifier.isPrivate(cls.getModifiers());
   }
 
-  public static boolean isFinal(Class<?> targetType) {
+  /** Returns true if this type can be assigned from other types. */
+  public static boolean isPolyMorphic(Class<?> targetType) {
     if (targetType.isArray()) {
-      return isFinal(targetType.getComponentType());
+      return isPolyMorphic(targetType.getComponentType());
+    }
+    return !Modifier.isFinal(targetType.getModifiers());
+  }
+
+  /** Returns true if this type can't be assigned from other types. */
+  public static boolean isMonomorphic(Class<?> targetType) {
+    if (targetType.isArray()) {
+      return isMonomorphic(targetType.getComponentType());
     }
     return Modifier.isFinal(targetType.getModifiers());
   }

--- a/java/fury-core/src/test/java/org/apache/fury/FuryTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/FuryTest.java
@@ -29,6 +29,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.io.*;
 import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Array;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;

--- a/java/fury-core/src/test/java/org/apache/fury/FuryTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/FuryTest.java
@@ -29,7 +29,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.io.*;
 import java.lang.invoke.MethodHandles;
-import java.lang.reflect.Array;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;

--- a/java/fury-core/src/test/java/org/apache/fury/serializer/ArraySerializersTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/serializer/ArraySerializersTest.java
@@ -28,7 +28,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import org.apache.fury.Fury;
@@ -159,7 +158,6 @@ public class ArraySerializersTest extends FuryTestBase {
     }
   }
 
-
   @EqualsAndHashCode
   static class A {
     final int f1;
@@ -216,7 +214,8 @@ public class ArraySerializersTest extends FuryTestBase {
     final GenericArrayWrapper<String> wrapper = new GenericArrayWrapper<>(String.class, 2);
     wrapper.array[0] = "Hello";
     final byte[] bytes = fury.serialize(wrapper);
-    final GenericArrayWrapper<String> deserialized = (GenericArrayWrapper<String>) fury.deserialize(bytes);
+    final GenericArrayWrapper<String> deserialized =
+        (GenericArrayWrapper<String>) fury.deserialize(bytes);
     deserialized.array[1] = "World";
     Assert.assertEquals(deserialized.array, new String[] {"Hello", "World"});
   }

--- a/java/fury-core/src/test/java/org/apache/fury/serializer/MetaSharedCompatibleTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/serializer/MetaSharedCompatibleTest.java
@@ -186,6 +186,71 @@ public class MetaSharedCompatibleTest extends FuryTestBase {
     }
   }
 
+  @Test
+  public void testWriteCompatibleCollectionSimple() throws Exception {
+    BeanA beanA = BeanA.createBeanA(2);
+    String pkg = BeanA.class.getPackage().getName();
+    String code =
+      ""
+        + "package "
+        + pkg
+        + ";\n"
+        + "import java.util.*;\n"
+        + "import java.math.*;\n"
+        + "public class BeanA {\n"
+        + "  private List<Double> doubleList;\n"
+        + "  private Iterable<BeanB> beanBIterable;\n"
+        + "  private List<BeanB> beanBList;\n"
+        + "}";
+    Class<?> cls1 =
+      loadClass(
+        BeanA.class,
+        code,
+        MetaSharedCompatibleTest.class + "testWriteCompatibleCollectionBasic_1");
+    Fury fury1 =
+      Fury.builder()
+        .withCodegen(false)
+        .withMetaContextShare(true)
+        .withCompatibleMode(CompatibleMode.COMPATIBLE)
+        .requireClassRegistration(false)
+        .withClassLoader(cls1.getClassLoader())
+        .build();
+    code =
+      ""
+        + "package "
+        + pkg
+        + ";\n"
+        + "import java.util.*;\n"
+        + "import java.math.*;\n"
+        + "public class BeanA {\n"
+        + "  private List<Double> doubleList;\n"
+        + "  private Iterable<BeanB> beanBIterable;\n"
+        + "}";
+    Class<?> cls2 =
+      loadClass(
+        BeanA.class,
+        code,
+        MetaSharedCompatibleTest.class + "testWriteCompatibleCollectionBasic_2");
+    Object o2 = cls2.newInstance();
+    ReflectionUtils.unsafeCopy(beanA, o2);
+    Fury fury2 =
+      Fury.builder()
+        .withCodegen(false)
+        .withMetaContextShare(true)
+        .withCompatibleMode(CompatibleMode.COMPATIBLE)
+        .requireClassRegistration(false)
+        .withClassLoader(cls2.getClassLoader())
+        .build();
+
+    MetaContext context1 = new MetaContext();
+    MetaContext context2 = new MetaContext();
+    fury1.getSerializationContext().setMetaContext(context1);
+    byte[] objBytes = fury1.serialize(beanA);
+    fury2.getSerializationContext().setMetaContext(context2);
+    Object obj2 = fury2.deserialize(objBytes);
+    Assert.assertTrue(ReflectionUtils.objectCommonFieldsEquals(obj2, o2));
+  }
+
   @Test(dataProvider = "config3")
   public void testWriteCompatibleCollectionBasic(
       boolean referenceTracking,
@@ -195,16 +260,6 @@ public class MetaSharedCompatibleTest extends FuryTestBase {
       boolean enableCodegen3)
       throws Exception {
     BeanA beanA = BeanA.createBeanA(2);
-    Fury fury =
-        Fury.builder()
-            .withLanguage(Language.JAVA)
-            .withRefTracking(referenceTracking)
-            .withNumberCompressed(compressNumber)
-            .withCodegen(enableCodegen1)
-            .withMetaContextShare(true)
-            .withCompatibleMode(CompatibleMode.COMPATIBLE)
-            .requireClassRegistration(false)
-            .build();
     String pkg = BeanA.class.getPackage().getName();
     String code =
         ""
@@ -234,7 +289,6 @@ public class MetaSharedCompatibleTest extends FuryTestBase {
             .requireClassRegistration(false)
             .withClassLoader(cls1.getClassLoader())
             .build();
-    MetaContext context1 = new MetaContext();
     code =
         ""
             + "package "
@@ -264,6 +318,8 @@ public class MetaSharedCompatibleTest extends FuryTestBase {
             .requireClassRegistration(false)
             .withClassLoader(cls2.getClassLoader())
             .build();
+
+    MetaContext context1 = new MetaContext();
     MetaContext context2 = new MetaContext();
     fury2.getSerializationContext().setMetaContext(context2);
     byte[] bytes2 = fury2.serialize(o2);
@@ -282,6 +338,16 @@ public class MetaSharedCompatibleTest extends FuryTestBase {
     Object obj2 = fury2.deserialize(objBytes);
     Assert.assertTrue(ReflectionUtils.objectCommonFieldsEquals(obj2, o2));
 
+    Fury fury =
+      Fury.builder()
+        .withLanguage(Language.JAVA)
+        .withRefTracking(referenceTracking)
+        .withNumberCompressed(compressNumber)
+        .withCodegen(enableCodegen1)
+        .withMetaContextShare(true)
+        .withCompatibleMode(CompatibleMode.COMPATIBLE)
+        .requireClassRegistration(false)
+        .build();
     // fury <-> fury2 is a new channel, which needs a new context.
     MetaContext context = new MetaContext();
     MetaContext ctx2 = new MetaContext();

--- a/java/fury-core/src/test/java/org/apache/fury/serializer/MetaSharedCompatibleTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/serializer/MetaSharedCompatibleTest.java
@@ -191,56 +191,56 @@ public class MetaSharedCompatibleTest extends FuryTestBase {
     BeanA beanA = BeanA.createBeanA(2);
     String pkg = BeanA.class.getPackage().getName();
     String code =
-      ""
-        + "package "
-        + pkg
-        + ";\n"
-        + "import java.util.*;\n"
-        + "import java.math.*;\n"
-        + "public class BeanA {\n"
-        + "  private List<Double> doubleList;\n"
-        + "  private Iterable<BeanB> beanBIterable;\n"
-        + "  private List<BeanB> beanBList;\n"
-        + "}";
+        ""
+            + "package "
+            + pkg
+            + ";\n"
+            + "import java.util.*;\n"
+            + "import java.math.*;\n"
+            + "public class BeanA {\n"
+            + "  private List<Double> doubleList;\n"
+            + "  private Iterable<BeanB> beanBIterable;\n"
+            + "  private List<BeanB> beanBList;\n"
+            + "}";
     Class<?> cls1 =
-      loadClass(
-        BeanA.class,
-        code,
-        MetaSharedCompatibleTest.class + "testWriteCompatibleCollectionBasic_1");
+        loadClass(
+            BeanA.class,
+            code,
+            MetaSharedCompatibleTest.class + "testWriteCompatibleCollectionBasic_1");
     Fury fury1 =
-      Fury.builder()
-        .withCodegen(false)
-        .withMetaContextShare(true)
-        .withCompatibleMode(CompatibleMode.COMPATIBLE)
-        .requireClassRegistration(false)
-        .withClassLoader(cls1.getClassLoader())
-        .build();
+        Fury.builder()
+            .withCodegen(false)
+            .withMetaContextShare(true)
+            .withCompatibleMode(CompatibleMode.COMPATIBLE)
+            .requireClassRegistration(false)
+            .withClassLoader(cls1.getClassLoader())
+            .build();
     code =
-      ""
-        + "package "
-        + pkg
-        + ";\n"
-        + "import java.util.*;\n"
-        + "import java.math.*;\n"
-        + "public class BeanA {\n"
-        + "  private List<Double> doubleList;\n"
-        + "  private Iterable<BeanB> beanBIterable;\n"
-        + "}";
+        ""
+            + "package "
+            + pkg
+            + ";\n"
+            + "import java.util.*;\n"
+            + "import java.math.*;\n"
+            + "public class BeanA {\n"
+            + "  private List<Double> doubleList;\n"
+            + "  private Iterable<BeanB> beanBIterable;\n"
+            + "}";
     Class<?> cls2 =
-      loadClass(
-        BeanA.class,
-        code,
-        MetaSharedCompatibleTest.class + "testWriteCompatibleCollectionBasic_2");
+        loadClass(
+            BeanA.class,
+            code,
+            MetaSharedCompatibleTest.class + "testWriteCompatibleCollectionBasic_2");
     Object o2 = cls2.newInstance();
     ReflectionUtils.unsafeCopy(beanA, o2);
     Fury fury2 =
-      Fury.builder()
-        .withCodegen(false)
-        .withMetaContextShare(true)
-        .withCompatibleMode(CompatibleMode.COMPATIBLE)
-        .requireClassRegistration(false)
-        .withClassLoader(cls2.getClassLoader())
-        .build();
+        Fury.builder()
+            .withCodegen(false)
+            .withMetaContextShare(true)
+            .withCompatibleMode(CompatibleMode.COMPATIBLE)
+            .requireClassRegistration(false)
+            .withClassLoader(cls2.getClassLoader())
+            .build();
 
     MetaContext context1 = new MetaContext();
     MetaContext context2 = new MetaContext();
@@ -339,15 +339,15 @@ public class MetaSharedCompatibleTest extends FuryTestBase {
     Assert.assertTrue(ReflectionUtils.objectCommonFieldsEquals(obj2, o2));
 
     Fury fury =
-      Fury.builder()
-        .withLanguage(Language.JAVA)
-        .withRefTracking(referenceTracking)
-        .withNumberCompressed(compressNumber)
-        .withCodegen(enableCodegen1)
-        .withMetaContextShare(true)
-        .withCompatibleMode(CompatibleMode.COMPATIBLE)
-        .requireClassRegistration(false)
-        .build();
+        Fury.builder()
+            .withLanguage(Language.JAVA)
+            .withRefTracking(referenceTracking)
+            .withNumberCompressed(compressNumber)
+            .withCodegen(enableCodegen1)
+            .withMetaContextShare(true)
+            .withCompatibleMode(CompatibleMode.COMPATIBLE)
+            .requireClassRegistration(false)
+            .build();
     // fury <-> fury2 is a new channel, which needs a new context.
     MetaContext context = new MetaContext();
     MetaContext ctx2 = new MetaContext();


### PR DESCRIPTION
`Object[]` can be assigned from `String[]` and other arrays, we take it as a final type before, so we skip writing classinfo for such types and lost object type too.

This PR fix this polymorphic array serialization bug by checking array type polymorphism by component type.

Closes #1323 