### PR TITLE
fix(java): Allow partial read of serialized size from `InputStream`

### DIFF
--- a/java/fury-core/src/main/java/org/apache/fury/Fury.java
+++ b/java/fury-core/src/main/java/org/apache/fury/Fury.java
@@ -1174,22 +1174,28 @@ public final class Fury implements BaseFury {
     }
   }
 
-  private static void readToBufferFromStream(InputStream inputStream, MemoryBuffer buffer)
-      throws IOException {
+    private static void readToBufferFromStream(InputStream inputStream, MemoryBuffer buffer)
+        throws IOException {
     buffer.readerIndex(0);
-    int read = inputStream.read(buffer.getHeapMemory(), 0, 4);
+    int read = readBytes(inputStream, buffer.getHeapMemory(), 0, 4);
     Preconditions.checkArgument(read == 4);
     int size = buffer.readInt();
     buffer.ensure(4 + size);
-    read = 0;
+    read = readBytes(inputStream, buffer.getHeapMemory(), 4, size);
+    Preconditions.checkArgument(read == size);
+  }
+
+  private static int readBytes(InputStream inputStream, byte[] buffer, int offset, int size)
+      throws IOException {
+    int read = 0;
+    int count = 0;
     while (read < size) {
-      int count;
-      if ((count = inputStream.read(buffer.getHeapMemory(), read + 4, size - read)) == -1) {
+      if ((count = inputStream.read(buffer, offset + read, size - read)) == -1) {
         break;
       }
       read += count;
     }
-    Preconditions.checkArgument(read == size);
+    return (read == 0 && count == -1) ? -1 : read;
   }
 
   public void reset() {

--- a/java/fury-core/src/main/java/org/apache/fury/Fury.java
+++ b/java/fury-core/src/main/java/org/apache/fury/Fury.java
@@ -1174,8 +1174,8 @@ public final class Fury implements BaseFury {
     }
   }
 
-    private static void readToBufferFromStream(InputStream inputStream, MemoryBuffer buffer)
-        throws IOException {
+  private static void readToBufferFromStream(InputStream inputStream, MemoryBuffer buffer)
+      throws IOException {
     buffer.readerIndex(0);
     int read = readBytes(inputStream, buffer.getHeapMemory(), 0, 4);
     Preconditions.checkArgument(read == 4);


### PR DESCRIPTION
Deserialize from `InputStream` throws when the size cannot be read in one read. This fixes the issue by reading in a loop like it does for the serialized data.

Closes #1383 