### PR TITLE
fix(java): CodeGen: Name conflicts when omitting java.lang prefix #1363

### DIFF
--- a/java/fury-core/src/main/java/org/apache/fury/codegen/CodegenContext.java
+++ b/java/fury-core/src/main/java/org/apache/fury/codegen/CodegenContext.java
@@ -307,7 +307,7 @@ public class CodegenContext {
                     return Boolean.FALSE;
                   }
                 });
-        return conflictRes.booleanValue() ? clz.getName() : simpleName;
+        return conflictRes ? clz.getName() : simpleName;
       }
     }
     if (imports.contains(type)) {

--- a/java/fury-core/src/main/java/org/apache/fury/codegen/CodegenContext.java
+++ b/java/fury-core/src/main/java/org/apache/fury/codegen/CodegenContext.java
@@ -289,8 +289,9 @@ public class CodegenContext {
     if (type.startsWith("java.lang")) {
       if (!type.substring("java.lang.".length()).contains(".")) {
         String simpleName = clz.getSimpleName();
+        boolean hasPackage = StringUtils.isNotBlank(pkg);
         Map<String, Boolean> packageMap =
-            nameConflicts.computeIfAbsent(pkg, p -> new ConcurrentHashMap<>());
+            nameConflicts.computeIfAbsent(hasPackage ? pkg : "", p -> new ConcurrentHashMap<>());
         Boolean conflictRes =
             packageMap.computeIfAbsent(
                 simpleName,
@@ -300,7 +301,7 @@ public class CodegenContext {
                         clz.getClassLoader() == null
                             ? Thread.currentThread().getContextClassLoader()
                             : clz.getClassLoader();
-                    beanClassClassLoader.loadClass(pkg + "." + sn);
+                    beanClassClassLoader.loadClass(hasPackage ? pkg + "." + sn : sn);
                     return Boolean.TRUE;
                   } catch (ClassNotFoundException e) {
                     return Boolean.FALSE;

--- a/java/fury-core/src/main/java/org/apache/fury/codegen/CodegenContext.java
+++ b/java/fury-core/src/main/java/org/apache/fury/codegen/CodegenContext.java
@@ -36,6 +36,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import org.apache.fury.codegen.Expression.BaseInvoke;
 import org.apache.fury.codegen.Expression.Reference;
@@ -114,6 +115,8 @@ public class CodegenContext {
             "null"));
     JAVA_RESERVED_WORDS = ImmutableSet.copyOf(JAVA_RESERVED_WORDS);
   }
+
+  private static Map<String, Map<String, Boolean>> nameConflicts = new ConcurrentHashMap<>();
 
   Map<String, Long> newValNameIds = new HashMap<>();
   Set<String> valNames = new HashSet<>();
@@ -285,7 +288,25 @@ public class CodegenContext {
     String type = ReflectionUtils.getCanonicalName(clz);
     if (type.startsWith("java.lang")) {
       if (!type.substring("java.lang.".length()).contains(".")) {
-        return clz.getSimpleName();
+        String simpleName = clz.getSimpleName();
+        Map<String, Boolean> packageMap =
+            nameConflicts.computeIfAbsent(pkg, p -> new ConcurrentHashMap<>());
+        Boolean conflictRes =
+            packageMap.computeIfAbsent(
+                simpleName,
+                sn -> {
+                  try {
+                    ClassLoader beanClassClassLoader =
+                        clz.getClassLoader() == null
+                            ? Thread.currentThread().getContextClassLoader()
+                            : clz.getClassLoader();
+                    beanClassClassLoader.loadClass(pkg + "." + sn);
+                    return Boolean.TRUE;
+                  } catch (ClassNotFoundException e) {
+                    return Boolean.FALSE;
+                  }
+                });
+        return conflictRes.booleanValue() ? clz.getName() : simpleName;
       }
     }
     if (imports.contains(type)) {

--- a/java/fury-core/src/test/java/org/apache/fury/codegen/CodegenContextTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/codegen/CodegenContextTest.java
@@ -97,4 +97,21 @@ public class CodegenContextTest {
     Assert.assertTrue(code.contains("int value = \"abc\".length();"));
     Assert.assertTrue(code.contains("catch (Throwable e)"));
   }
+
+  // test case for #1363
+  @Test
+  public void testJavaLangNameConflict() {
+    CodegenContext ctx = new CodegenContext();
+
+    ctx.setPackage(CodegenContextTest.class.getPackage().getName());
+    // we expect the simple name here.
+    Assert.assertEquals(ctx.type(Object.class), Object.class.getSimpleName());
+
+    ctx.setPackage(
+        org.apache.fury.codegen.javalangnameconflict.Object.class.getPackage().getName());
+    // we expect the full name here.
+    Assert.assertEquals(ctx.type(Object.class), Object.class.getName());
+    // we expect the simple name here.
+    Assert.assertEquals(ctx.type(Integer.class), Integer.class.getSimpleName());
+  }
 }

--- a/java/fury-core/src/test/java/org/apache/fury/codegen/javalangnameconflict/Object.java
+++ b/java/fury-core/src/test/java/org/apache/fury/codegen/javalangnameconflict/Object.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fury.codegen.javalangnameconflict;
+
+/** this is just in place to trigger the name conflict for #1363 */
+public class Object {}


### PR DESCRIPTION
Hi. This is my initial approach to provide a PR for fixing #1363 

I'm not sure what you mean
> Maybe we should move it to CodeGenerator
as the CodeGenerator is not available in `CodegenContext`. So for the first approach I use the same way to determine the classloader as in the sample.

As we only have 'java.lang' classes here - wouldn't the classloader of java.lang.X  always be null?