### PR TITLE
fix(Rust): Fix memory errors caused by casting

### DIFF
--- a/rust/fury/src/deserializer.rs
+++ b/rust/fury/src/deserializer.rs
@@ -124,7 +124,7 @@ impl_num_deserialize_and_pritimive_vec!(f64, f64);
 impl Deserialize for String {
     fn read(deserializer: &mut DeserializerState) -> Result<Self, Error> {
         let len = deserializer.reader.var_int32();
-        Ok(deserializer.reader.string(len as u32))
+        Ok(deserializer.reader.string(len as usize))
     }
 }
 


### PR DESCRIPTION
In the stable version of Rust, the `from_raw_parts_mut` API does not check for memory alignment, but in the 1.78.0-nightly version, alignment checking has been added to the preconditions.  To ensure memory safety, we have replaced direct memory writes with the `LittleEndian::write_xx` methods from the appropriate library. While this may introduce additional overhead for memory checks, robustness is the priority before releasing the software.