### PR TITLE
fix(Rust): incorrect cast

### DIFF
--- a/rust/fury/src/lib.rs
+++ b/rust/fury/src/lib.rs
@@ -31,7 +31,7 @@ pub use serializer::to_buffer;
 pub mod __derive {
     pub use crate::buffer::{Reader, Writer};
     pub use crate::deserializer::{Deserialize, DeserializerState};
-    pub use crate::row::{Row, StructViewer, StructWriter};
+    pub use crate::row::{Row, StructViewer, StructWriter, ArrayViewer, ArrayWriter};
     pub use crate::serializer::{Serialize, SerializerState};
     pub use crate::types::{compute_struct_hash, FieldType, FuryMeta, SIZE_OF_REF_AND_TYPE};
     pub use crate::Error;

--- a/rust/fury/src/lib.rs
+++ b/rust/fury/src/lib.rs
@@ -31,7 +31,7 @@ pub use serializer::to_buffer;
 pub mod __derive {
     pub use crate::buffer::{Reader, Writer};
     pub use crate::deserializer::{Deserialize, DeserializerState};
-    pub use crate::row::{Row, StructViewer, StructWriter, ArrayViewer, ArrayWriter};
+    pub use crate::row::{ArrayViewer, ArrayWriter, Row, StructViewer, StructWriter};
     pub use crate::serializer::{Serialize, SerializerState};
     pub use crate::types::{compute_struct_hash, FieldType, FuryMeta, SIZE_OF_REF_AND_TYPE};
     pub use crate::Error;

--- a/rust/fury/src/row/writer.rs
+++ b/rust/fury/src/row/writer.rs
@@ -177,7 +177,7 @@ impl<'a> MapWriter<'a> {
     pub fn write_end(&mut self, data_start: usize) {
         let size: usize = self.writer.len() - data_start;
         self.writer
-            .set_bytes(self.base_offset, &(size as u32).to_le_bytes());
+            .set_bytes(self.base_offset, &(size as u64).to_le_bytes());
     }
 }
 

--- a/rust/fury/src/types.rs
+++ b/rust/fury/src/types.rs
@@ -184,7 +184,7 @@ pub enum FieldType {
 
 const MAX_UNT32: u64 = (1 << 31) - 1;
 
-// todo: struct hash 
+// todo: struct hash
 #[allow(dead_code)]
 pub fn compute_string_hash(s: &str) -> u32 {
     let mut hash: u64 = 17;

--- a/rust/fury/src/types.rs
+++ b/rust/fury/src/types.rs
@@ -184,6 +184,8 @@ pub enum FieldType {
 
 const MAX_UNT32: u64 = (1 << 31) - 1;
 
+// todo: struct hash 
+#[allow(dead_code)]
 pub fn compute_string_hash(s: &str) -> u32 {
     let mut hash: u64 = 17;
     s.as_bytes().iter().for_each(|b| {
@@ -233,6 +235,8 @@ pub fn compute_struct_hash(props: Vec<(&str, FieldType, &str)>) -> u32 {
     hash
 }
 
+// todo: flag check
+#[allow(dead_code)]
 pub mod config_flags {
     pub const IS_NULL_FLAG: u8 = 1 << 0;
     pub const IS_LITTLE_ENDIAN_FLAG: u8 = 2;


### PR DESCRIPTION
1. Dismiss warnings
2. Fix incorrect type conversions which cause the failures in #1332 