### PR TITLE
feat(JavaScript): Support oneof

### DIFF
--- a/javascript/package.json
+++ b/javascript/package.json
@@ -1,7 +1,8 @@
 {
   "scripts": {
     "test": "npm run build && jest",
-    "build": "npm run build -w packages/fury -w packages/hps",
+    "clear": "rm -rf ./packages/fury/dist && rm -rf ./packages/hps/dist",
+    "build": "npm run clear && npm run build -w packages/fury -w packages/hps",
     "lint": "eslint .",
     "lint-fix": "eslint . --fix"
   },

--- a/javascript/packages/fury/lib/description.ts
+++ b/javascript/packages/fury/lib/description.ts
@@ -20,59 +20,59 @@
 import { InternalSerializerType } from "./type";
 
 export interface TypeDescription {
-  type: InternalSerializerType
-  label?: string
+  type: InternalSerializerType;
+  label?: string;
 }
 
 export interface ObjectTypeDescription extends TypeDescription {
   options: {
-    props: { [key: string]: TypeDescription }
-    tag: string
-  }
+    props: { [key: string]: TypeDescription };
+    tag: string;
+  };
 }
 
 export interface EnumTypeDescription extends TypeDescription {
   options: {
-    inner: { [key: string]: any }
-  }
+    inner: { [key: string]: any };
+  };
 }
 
 export interface OneofTypeDescription extends TypeDescription {
   options: {
-    inner: { [key: string]: TypeDescription }
-  }
+    inner: { [key: string]: TypeDescription };
+  };
 }
 
 export interface ArrayTypeDescription extends TypeDescription {
   options: {
-    inner: TypeDescription
-  }
+    inner: TypeDescription;
+  };
 }
 
 export interface TupleTypeDescription extends TypeDescription {
   options: {
-    inner: TypeDescription[]
-  }
+    inner: TypeDescription[];
+  };
 }
 
 export interface SetTypeDescription extends TypeDescription {
   options: {
-    key: TypeDescription
-  }
+    key: TypeDescription;
+  };
 }
 
 export interface MapTypeDescription extends TypeDescription {
   options: {
-    key: TypeDescription
-    value: TypeDescription
-  }
+    key: TypeDescription;
+    value: TypeDescription;
+  };
 }
 
 type Props<T> = T extends {
   options: {
-    props?: infer T2 extends { [key: string]: any }
-    tag: string
-  }
+    props?: infer T2 extends { [key: string]: any };
+    tag: string;
+  };
 }
   ? {
       [P in keyof T2]?: (InputType<T2[P]> | null);
@@ -81,25 +81,25 @@ type Props<T> = T extends {
 
 type InnerProps<T> = T extends {
   options: {
-    inner: infer T2 extends TypeDescription
-  }
+    inner: infer T2 extends TypeDescription;
+  };
 }
   ? (InputType<T2> | null)[]
   : unknown;
 
 type MapProps<T> = T extends {
   options: {
-    key: infer T2 extends TypeDescription
-    value: infer T3 extends TypeDescription
-  }
+    key: infer T2 extends TypeDescription;
+    value: infer T3 extends TypeDescription;
+  };
 }
   ? Map<InputType<T2>, InputType<T3> | null>
   : unknown;
 
 type TupleProps<T> = T extends {
   options: {
-    inner: infer T2 extends readonly [...TypeDescription[]]
-  }
+    inner: infer T2 extends readonly [...TypeDescription[]];
+  };
 }
   ? { [K in keyof T2]: InputType<T2[K]> }
   : unknown;
@@ -108,16 +108,16 @@ type Value<T> = T extends { [s: string]: infer T2 } ? T2 : unknown;
 
 type EnumProps<T> = T extends {
   options: {
-    inner: infer T2
-  }
+    inner: infer T2;
+  };
 }
   ? Value<T2>
   : unknown;
 
 type OneofProps<T> = T extends {
   options: {
-    inner?: infer T2 extends { [key: string]: any }
-  }
+    inner?: infer T2 extends { [key: string]: any };
+  };
 }
   ? {
       [P in keyof T2]?: (InputType<T2[P]> | null);
@@ -126,30 +126,30 @@ type OneofProps<T> = T extends {
 
 type OneofResult<T> = T extends {
   options: {
-    inner?: infer T2
-  }
+    inner?: infer T2;
+  };
 }
   ? ResultType<Value<T2>>
   : unknown;
 
 type SetProps<T> = T extends {
   options: {
-    key: infer T2 extends TypeDescription
-  }
+    key: infer T2 extends TypeDescription;
+  };
 }
   ? Set<(InputType<T2> | null)>
   : unknown;
 
 export type InputType<T> = T extends {
-  type: InternalSerializerType.FURY_TYPE_TAG
+  type: InternalSerializerType.FURY_TYPE_TAG;
 }
   ? Props<T>
   : T extends {
-    type: InternalSerializerType.STRING
+    type: InternalSerializerType.STRING;
   }
     ? string
     : T extends {
-      type: InternalSerializerType.TUPLE
+      type: InternalSerializerType.TUPLE;
     }
       ? TupleProps<T>
       : T extends {
@@ -161,64 +161,64 @@ export type InputType<T> = T extends {
           | InternalSerializerType.INT16
           | InternalSerializerType.INT32
           | InternalSerializerType.FLOAT
-          | InternalSerializerType.DOUBLE
+          | InternalSerializerType.DOUBLE;
       }
         ? number
 
         : T extends {
           type: InternalSerializerType.UINT64
-            | InternalSerializerType.INT64
+            | InternalSerializerType.INT64;
         }
           ? bigint
           : T extends {
-            type: InternalSerializerType.MAP
+            type: InternalSerializerType.MAP;
           }
             ? MapProps<T>
             : T extends {
-              type: InternalSerializerType.FURY_SET
+              type: InternalSerializerType.FURY_SET;
             }
               ? SetProps<T>
               : T extends {
-                type: InternalSerializerType.ARRAY
+                type: InternalSerializerType.ARRAY;
               }
                 ? InnerProps<T>
                 : T extends {
-                  type: InternalSerializerType.BOOL
+                  type: InternalSerializerType.BOOL;
                 }
                   ? boolean
                   : T extends {
-                    type: InternalSerializerType.DATE
+                    type: InternalSerializerType.DATE;
                   }
                     ? Date
                     : T extends {
-                      type: InternalSerializerType.TIMESTAMP
+                      type: InternalSerializerType.TIMESTAMP;
                     }
                       ? number
                       : T extends {
-                        type: InternalSerializerType.BINARY
+                        type: InternalSerializerType.BINARY;
                       }
                         ? Uint8Array
                         : T extends {
-                          type: InternalSerializerType.ANY
+                          type: InternalSerializerType.ANY;
                         }
                           ? any
                           : T extends {
-                            type: InternalSerializerType.ENUM
+                            type: InternalSerializerType.ENUM;
                           }
                             ? EnumProps<T> : T extends {
-                              type: InternalSerializerType.ONEOF
+                              type: InternalSerializerType.ONEOF;
                             } ? OneofProps<T> : unknown;
 
 export type ResultType<T> = T extends {
-  type: InternalSerializerType.FURY_TYPE_TAG
+  type: InternalSerializerType.FURY_TYPE_TAG;
 }
   ? Props<T>
   : T extends {
-    type: InternalSerializerType.STRING
+    type: InternalSerializerType.STRING;
   }
     ? string
     : T extends {
-      type: InternalSerializerType.TUPLE
+      type: InternalSerializerType.TUPLE;
     }
       ? TupleProps<T>
       : T extends {
@@ -230,52 +230,52 @@ export type ResultType<T> = T extends {
           | InternalSerializerType.INT16
           | InternalSerializerType.INT32
           | InternalSerializerType.FLOAT
-          | InternalSerializerType.DOUBLE
+          | InternalSerializerType.DOUBLE;
       }
         ? number
 
         : T extends {
           type: InternalSerializerType.UINT64
-            | InternalSerializerType.INT64
+            | InternalSerializerType.INT64;
         }
           ? bigint
           : T extends {
-            type: InternalSerializerType.MAP
+            type: InternalSerializerType.MAP;
           }
             ? MapProps<T>
             : T extends {
-              type: InternalSerializerType.FURY_SET
+              type: InternalSerializerType.FURY_SET;
             }
               ? SetProps<T>
               : T extends {
-                type: InternalSerializerType.ARRAY
+                type: InternalSerializerType.ARRAY;
               }
                 ? InnerProps<T>
                 : T extends {
-                  type: InternalSerializerType.BOOL
+                  type: InternalSerializerType.BOOL;
                 }
                   ? boolean
                   : T extends {
-                    type: InternalSerializerType.DATE
+                    type: InternalSerializerType.DATE;
                   }
                     ? Date
                     : T extends {
-                      type: InternalSerializerType.TIMESTAMP
+                      type: InternalSerializerType.TIMESTAMP;
                     }
                       ? number
                       : T extends {
-                        type: InternalSerializerType.BINARY
+                        type: InternalSerializerType.BINARY;
                       }
                         ? Uint8Array
                         : T extends {
-                          type: InternalSerializerType.ANY
+                          type: InternalSerializerType.ANY;
                         }
                           ? any
                           : T extends {
-                            type: InternalSerializerType.ENUM
+                            type: InternalSerializerType.ENUM;
                           }
                             ? EnumProps<T> : T extends {
-                              type: InternalSerializerType.ONEOF
+                              type: InternalSerializerType.ONEOF;
                             } ? OneofResult<T> : unknown;
 
 export const Type = {

--- a/javascript/packages/fury/lib/fury.ts
+++ b/javascript/packages/fury/lib/fury.ts
@@ -23,7 +23,7 @@ import { BinaryReader } from "./reader";
 import { ReferenceResolver } from "./referenceResolver";
 import { ConfigFlags, Serializer, Config, Language, BinaryReader as BinaryReaderType, BinaryWriter as BinaryWriterType } from "./type";
 import { OwnershipError } from "./error";
-import { ToRecordType, TypeDescription } from "./description";
+import { InputType, ResultType, TypeDescription } from "./description";
 import { generateSerializer, AnySerializer } from "./gen";
 
 export default class {
@@ -50,14 +50,14 @@ export default class {
     const serializer = generateSerializer(this, description);
     return {
       serializer,
-      serialize: (data: ToRecordType<T>) => {
+      serialize: (data: InputType<T>) => {
         return this.serialize(data, serializer);
       },
-      serializeVolatile: (data: ToRecordType<T>) => {
+      serializeVolatile: (data: InputType<T>) => {
         return this.serializeVolatile(data, serializer);
       },
       deserialize: (bytes: Uint8Array) => {
-        return this.deserialize(bytes, serializer) as ToRecordType<T>;
+        return this.deserialize(bytes, serializer) as ResultType<T>;
       },
     };
   }

--- a/javascript/packages/fury/lib/gen/any.ts
+++ b/javascript/packages/fury/lib/gen/any.ts
@@ -124,13 +124,13 @@ class AnySerializerGenerator extends BaseSerializerGenerator {
 
     const declare = `
       const readInner = (fromRef) => {
-        throw new Error("Type oneof readInner can't call directly");
+        throw new Error("Type Any readInner can't call directly");
       };
       const read = () => {
         ${this.toReadEmbed(expr => `return ${expr}`)}
       };
       const writeInner = (v) => {
-        throw new Error("Type oneof writeInner can't call directly");
+        throw new Error("Type Any writeInner can't call directly");
       };
       const write = (v) => {
         ${this.toWriteEmbed("v")}

--- a/javascript/packages/fury/lib/gen/any.ts
+++ b/javascript/packages/fury/lib/gen/any.ts
@@ -94,12 +94,12 @@ class AnySerializerGenerator extends BaseSerializerGenerator {
     this.description = description;
   }
 
-  writeStmt(accessor: string): string {
-    return `${this.builder.furyName()}.anySerializer.writeInner(${accessor})`;
+  writeStmt(): string {
+    throw new Error("Type Any writeStmt can't inline");
   }
 
-  readStmt(accessor: (expr: string) => string): string {
-    return `${this.builder.furyName()}.anySerializer.readInner(${accessor})`;
+  readStmt(): string {
+    throw new Error("Type Any readStmt can't inline");
   }
 
   toReadEmbed(accessor: (expr: string) => string, excludeHead = false): string {
@@ -114,6 +114,41 @@ class AnySerializerGenerator extends BaseSerializerGenerator {
       throw new Error("Anonymous can't excludeHead");
     }
     return `${this.builder.furyName()}.anySerializer.write(${accessor})`;
+  }
+
+  toSerializer() {
+    this.scope.assertNameNotDuplicate("read");
+    this.scope.assertNameNotDuplicate("readInner");
+    this.scope.assertNameNotDuplicate("write");
+    this.scope.assertNameNotDuplicate("writeInner");
+
+    const declare = `
+      const readInner = (fromRef) => {
+        throw new Error("Type oneof readInner can't call directly");
+      };
+      const read = () => {
+        ${this.toReadEmbed(expr => `return ${expr}`)}
+      };
+      const writeInner = (v) => {
+        throw new Error("Type oneof writeInner can't call directly");
+      };
+      const write = (v) => {
+        ${this.toWriteEmbed("v")}
+      };
+    `;
+    return `
+        return function (fury, external) {
+            ${this.scope.generate()}
+            ${declare}
+            return {
+              read,
+              readInner,
+              write,
+              writeInner,
+              meta: ${JSON.stringify(this.builder.meta(this.description))}
+            };
+        }
+        `;
   }
 }
 

--- a/javascript/packages/fury/lib/gen/builder.ts
+++ b/javascript/packages/fury/lib/gen/builder.ts
@@ -331,6 +331,13 @@ export class CodecBuilder {
     return v.replace(/\\/g, "\\\\").replace(/"/g, "\\\"");
   }
 
+  static safeString(target: string) {
+    if (!CodecBuilder.isDotPropAccessor(target) || CodecBuilder.isReserved(target)) {
+      return `"${CodecBuilder.replaceBackslashAndQuote(target)}"`;
+    }
+    return `"${target}"`;
+  }
+
   static safePropAccessor(prop: string) {
     if (!CodecBuilder.isDotPropAccessor(prop) || CodecBuilder.isReserved(prop)) {
       return `["${CodecBuilder.replaceBackslashAndQuote(prop)}"]`;

--- a/javascript/packages/fury/lib/gen/index.ts
+++ b/javascript/packages/fury/lib/gen/index.ts
@@ -18,7 +18,7 @@
  */
 
 import { InternalSerializerType } from "../type";
-import { ArrayTypeDescription, MapTypeDescription, ObjectTypeDescription, SetTypeDescription, TupleTypeDescription, TypeDescription } from "../description";
+import { ArrayTypeDescription, MapTypeDescription, ObjectTypeDescription, OneofTypeDescription, SetTypeDescription, TupleTypeDescription, TypeDescription } from "../description";
 import { CodegenRegistry } from "./router";
 import { CodecBuilder } from "./builder";
 import { Scope } from "./scope";
@@ -35,6 +35,7 @@ import "./tuple";
 import "./typedArray";
 import Fury from "../fury";
 import "./enum";
+import "./oneof";
 
 export { AnySerializer } from "./any";
 
@@ -85,6 +86,14 @@ function regDependencies(fury: Fury, description: TypeDescription) {
     (<TupleTypeDescription>description).options.inner.forEach((x) => {
       regDependencies(fury, x);
     });
+  }
+  if (description.type === InternalSerializerType.ONEOF) {
+    const options = (<OneofTypeDescription>description).options;
+    if (options.inner) {
+      Object.values(options.inner).forEach((x) => {
+        regDependencies(fury, x);
+      });
+    }
   }
 }
 

--- a/javascript/packages/fury/lib/gen/object.ts
+++ b/javascript/packages/fury/lib/gen/object.ts
@@ -112,7 +112,7 @@ class ObjectSerializerGenerator extends BaseSerializerGenerator {
          `;
   }
 
-  safeTag() {
+  private safeTag() {
     return CodecBuilder.replaceBackslashAndQuote(this.description.options.tag);
   }
 

--- a/javascript/packages/fury/lib/gen/oneof.ts
+++ b/javascript/packages/fury/lib/gen/oneof.ts
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { OneofTypeDescription, Type, TypeDescription } from "../description";
+import { CodecBuilder } from "./builder";
+import { BaseSerializerGenerator } from "./serializer";
+import { CodegenRegistry } from "./router";
+import { InternalSerializerType, RefFlags } from "../type";
+import { Scope } from "./scope";
+
+class OneofSerializerGenerator extends BaseSerializerGenerator {
+  description: OneofTypeDescription;
+
+  constructor(description: TypeDescription, builder: CodecBuilder, scope: Scope) {
+    super(description, builder, scope);
+    this.description = <OneofTypeDescription>description;
+  }
+
+  writeStmt(): string {
+    throw new Error("Type oneof writeStmt can't inline");
+  }
+
+  readStmt(): string {
+    throw new Error("Type oneof readStmt can't inline");
+  }
+
+  toWriteEmbed(accessor: string, excludeHead = false) {
+    if (excludeHead) {
+      throw new Error("Oneof can't excludeHead");
+    }
+    if (Object.values(this.description.options.inner).length < 1) {
+      throw new Error("Type oneof must contain at least one field");
+    }
+    const stmts = [
+            `if (${accessor} === null || ${accessor} === undefined) {
+                ${this.builder.writer.int8(RefFlags.NullFlag)};
+            }`,
+    ];
+    Object.entries(this.description.options.inner).forEach(([key, value]) => {
+      const InnerGeneratorClass = CodegenRegistry.get(value.type);
+      if (!InnerGeneratorClass) {
+        throw new Error(`${value.type} generator not exists`);
+      }
+      const innerGenerator = new InnerGeneratorClass(value, this.builder, this.scope);
+      stmts.push(` if (${CodecBuilder.safeString(key)} in ${accessor}) {
+                ${innerGenerator.toWriteEmbed(`${accessor}${CodecBuilder.safePropAccessor(key)}`)}
+            }`);
+    });
+    stmts.push(`
+            {
+                ${this.builder.writer.int8(RefFlags.NullFlag)};
+            }
+        `);
+    return stmts.join("else");
+  }
+
+  toReadEmbed(accessor: (expr: string) => string, excludeHead = false): string {
+    const AnyGeneratorClass = CodegenRegistry.get(InternalSerializerType.ANY)!;
+    const anyGenerator = new AnyGeneratorClass(Type.any(), this.builder, this.scope);
+    return anyGenerator.toReadEmbed(accessor, excludeHead);
+  }
+
+  toSerializer() {
+    this.scope.assertNameNotDuplicate("read");
+    this.scope.assertNameNotDuplicate("readInner");
+    this.scope.assertNameNotDuplicate("write");
+    this.scope.assertNameNotDuplicate("writeInner");
+
+    const declare = `
+          const readInner = (fromRef) => {
+            throw new Error("Type oneof readInner can't call directly");
+          };
+          const read = () => {
+            ${this.toReadEmbed(expr => `return ${expr}`)}
+          };
+          const writeInner = (v) => {
+            throw new Error("Type oneof writeInner can't call directly");
+          };
+          const write = (v) => {
+            ${this.toWriteEmbed("v")}
+          };
+        `;
+    return `
+            return function (fury, external) {
+                ${this.scope.generate()}
+                ${declare}
+                return {
+                  read,
+                  readInner,
+                  write,
+                  writeInner,
+                  meta: ${JSON.stringify(this.builder.meta(this.description))}
+                };
+            }
+            `;
+  }
+}
+
+CodegenRegistry.register(InternalSerializerType.ONEOF, OneofSerializerGenerator);

--- a/javascript/packages/fury/lib/gen/serializer.ts
+++ b/javascript/packages/fury/lib/gen/serializer.ts
@@ -25,9 +25,9 @@ import { Scope } from "./scope";
 import { TypeDescription, ObjectTypeDescription } from "../description";
 
 export interface SerializerGenerator {
-  toSerializer(): string
-  toWriteEmbed(accessor: string, excludeHead?: boolean): string
-  toReadEmbed(accessor: (expr: string) => string, excludeHead?: boolean, refState?: RefState): string
+  toSerializer(): string;
+  toWriteEmbed(accessor: string, excludeHead?: boolean): string;
+  toReadEmbed(accessor: (expr: string) => string, excludeHead?: boolean, refState?: RefState): string;
 }
 
 export enum RefStateType {

--- a/javascript/packages/fury/lib/meta.ts
+++ b/javascript/packages/fury/lib/meta.ts
@@ -23,9 +23,9 @@ import { ObjectTypeDescription, TypeDescription } from "./description";
 import { InternalSerializerType } from "./type";
 
 export type Meta = {
-  fixedSize: number
-  needToWriteRef: boolean
-  type: InternalSerializerType
+  fixedSize: number;
+  needToWriteRef: boolean;
+  type: InternalSerializerType;
 };
 
 export const getMeta = (description: TypeDescription, fury: Fury): Meta => {

--- a/javascript/packages/fury/lib/meta.ts
+++ b/javascript/packages/fury/lib/meta.ts
@@ -138,6 +138,7 @@ export const getMeta = (description: TypeDescription, fury: Fury): Meta => {
         needToWriteRef: Boolean(fury.config.refTracking) && true,
         type,
       };
+    case InternalSerializerType.ONEOF:
     case InternalSerializerType.ANY:
       return {
         fixedSize: 11,

--- a/javascript/packages/fury/lib/platformBuffer.ts
+++ b/javascript/packages/fury/lib/platformBuffer.ts
@@ -20,11 +20,11 @@
 import { isNodeEnv } from "./util";
 
 export interface PlatformBuffer extends Uint8Array {
-  latin1Slice(start: number, end: number): string
-  utf8Slice(start: number, end: number): string
-  latin1Write(v: string, offset: number): void
-  utf8Write(v: string, offset: number): void
-  copy(target: Uint8Array, targetStart?: number, sourceStart?: number, sourceEnd?: number): void
+  latin1Slice(start: number, end: number): string;
+  utf8Slice(start: number, end: number): string;
+  latin1Write(v: string, offset: number): void;
+  utf8Write(v: string, offset: number): void;
+  copy(target: Uint8Array, targetStart?: number, sourceStart?: number, sourceEnd?: number): void;
 }
 
 export class BrowserBuffer extends Uint8Array implements PlatformBuffer {

--- a/javascript/packages/fury/lib/referenceResolver.ts
+++ b/javascript/packages/fury/lib/referenceResolver.ts
@@ -30,7 +30,7 @@ export const makeHead = (flag: RefFlags, type: InternalSerializerType) => {
 
 export const ReferenceResolver = (
   config: {
-    refTracking?: boolean
+    refTracking?: boolean;
   },
   binaryWriter: BinaryWriter,
   binaryReader: BinaryReader,

--- a/javascript/packages/fury/lib/type.ts
+++ b/javascript/packages/fury/lib/type.ts
@@ -54,6 +54,7 @@ export enum InternalSerializerType {
   FURY_PRIMITIVE_DOUBLE_ARRAY = 263,
   FURY_STRING_ARRAY = 264,
   ANY = -1,
+  ONEOF = -2,
 }
 
 export enum ConfigFlags {

--- a/javascript/packages/fury/lib/type.ts
+++ b/javascript/packages/fury/lib/type.ts
@@ -66,11 +66,11 @@ export enum ConfigFlags {
 
 // read, write
 export type Serializer<T = any, T2 = any> = {
-  read: () => T2
-  write: (v: T2) => T
-  readInner: (refValue?: boolean) => T2
-  writeInner: (v: T2) => T
-  meta: Meta
+  read: () => T2;
+  write: (v: T2) => T;
+  readInner: (refValue?: boolean) => T2;
+  writeInner: (v: T2) => T;
+  meta: Meta;
 };
 
 export enum RefFlags {
@@ -95,17 +95,17 @@ export const LATIN1 = 0;
 export const UTF8 = 1;
 
 export interface Hps {
-  isLatin1: (str: string) => boolean
-  stringCopy: (str: string, dist: Uint8Array, offset: number) => void
+  isLatin1: (str: string) => boolean;
+  stringCopy: (str: string, dist: Uint8Array, offset: number) => void;
 }
 
 export interface Config {
-  hps?: Hps
-  refTracking?: boolean
-  useSliceString?: boolean
+  hps?: Hps;
+  refTracking?: boolean;
+  useSliceString?: boolean;
   hooks?: {
-    afterCodeGenerated?: (code: string) => string
-  }
+    afterCodeGenerated?: (code: string) => string;
+  };
 }
 
 export enum Language {

--- a/javascript/packages/hps/index.ts
+++ b/javascript/packages/hps/index.ts
@@ -20,8 +20,8 @@
 const hps: Hps = require("bindings")("hps.node");
 
 interface Hps {
-  isLatin1: (str: string) => boolean
-  stringCopy: (str: string, dist: Uint8Array, offset: number) => void
+  isLatin1: (str: string) => boolean;
+  stringCopy: (str: string, dist: Uint8Array, offset: number) => void;
 }
 
 const { isLatin1, stringCopy } = hps;

--- a/javascript/test/any.test.ts
+++ b/javascript/test/any.test.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import Fury, { TypeDescription, InternalSerializerType } from '../packages/fury/index';
+import Fury, { TypeDescription, InternalSerializerType, Type } from '../packages/fury/index';
 import { describe, expect, test } from '@jest/globals';
 
 describe('bool', () => {
@@ -121,5 +121,13 @@ describe('bool', () => {
         const ret = fury.deserialize(bin);
         expect(ret instanceof Array).toBe(true)
         expect(ret).toEqual(obj)
+    });
+
+    test('should root any work', () => {
+        const fury = new Fury();
+        const { serialize, deserialize } = fury.registerSerializer(Type.any());
+        const bin = serialize("hello");
+        const result = deserialize(bin);
+        expect(result).toEqual("hello")
     });
 });

--- a/javascript/test/oneof.test.ts
+++ b/javascript/test/oneof.test.ts
@@ -67,6 +67,24 @@ describe('oneof', () => {
         );
         expect(result).toEqual(obj.option3)
     });
+    test('should nested oneof work1', () => {
+        const fury = new Fury({ refTracking: true });
+        const { serialize, deserialize } = fury.registerSerializer(Type.object("foo2", {
+            f: oneOfThree
+        }));
+        const obj = {
+            option1: "hello"
+        }
+        const input = serialize({
+            f: obj
+        });
+        const result = deserialize(
+            input
+        );
+        expect(result).toEqual({
+            f: obj.option1
+        })
+    });
 });
 
 

--- a/javascript/test/oneof.test.ts
+++ b/javascript/test/oneof.test.ts
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import Fury, { TypeDescription, InternalSerializerType, Type } from '../packages/fury/index';
+import { describe, expect, test } from '@jest/globals';
+
+const oneOfThree = Type.oneof({
+    option1: Type.string(),
+    option2: Type.object("foo", {
+        a: Type.int32()
+    }),
+    option3: Type.int32(),
+});
+
+describe('oneof', () => {
+    test('option1: should oneof work1', () => {
+        const fury = new Fury({ refTracking: true });
+        const { serialize, deserialize } = fury.registerSerializer(oneOfThree);
+        const obj = {
+            option1: "hello"
+        }
+        const input = serialize(obj);
+        const result = deserialize(
+            input
+        );
+        expect(result).toEqual(obj.option1)
+    });
+    test('option2: should oneof work', () => {
+        const fury = new Fury({ refTracking: true });
+        const { serialize, deserialize } = fury.registerSerializer(oneOfThree);
+        const obj = {
+            option2: {
+                a: 123
+            }
+        }
+        const input = serialize(obj);
+        const result = deserialize(
+            input
+        );
+        expect(result).toEqual(obj.option2)
+    });
+    test('option3: should oneof work', () => {
+        const fury = new Fury({ refTracking: true });
+        const { serialize, deserialize } = fury.registerSerializer(oneOfThree);
+        const obj = {
+            option3: 123
+        }
+        const input = serialize(obj);
+        const result = deserialize(
+            input
+        );
+        expect(result).toEqual(obj.option3)
+    });
+});
+
+


### PR DESCRIPTION
### 1. Fixed a performance bug that caused writeInt32 to slow down
Before:
```JavaScript
// reader/index.ts
function writeVarInt32() {
    buffer.byteLength
}
```
After:
```JavaScript
// reader/index.ts
const byteLength = buffer.byteLength;
function writeVarInt32() {
    byteLength
}
```
The byteLength property in a Buffer is slow to access. It appears that when we access byteLength, the V8 engine processes it using a hash lookup. so we store it in closure.

### 2.  Support Oneof
Sometimes, the data we want to serialize does not have a confirmed type; instead, it could be one of several confirmed types. If we use an object to handle this situation, the size of the resulting binary will be too large, as it will contain much unused information.

usage:
```JavaScript

      const oneOfThree = Type.oneof({
          option1: Type.string(),
          option2: Type.object("foo", {
              a: Type.int32()
          }),
          option3: Type.int32(),
      });
      const fury = new Fury({ refTracking: true });
      const { serialize, deserialize } = fury.registerSerializer(oneOfThree);
      const obj = {
          option1: "hello"
      }
      const input = serialize(obj);
      const result = deserialize(
          input
      );
      expect(result).toEqual(obj.option1)
```