### PR TITLE
chore(JavaScript): Drop optional chaining expression

### DIFF
--- a/javascript/packages/fury/lib/gen/index.ts
+++ b/javascript/packages/fury/lib/gen/index.ts
@@ -45,10 +45,13 @@ export const generate = (fury: Fury, description: TypeDescription) => {
   const generator = new InnerGeneratorClass(description, new CodecBuilder(scope, fury), scope);
 
   const funcString = generator.toSerializer();
-  const afterCodeGenerated = fury.config?.hooks?.afterCodeGenerated;
-  if (typeof afterCodeGenerated === "function") {
-    return new Function(afterCodeGenerated(funcString));
+  if (fury.config && fury.config.hooks) {
+    const afterCodeGenerated = fury.config.hooks.afterCodeGenerated;
+    if (typeof afterCodeGenerated === "function") {
+      return new Function(afterCodeGenerated(funcString));
+    }
   }
+
   return new Function(funcString);
 };
 

--- a/javascript/packages/fury/lib/writer.ts
+++ b/javascript/packages/fury/lib/writer.ts
@@ -333,7 +333,7 @@ export const BinaryWriter = (config: Config) => {
     varUInt32,
     varUInt64,
     varInt64,
-    stringOfVarUInt32: config?.hps
+    stringOfVarUInt32: config && config.hps
       ? stringOfVarUInt32Fast()
       : stringOfVarUInt32Slow,
     bufferWithoutMemCheck,

--- a/javascript/packages/fury/package.json
+++ b/javascript/packages/fury/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@furyjs/fury",
-  "version": "0.5.5-beta",
+  "version": "0.5.6-beta",
   "description": "A blazing fast multi-language serialization framework powered by jit and zero-copy",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
some old compiler did not recognize the `?.` expression(sadly).

