### PR TITLE
chore(JavaScript): Fix using npm run build error

### DIFF
--- a/javascript/packages/hps/package.json
+++ b/javascript/packages/hps/package.json
@@ -11,7 +11,7 @@
   "gypfile": false,
   "scripts": {
     "postinstall": "node -e \"if (process.version.match(/v(\\d+)/)[1] >= 20 && process.platform !== 'win32') { require('child_process').execSync('npx node-gyp rebuild') } \"",
-    "build": "npx node-gyp rebuild && tsc",
+    "build": "node -e \"if (process.version.match(/v(\\d+)/)[1] >= 20 && process.platform !== 'win32') { require('child_process').execSync('npx node-gyp rebuild && tsc') } \"",
     "prepublishOnly": "npm run build"
   },
   "license": "Apache",


### PR DESCRIPTION
When using `npm run build` or `npm run test`, the hps module will still be compiled, resulting in an error.