### PR TITLE
fix(java): add potential missing bean class-loader

### DIFF
--- a/java/fury-core/src/main/java/org/apache/fury/codegen/CodegenContext.java
+++ b/java/fury-core/src/main/java/org/apache/fury/codegen/CodegenContext.java
@@ -38,6 +38,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
+
+import org.apache.fury.Fury;
 import org.apache.fury.codegen.Expression.BaseInvoke;
 import org.apache.fury.codegen.Expression.Reference;
 import org.apache.fury.collection.Collections;
@@ -299,6 +301,9 @@ public class CodegenContext {
                         c.getClassLoader() == null
                             ? Thread.currentThread().getContextClassLoader()
                             : c.getClassLoader();
+                    if (beanClassClassLoader == null) {
+                        beanClassClassLoader = Fury.class.getClassLoader();
+                    }
                     beanClassClassLoader.loadClass(hasPackage ? pkg + "." + sn : sn);
                     return Boolean.TRUE;
                   } catch (ClassNotFoundException e) {

--- a/java/fury-core/src/main/java/org/apache/fury/codegen/CodegenContext.java
+++ b/java/fury-core/src/main/java/org/apache/fury/codegen/CodegenContext.java
@@ -38,7 +38,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
-
 import org.apache.fury.Fury;
 import org.apache.fury.codegen.Expression.BaseInvoke;
 import org.apache.fury.codegen.Expression.Reference;
@@ -302,7 +301,7 @@ public class CodegenContext {
                             ? Thread.currentThread().getContextClassLoader()
                             : c.getClassLoader();
                     if (beanClassClassLoader == null) {
-                        beanClassClassLoader = Fury.class.getClassLoader();
+                      beanClassClassLoader = Fury.class.getClassLoader();
                     }
                     beanClassClassLoader.loadClass(hasPackage ? pkg + "." + sn : sn);
                     return Boolean.TRUE;


### PR DESCRIPTION
As found with previous context class-loaders add Fury class-loader as a fallback instance.