### PR TITLE
chore(JavaScript): fix test ci on early Node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,8 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Upgrade npm
+        run: npm install -g npm@8
       - name: Run CI with NodeJS
         run: ./ci/run_ci.sh javascript
 

--- a/ci/run_ci.sh
+++ b/ci/run_ci.sh
@@ -201,8 +201,7 @@ case $1 in
       testcode=$?
       if [[ $testcode -ne 0 ]]; then
         echo "Executing fury javascript tests failed"
-        # TODO(bigtech) enable js ci
-        # exit $testcode
+        exit $testcode
       fi
       echo "Executing fury javascript tests succeeds"
     ;;

--- a/javascript/jest.config.js
+++ b/javascript/jest.config.js
@@ -19,7 +19,7 @@
 
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 const semver = require("semver");
-const hpsEnable = semver.gt(process.versions.node, '20.0.0')
+const hpsEnable = semver.gt(process.versions.node, '20.0.0') && process.platform !== 'win32';
 
 module.exports = {
   collectCoverage: hpsEnable,

--- a/javascript/packages/hps/package.json
+++ b/javascript/packages/hps/package.json
@@ -8,8 +8,9 @@
     "src",
     "binding.gyp"
   ],
+  "gypfile": false,
   "scripts": {
-    "postinstall": "npx node-gyp rebuild",
+    "postinstall": "node -e \"if (process.version.match(/v(\\d+)/)[1] >= 20 && process.platform !== 'win32') { require('child_process').execSync('npx node-gyp rebuild') } \"",
     "build": "npx node-gyp rebuild && tsc",
     "prepublishOnly": "npm run build"
   },


### PR DESCRIPTION
1. Npm 6 doesn't support workspace, upgrade it before run test
2. There are Some node-gyp compile problems on windows, ignore it temporary
#1350