### PR TITLE
chore(java): Remove redundant code

### DIFF
--- a/java/fury-core/src/main/java/org/apache/fury/config/FuryBuilder.java
+++ b/java/fury-core/src/main/java/org/apache/fury/config/FuryBuilder.java
@@ -51,9 +51,6 @@ public final class FuryBuilder {
         System.getProperty(
             "fury.enable_fury_security_mode_forcibly",
             System.getenv("ENABLE_CLASS_REGISTRATION_FORCIBLY"));
-    if (flagValue == null) {
-      flagValue = "false";
-    }
     ENABLE_CLASS_REGISTRATION_FORCIBLY = "true".equals(flagValue) || "1".equals(flagValue);
   }
 


### PR DESCRIPTION
Both `false` and `null` will determine `ENABLE_CLASS_REGISTRATION_FORCIBLY` as `false`, so there is no need to take this extra step.