### PR TITLE
ci(JavaScript): JavaScript ci is ported from run_ci.sh to run_ci.py

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,10 +107,11 @@ jobs:
 
   javascript:
     name: JavaScript CI
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         node-version: [14.x, 16.x, 18.x, 20.x]
+        os: [ubuntu-latest, macos-latest, windows-2022]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
@@ -119,8 +120,17 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Upgrade npm
         run: npm install -g npm@8
+      # node-gyp needs to use python and relies on the distutils module.
+      # The distutils module has been removed starting from python 3.12
+      # (see https://docs.python.org/3.10/library/distutils.html). Some
+      # OS (such as macos -latest) uses python3.12 by default, so python 3.8
+      # is used here to avoid this problem.
+      - name: Set up Python3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
       - name: Run CI with NodeJS
-        run: ./ci/run_ci.sh javascript
+        run: python ./ci/run_ci.py javascript
 
   rust:
     name: Rust CI

--- a/ci/run_ci.py
+++ b/ci/run_ci.py
@@ -29,6 +29,9 @@ BAZEL_VERSION = "6.3.2"
 
 PYARROW_VERSION = "14.0.0"
 
+PROJECT_ROOT_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../")
+
+
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
 )
@@ -71,6 +74,10 @@ def _get_bazel_download_url():
     )
 
 
+def _cd_project_subdir(subdir):
+    os.chdir(os.path.join(PROJECT_ROOT_DIR, subdir))
+
+
 def _run_cpp():
     _install_cpp_deps()
     # run test
@@ -84,8 +91,7 @@ def _run_rust():
     _exec_cmd("rustup component add clippy-preview")
     _exec_cmd("rustup component add rustfmt")
     logging.info("Executing fury rust tests")
-    cur_script_abs_path = os.path.split(os.path.realpath(__file__))[0]
-    os.chdir(os.path.join(cur_script_abs_path, "../rust"))
+    _cd_project_subdir("rust")
 
     cmds = (
         "cargo doc --no-deps --document-private-items --all-features --open",
@@ -100,6 +106,14 @@ def _run_rust():
     for cmd in cmds:
         _exec_cmd(cmd)
     logging.info("Executing fury rust tests succeeds")
+
+
+def _run_js():
+    logging.info("Executing fury javascript tests.")
+    _cd_project_subdir("javascript")
+    _exec_cmd("npm install")
+    _exec_cmd("npm run test")
+    logging.info("Executing fury javascript tests succeeds.")
 
 
 def _install_cpp_deps():
@@ -155,6 +169,14 @@ def _parse_args():
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     rust_parser.set_defaults(func=_run_rust)
+
+    js_parser = subparsers.add_parser(
+        "javascript",
+        description="Run Javascript CI",
+        help="Run Javascript CI",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    js_parser.set_defaults(func=_run_js)
 
     args = parser.parse_args()
     arg_dict = dict(vars(args))


### PR DESCRIPTION
1. JavaScript CI implemented using python.
2. Enable windows CI and macos CI for JavaScript.