### PR TITLE
[refactor] threadSafeFury use thread pool

### DIFF
--- a/java/fury-core/src/main/java/org/apache/fury/config/FuryBuilder.java
+++ b/java/fury-core/src/main/java/org/apache/fury/config/FuryBuilder.java
@@ -340,8 +340,8 @@ public final class FuryBuilder {
   }
 
   /** Build thread safe fury. */
-  public ThreadSafeFury buildThreadSafeFury() {
-    return buildThreadLocalFury();
+  public ThreadSafeFury buildThreadSafeFury(int minPoolSize, int maxPoolSize) {
+    return buildThreadSafeFuryPool(minPoolSize, maxPoolSize);
   }
 
   /** Build thread safe fury backed by {@link ThreadLocalFury}. */

--- a/java/fury-core/src/main/java/org/apache/fury/config/FuryBuilder.java
+++ b/java/fury-core/src/main/java/org/apache/fury/config/FuryBuilder.java
@@ -339,6 +339,13 @@ public final class FuryBuilder {
     return newFury(this, loader);
   }
 
+  /** Build thread safe fury with default params. */
+  public ThreadSafeFury buildThreadSafeFury() {
+    Runtime runtime = Runtime.getRuntime();
+    int cores = runtime.availableProcessors();
+    return buildThreadSafeFuryPool(cores, cores * 2);
+  }
+
   /** Build thread safe fury. */
   public ThreadSafeFury buildThreadSafeFury(int minPoolSize, int maxPoolSize) {
     return buildThreadSafeFuryPool(minPoolSize, maxPoolSize);

--- a/java/fury-core/src/test/java/org/apache/fury/FuryInitPerf.java
+++ b/java/fury-core/src/test/java/org/apache/fury/FuryInitPerf.java
@@ -39,7 +39,7 @@ public class FuryInitPerf {
   private static final Logger LOG = LoggerFactory.getLogger(FuryInitPerf.class);
 
   public void testFuryInit() {
-    Fury.builder().buildThreadSafeFury(5, 10);
+    Fury.builder().buildThreadSafeFury();
     int num = 1000;
     List<Fury> furyList = new ArrayList<>(num);
     List<Double> durations = new ArrayList<>(num);
@@ -71,7 +71,7 @@ public class FuryInitPerf {
   }
 
   public void testNewFurySerialization() {
-    Fury.builder().buildThreadSafeFury(5, 10);
+    Fury.builder().buildThreadSafeFury();
     int num = 1000;
     Fury fury =
         Fury.builder()

--- a/java/fury-core/src/test/java/org/apache/fury/FuryInitPerf.java
+++ b/java/fury-core/src/test/java/org/apache/fury/FuryInitPerf.java
@@ -39,7 +39,7 @@ public class FuryInitPerf {
   private static final Logger LOG = LoggerFactory.getLogger(FuryInitPerf.class);
 
   public void testFuryInit() {
-    Fury.builder().buildThreadSafeFury();
+    Fury.builder().buildThreadSafeFury(5, 10);
     int num = 1000;
     List<Fury> furyList = new ArrayList<>(num);
     List<Double> durations = new ArrayList<>(num);
@@ -71,7 +71,7 @@ public class FuryInitPerf {
   }
 
   public void testNewFurySerialization() {
-    Fury.builder().buildThreadSafeFury();
+    Fury.builder().buildThreadSafeFury(5, 10);
     int num = 1000;
     Fury fury =
         Fury.builder()

--- a/java/fury-core/src/test/java/org/apache/fury/ThreadSafeFuryTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/ThreadSafeFuryTest.java
@@ -54,7 +54,7 @@ public class ThreadSafeFuryTest extends FuryTestBase {
             .withRefTracking(true)
             .requireClassRegistration(false)
             .withAsyncCompilation(true)
-            .buildThreadSafeFuryPool(5, 10);
+            .buildThreadSafeFuryPool(1, 8);
     for (int i = 0; i < 2000; i++) {
       new Thread(
               () -> {

--- a/java/fury-core/src/test/java/org/apache/fury/ThreadSafeFuryTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/ThreadSafeFuryTest.java
@@ -118,7 +118,7 @@ public class ThreadSafeFuryTest extends FuryTestBase {
             .withRefTracking(true)
             .requireClassRegistration(false)
             .withAsyncCompilation(true)
-            .buildThreadSafeFury();
+            .buildThreadSafeFury(5, 10);
     ExecutorService executorService = Executors.newFixedThreadPool(12);
     for (int i = 0; i < 2000; i++) {
       executorService.execute(
@@ -145,13 +145,13 @@ public class ThreadSafeFuryTest extends FuryTestBase {
         Fury.builder()
             .withLanguage(Language.JAVA)
             .requireClassRegistration(false)
-            .buildThreadSafeFury();
+            .buildThreadSafeFury(5, 10);
     ThreadSafeFury fury2 =
         Fury.builder()
             .withLanguage(Language.JAVA)
             .withMetaContextShare(true)
             .requireClassRegistration(false)
-            .buildThreadSafeFury();
+            .buildThreadSafeFury(5, 10);
     BeanA beanA = BeanA.createBeanA(2);
     ExecutorService executorService = Executors.newFixedThreadPool(12);
     ConcurrentHashMap<Thread, MetaContext> metaMap = new ConcurrentHashMap<>();
@@ -220,7 +220,7 @@ public class ThreadSafeFuryTest extends FuryTestBase {
 
   @Test(dataProvider = "stagingConfig")
   public void testClassDuplicateName(StagingType staging) {
-    ThreadSafeFury fury = Fury.builder().requireClassRegistration(false).buildThreadSafeFury();
+    ThreadSafeFury fury = Fury.builder().requireClassRegistration(false).buildThreadSafeFury(5, 10);
     String className = "DuplicateStruct";
 
     Class<?> structClass1 = Struct.createStructClass(className, 1);
@@ -277,7 +277,7 @@ public class ThreadSafeFuryTest extends FuryTestBase {
   }
 
   private WeakHashMap<Class<?>, Boolean> generateClassForGC() {
-    ThreadSafeFury fury = Fury.builder().requireClassRegistration(false).buildThreadSafeFury();
+    ThreadSafeFury fury = Fury.builder().requireClassRegistration(false).buildThreadSafeFury(5, 10);
     String className = "DuplicateStruct";
     WeakHashMap<Class<?>, Boolean> map = new WeakHashMap<>();
     {
@@ -309,7 +309,7 @@ public class ThreadSafeFuryTest extends FuryTestBase {
   public void testSerializeJavaObject() {
     for (ThreadSafeFury fury :
         new ThreadSafeFury[] {
-          Fury.builder().requireClassRegistration(false).buildThreadSafeFury(),
+          Fury.builder().requireClassRegistration(false).buildThreadSafeFury(5, 10),
           Fury.builder().requireClassRegistration(false).buildThreadSafeFuryPool(2, 2)
         }) {
       byte[] bytes = fury.serializeJavaObject("abc");

--- a/java/fury-core/src/test/java/org/apache/fury/ThreadSafeFuryTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/ThreadSafeFuryTest.java
@@ -145,13 +145,13 @@ public class ThreadSafeFuryTest extends FuryTestBase {
         Fury.builder()
             .withLanguage(Language.JAVA)
             .requireClassRegistration(false)
-            .buildThreadSafeFury(5, 10);
+            .buildThreadSafeFury();
     ThreadSafeFury fury2 =
         Fury.builder()
             .withLanguage(Language.JAVA)
             .withMetaContextShare(true)
             .requireClassRegistration(false)
-            .buildThreadSafeFury(5, 10);
+            .buildThreadSafeFury();
     BeanA beanA = BeanA.createBeanA(2);
     ExecutorService executorService = Executors.newFixedThreadPool(12);
     ConcurrentHashMap<Thread, MetaContext> metaMap = new ConcurrentHashMap<>();
@@ -220,7 +220,7 @@ public class ThreadSafeFuryTest extends FuryTestBase {
 
   @Test(dataProvider = "stagingConfig")
   public void testClassDuplicateName(StagingType staging) {
-    ThreadSafeFury fury = Fury.builder().requireClassRegistration(false).buildThreadSafeFury(5, 10);
+    ThreadSafeFury fury = Fury.builder().requireClassRegistration(false).buildThreadSafeFury();
     String className = "DuplicateStruct";
 
     Class<?> structClass1 = Struct.createStructClass(className, 1);
@@ -277,7 +277,7 @@ public class ThreadSafeFuryTest extends FuryTestBase {
   }
 
   private WeakHashMap<Class<?>, Boolean> generateClassForGC() {
-    ThreadSafeFury fury = Fury.builder().requireClassRegistration(false).buildThreadSafeFury(5, 10);
+    ThreadSafeFury fury = Fury.builder().requireClassRegistration(false).buildThreadSafeFury();
     String className = "DuplicateStruct";
     WeakHashMap<Class<?>, Boolean> map = new WeakHashMap<>();
     {
@@ -309,7 +309,7 @@ public class ThreadSafeFuryTest extends FuryTestBase {
   public void testSerializeJavaObject() {
     for (ThreadSafeFury fury :
         new ThreadSafeFury[] {
-          Fury.builder().requireClassRegistration(false).buildThreadSafeFury(5, 10),
+          Fury.builder().requireClassRegistration(false).buildThreadSafeFury(),
           Fury.builder().requireClassRegistration(false).buildThreadSafeFuryPool(2, 2)
         }) {
       byte[] bytes = fury.serializeJavaObject("abc");


### PR DESCRIPTION
close #1335 

**Use org.apache.fury.pool.ThreadPoolFury as default ThreadSafeFury implementation.**


**failed test case** 
- *org.apache.fury.ThreadSafeFuryTest#testClassDuplicateName*
- *org.apache.fury.ThreadSafeFuryTest#testClassGC*
- *org.apache.fury.ThreadSafeFuryTest#testSerializeWithMetaShare*

