### PR TITLE
fix(java): fix big buffer trunc

### DIFF
--- a/java/fury-core/src/test/java/org/apache/fury/FuryTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/FuryTest.java
@@ -68,6 +68,7 @@ import org.apache.fury.test.bean.Struct;
 import org.apache.fury.type.Descriptor;
 import org.apache.fury.util.DateTimeUtils;
 import org.apache.fury.util.Platform;
+import org.apache.fury.util.ReflectionUtils;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -621,5 +622,29 @@ public class FuryTest extends FuryTestBase {
     HashBasedTable<Object, Object, Object> table = HashBasedTable.create(2, 4);
     table.put("r", "c", 100);
     serDeCheckSerializer(fury, table, "Codec");
+  }
+
+  @Test
+  public void testBufferReset() {
+    Fury fury = Fury.builder().withRefTracking(true).requireClassRegistration(false).build();
+    fury.serialize(new byte[1000 * 1000]);
+    checkBuffer(fury);
+    fury.serializeJavaObject(new byte[1000 * 1000]);
+    checkBuffer(fury);
+    fury.serializeJavaObjectAndClass(new byte[1000 * 1000]);
+    checkBuffer(fury);
+    fury.serialize(new ByteArrayOutputStream(), new byte[1000 * 1000]);
+    checkBuffer(fury);
+    fury.serializeJavaObject(new ByteArrayOutputStream(), new byte[1000 * 1000]);
+    checkBuffer(fury);
+    fury.serializeJavaObjectAndClass(new ByteArrayOutputStream(), new byte[1000 * 1000]);
+    checkBuffer(fury);
+  }
+
+  private void checkBuffer(Fury fury) {
+    Object buf = ReflectionUtils.getObjectFieldValue(fury, "buffer");
+    MemoryBuffer buffer = (MemoryBuffer) buf;
+    assert buffer != null;
+    assertTrue(buffer.size() < 1000 * 1000);
   }
 }

--- a/java/fury-core/src/test/java/org/apache/fury/FuryTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/FuryTest.java
@@ -627,18 +627,34 @@ public class FuryTest extends FuryTestBase {
   @Test
   public void testBufferReset() {
     Fury fury = Fury.builder().withRefTracking(true).requireClassRegistration(false).build();
-    fury.serialize(new byte[1000 * 1000]);
+    byte[] bytes = fury.serialize(new byte[1000 * 1000]);
     checkBuffer(fury);
-    fury.serializeJavaObject(new byte[1000 * 1000]);
+    assertEquals(fury.deserialize(bytes), new byte[1000 * 1000]);
+    bytes = fury.serializeJavaObject(new byte[1000 * 1000]);
     checkBuffer(fury);
-    fury.serializeJavaObjectAndClass(new byte[1000 * 1000]);
+    assertEquals(fury.deserializeJavaObject(bytes, byte[].class), new byte[1000 * 1000]);
+
+    bytes = fury.serializeJavaObjectAndClass(new byte[1000 * 1000]);
     checkBuffer(fury);
-    fury.serialize(new ByteArrayOutputStream(), new byte[1000 * 1000]);
+    assertEquals(fury.deserializeJavaObjectAndClass(bytes), new byte[1000 * 1000]);
+
+    ByteArrayOutputStream bas = new ByteArrayOutputStream();
+    fury.serialize(bas, new byte[1000 * 1000]);
     checkBuffer(fury);
-    fury.serializeJavaObject(new ByteArrayOutputStream(), new byte[1000 * 1000]);
+    Object o = fury.deserialize(new ByteArrayInputStream(bas.toByteArray()));
+    assertEquals(o, new byte[1000 * 1000]);
+
+    bas.reset();
+    fury.serializeJavaObject(bas, new byte[1000 * 1000]);
     checkBuffer(fury);
-    fury.serializeJavaObjectAndClass(new ByteArrayOutputStream(), new byte[1000 * 1000]);
+    o = fury.deserializeJavaObject(new ByteArrayInputStream(bas.toByteArray()), byte[].class);
+    assertEquals(o, new byte[1000 * 1000]);
+
+    bas.reset();
+    fury.serializeJavaObjectAndClass(bas, new byte[1000 * 1000]);
     checkBuffer(fury);
+    o = fury.deserializeJavaObjectAndClass(new ByteArrayInputStream(bas.toByteArray()));
+    assertEquals(o, new byte[1000 * 1000]);
   }
 
   private void checkBuffer(Fury fury) {


### PR DESCRIPTION
fix big buffer trunc introduced in #1397, which reset buffer before copying data from it