### PR TITLE
chore(Rust): remove fury-derive

### DIFF
--- a/docs/guide/xlang_object_graph_guide.md
+++ b/docs/guide/xlang_object_graph_guide.md
@@ -115,8 +115,7 @@ console.log(result);
 
 ```rust
 use chrono::{NaiveDate, NaiveDateTime};
-use fury::{from_buffer, to_buffer};
-use fury_derive::Fury;
+use fury::{from_buffer, to_buffer, Fury};
 use std::collections::HashMap;
 
 fn run() {
@@ -339,8 +338,7 @@ console.log(result);
 
 ```rust
 use chrono::{NaiveDate, NaiveDateTime};
-use fury::{from_buffer, to_buffer};
-use fury_derive::Fury;
+use fury::{from_buffer, to_buffer, Fury};
 use std::collections::HashMap;
 
 #[test]

--- a/docs/guide/xlang_object_graph_guide.md
+++ b/docs/guide/xlang_object_graph_guide.md
@@ -120,7 +120,7 @@ use std::collections::HashMap;
 
 fn run() {
     let bin: Vec<u8> = to_buffer(&"hello".to_string());
-    let obj: String = from_buffer(&bin2).expect("should success");
+    let obj: String = from_buffer(&bin).expect("should success");
     assert_eq!("hello".to_string(), obj);
 }
 ```

--- a/rust/fury/src/serializer.rs
+++ b/rust/fury/src/serializer.rs
@@ -23,7 +23,7 @@
 //! # Examples:
 //! ```
 //!
-//! use fury_derive::Fury;
+//! use fury::Fury;
 //! #[derive(Fury)]
 //! #[tag("example.foo2")]
 //! struct Animal {
@@ -31,7 +31,7 @@
 //! }
 //!
 //! ```
-//! fury_derive would expand the code and automatic implements the Serialize trait
+//! fury::Fury would expand the code and automatic implements the Serialize trait
 
 use super::buffer::Writer;
 use super::types::{config_flags, FuryMeta, Language, RefFlag, SIZE_OF_REF_AND_TYPE};

--- a/rust/tests/tests/test_complex_struct.rs
+++ b/rust/tests/tests/test_complex_struct.rs
@@ -16,8 +16,7 @@
 // under the License.
 
 use chrono::{NaiveDate, NaiveDateTime};
-use fury::{from_buffer, to_buffer};
-use fury_derive::Fury;
+use fury::{from_buffer, to_buffer, Fury};
 use std::collections::HashMap;
 
 #[test]


### PR DESCRIPTION
Remove `fury-derive` as `fury::Fury` is enough to do the job.  Closes #1384