### PR TITLE
feat(spec): standardizing fury cross-language serialization specification

### DIFF
--- a/docs/guide/xlang_type_mapping.md
+++ b/docs/guide/xlang_type_mapping.md
@@ -1,0 +1,7 @@
+---
+title: Type Mapping of Xlang Serialization
+sidebar_position: 3
+id: xlang_type_mapping
+---
+
+Coming soon.

--- a/docs/protocols/README.md
+++ b/docs/protocols/README.md
@@ -1,4 +1,4 @@
 # Serialization Protocols
+- For Cross Language Object Graph Protocol, see [xlang_object_graph_format_spec](./xlang_object_graph_spec.md) doc.
 - For Java Object Graph Protocol, see [java_object_graph_format_spec](java_object_graph_spec.md) doc.
-- For Cross Language Object Graph Protocol, see [xlang_object_graph_format_spec](./xlang_object_graph.md) doc.
 - For Row Format Protocol, see [row format_spec](./row_format.md) doc.

--- a/docs/protocols/java_object_graph_spec.md
+++ b/docs/protocols/java_object_graph_spec.md
@@ -211,7 +211,7 @@ Same encoding algorithm as the previous layer except:
 
 ## Meta String
 
-Meta string is mainly used to encode meta strings such class name and field names.
+Meta string is mainly used to encode meta strings such as class name and field names.
 
 ### Encoding Algorithms
 

--- a/docs/protocols/xlang_object_graph.md
+++ b/docs/protocols/xlang_object_graph.md
@@ -1,2 +1,0 @@
-# Cross language object graph serialization
-Coming soon

--- a/docs/protocols/xlang_object_graph_spec.md
+++ b/docs/protocols/xlang_object_graph_spec.md
@@ -471,7 +471,7 @@ Primitive array are taken as a binary buffer, serialization will just write the 
 then copy the whole buffer into the stream.
 
 Such serialization won't compress the array. If users want to compress primitive array, users need to register custom
-serializers for such types.
+serializers for such types or mark it as list type.
 
 #### object array
 
@@ -488,7 +488,7 @@ Format:
 | length(unsigned varint) | key value chunk data | ... | key value chunk data |
 ```
 
-#### map key-value data
+#### map key-value chunk data
 
 Map iteration is too expensive, Fury won't compute the header like for list since it introduce
 [considerable overhead](https://github.com/apache/incubator-fury/issues/925).

--- a/docs/protocols/xlang_object_graph_spec.md
+++ b/docs/protocols/xlang_object_graph_spec.md
@@ -24,6 +24,8 @@ also introduce more complexities compared to static serialization frameworks. So
 - float: A 32-bit floating point number.
 - double: A 64-bit floating point number including NaN and Infinity.
 - string: A text string encoded using Latin1/UTF16/UTF-8 encoding.
+- enum: a data type consisting of a set of named values. Rust enum with non-predefined field values are not supported as
+  an enum
 - list: A sequence of objects.
 - set: An unordered set of unique elements.
 - map: A map of key-value pairs.
@@ -50,7 +52,7 @@ also introduce more complexities compared to static serialization frameworks. So
 
 ### Type ambiguities
 
-Due to differences between type systems of languages, those types can't mapped one-to-one between languages. When
+Due to differences between type systems of languages, those types can't be mapped one-to-one between languages. When
 deserializing, Fury use the target data structure type and the data type in the data jointly to determine how to
 deserialize and populate the target data structure. For example:
 

--- a/docs/protocols/xlang_object_graph_spec.md
+++ b/docs/protocols/xlang_object_graph_spec.md
@@ -345,9 +345,14 @@ for data.
 #### int16
 
 - size: 2 byte
-- byte order: little endian order
+- byte order: raw bytes of little endian order
 
 #### unsigned int32
+
+- size: 4 byte
+- byte order: raw bytes of little endian order
+
+#### unsigned varint32
 
 - size: 1~5 byte
 - Format: The most significant bit (MSB) in every byte indicates whether to have the next byte. If first bit is set
@@ -356,11 +361,21 @@ for data.
 
 #### signed int32
 
+- size: 4 byte
+- byte order: raw bytes of little endian order
+
+#### signed varint32
+
 - size: 1~5 byte
 - Format: First convert the number into positive unsigned int by `(v << 1) ^ (v >> 31)` ZigZag algorithm, then encode
   it as an unsigned varint.
 
 #### unsigned int64
+
+- size: 8 byte
+- byte order: raw bytes of little endian order
+
+#### unsigned varint64
 
 - size: 1~9 byte
 - Fury SLI(Small long as int) Encoding:
@@ -371,6 +386,11 @@ for data.
       i.e. `b & 0x80 == 0x80`, then the next byte should be read until the first bit is unset.
 
 #### signed int64
+
+- size: 8 byte
+- byte order: raw bytes of little endian order
+
+#### signed varint64
 
 - size: 1~9 byte
 - Fury SLI(Small long as int) Encoding:

--- a/docs/protocols/xlang_object_graph_spec.md
+++ b/docs/protocols/xlang_object_graph_spec.md
@@ -511,6 +511,17 @@ Field will be ordered as following, every group of fields will have its own orde
 
 #### schema consistent
 
+Object will be written as:
+
+```
+|    4 byte     |  variable bytes  |
++---------------+------------------+
+|   type hash   |   field values   |
+```
+
+Type hash is used to check the type schema consistency across languages. Type hash will be the first 32 bits of 56 bits
+value of the type meta.
+
 Object fields will be serialized one by one using following format:
 
 ```

--- a/docs/protocols/xlang_object_graph_spec.md
+++ b/docs/protocols/xlang_object_graph_spec.md
@@ -197,7 +197,7 @@ If schema evolution mode is enabled globally or enabled for current type, type m
       ```
     - If type meta has been written before, the data will be written as:
       ```
-      | unsigned varint: written index << 1 | type def |
+      | unsigned varint: written index << 1 |
       ```
 - If meta share mode is enabled:
     - If type meta hasn't been written before, add `type def` to `MetaContext`, then get

--- a/docs/protocols/xlang_object_graph_spec.md
+++ b/docs/protocols/xlang_object_graph_spec.md
@@ -15,26 +15,26 @@ also introduce more complexities compared to static serialization frameworks. So
 
 ### Data Types
 
-- bool: A boolean value (true or false).
-- int8: An 8-bit signed integer.
-- int16: A 16-bit signed integer.
-- int32: A 32-bit signed integer.
-- int64: A 64-bit signed integer.
-- float16: A 16-bit floating point number.
-- float32: A 32-bit floating point number.
-- float64: A 64-bit floating point number including NaN and Infinity.
-- string: A text string encoded using Latin1/UTF16/UTF-8 encoding.
-- enum: A data type consisting of a set of named values. Rust enum with non-predefined field values are not supported as
+- bool: a boolean value (true or false).
+- int8: a 8-bit signed integer.
+- int16: a 16-bit signed integer.
+- int32: a 32-bit signed integer.
+- int64: a 64-bit signed integer.
+- float16: a 16-bit floating point number.
+- float32: a 32-bit floating point number.
+- float64: a 64-bit floating point number including NaN and Infinity.
+- string: a text string encoded using Latin1/UTF16/UTF-8 encoding.
+- enum: a data type consisting of a set of named values. Rust enum with non-predefined field values are not supported as
   an enum.
-- list: A sequence of objects.
-- set: An unordered set of unique elements.
-- map: A map of key-value pairs.
+- list: a sequence of objects.
+- set: an unordered set of unique elements.
+- map: a map of key-value pairs.
 - time types:
-    - Duration: an absolute length of time, independent of any calendar/timezone, as a count of nanoseconds.
-    - Timestamp: a point in time, independent of any calendar/timezone, as a count of nanoseconds. The count is relative
+    - duration: an absolute length of time, independent of any calendar/timezone, as a count of nanoseconds.
+    - timestamp: a point in time, independent of any calendar/timezone, as a count of nanoseconds. The count is relative
       to an epoch at UTC midnight on January 1, 1970.
 - decimal: exact decimal value represented as an integer value in two's complement.
-- binary: An variable-length array of bytes.
+- binary: an variable-length array of bytes.
 - array type: only allow numeric component. Other arrays will be taken as List. The implementation should support the
   interoperability between array and list.
     - array: multidimensional array which every sub-array can have different size but all have same type.

--- a/docs/protocols/xlang_object_graph_spec.md
+++ b/docs/protocols/xlang_object_graph_spec.md
@@ -19,7 +19,12 @@ also introduce more complexities compared to static serialization frameworks. So
 - int8: a 8-bit signed integer.
 - int16: a 16-bit signed integer.
 - int32: a 32-bit signed integer.
+- var_int32: a 32-bit signed integer which use fury var_int32 encoding.
+- fixed_int32: a 32-bit signed integer which use two's complement encoding.
 - int64: a 64-bit signed integer.
+- var_int64: a 64-bit signed integer which use fury PVL encoding.
+- sli_int64: a 64-bit signed integer which use fury SLI encoding.
+- fixed_int64: a 64-bit signed integer which use two's complement encoding.
 - float16: a 16-bit floating point number.
 - float32: a 32-bit floating point number.
 - float64: a 64-bit floating point number including NaN and Infinity.
@@ -49,6 +54,10 @@ also introduce more complexities compared to static serialization frameworks. So
 - sparse tensor: a multidimensional array whose elements are almost all zeros.
 - arrow record batch: an arrow [record batch](https://arrow.apache.org/docs/cpp/tables.html#record-batches) object.
 - arrow table: an arrow [table](https://arrow.apache.org/docs/cpp/tables.html#tables) object.
+
+Note:
+
+- Unsigned int/long are not added here, since not every language support those types.
 
 ### Type disambiguation
 

--- a/docs/protocols/xlang_object_graph_spec.md
+++ b/docs/protocols/xlang_object_graph_spec.md
@@ -208,9 +208,10 @@ using one of the following mode. Which mode to use is configured when creating f
         - Firstly, set current to `meta start offset` of fury header
         - Then write `captured_type_defs` one by one:
           ```python
-          buffer.write_var_uint32(len(writting_type_defs))
+          buffer.write_var_uint32(len(writting_type_defs) - len(schema_consistent_type_def_stubs))
           for type_meta in writting_type_defs:
-              type_meta.write_type_def(buffer)
+              if not type_meta.is_stub():
+                  type_meta.write_type_def(buffer)
           writing_type_defs = copy(schema_consistent_type_def_stubs)
           ```
 - Meta share mode: the writing steps are same as the normal mode, but `captured_type_defs` will be shared across

--- a/docs/protocols/xlang_object_graph_spec.md
+++ b/docs/protocols/xlang_object_graph_spec.md
@@ -57,13 +57,16 @@ When reference tracking is disabled globally or for specific types, or for certa
 context(e.g., a field of a type), only the `NULL` and `NOT_NULL VALUE` flags will be used for reference meta.
 
 For languages which doesn't support reference such as rust, reference tracking must be disabled for correct
-deserialization
-by fury rust implementation.
+deserialization by fury rust implementation.
 
-In languages which doesn't support GC, Fury use `optional` to indicate nullability:
+For languages whose object values are not null by default:
 
 - In rust, Fury takes `Option:None` as a null value
 - In c++, Fury takes `std::nullopt` as a null value
+- In golang, Fury takes `null interface/pointer` as a null value
+
+If one want to deserialize in languages like `Java/Python/JavaScript`, he should mark the type with all fields
+not-null by default, or using schema-evolution mode to carry the not-null fields info in the data.
 
 ## Type Meta
 
@@ -292,11 +295,6 @@ If string has been written before, the data will be written as follows:
 - format: write as pure byte.
 
 #### Short
-
-- size: 2 byte
-- byte order: little endian order
-
-#### Char
 
 - size: 2 byte
 - byte order: little endian order

--- a/docs/protocols/xlang_object_graph_spec.md
+++ b/docs/protocols/xlang_object_graph_spec.md
@@ -1,5 +1,8 @@
 # Cross language object graph serialization
 
+> Format Version History:
+> - Version 0.1 - serialization spec formalized
+
 Fury xlang serialization is an automatic object serialization framework that supports reference and polymorphism.
 Fury will convert an object from/to fury xlang serialization binary format.
 Fury has two core concepts for xlang serialization:
@@ -135,6 +138,7 @@ Fury header consists starts one byte:
 +--------------+---------------+-------+-------+--------+-------+------------------------------------+
 | magic number | reserved bits |  oob  | xlang | endian | null  | unsigned int for meta start offset |
 ```
+
 - magic number: used to identify fury serialization protocol, current version use `0x62d4`.
 - null flag: 1 when object is null, 0 otherwise. If an object is null, other bits won't be set.
 - endian flag: 1 when data is encoded by little endian, 0 for big endian.

--- a/docs/protocols/xlang_object_graph_spec.md
+++ b/docs/protocols/xlang_object_graph_spec.md
@@ -1,7 +1,5 @@
 # Cross language object graph serialization
 
-## Spec overview
-
 Fury xlang serialization is an automatic object serialization framework that supports reference and polymorphism.
 Fury will convert an object from/to fury xlang serialization binary format.
 Fury has two core concepts for xlang serialization:
@@ -12,6 +10,11 @@ Fury has two core concepts for xlang serialization:
 The serialization format is a dynamic binary format. The dynamics and reference/polymorphism support make Fury flexible,
 much more easy to use, but
 also introduce more complexities compared to static serialization frameworks. So the format will be more complex.
+
+## Type Systems
+
+
+## Spec overview
 
 Here is the overall format:
 
@@ -332,12 +335,14 @@ If string has been written before, the data will be written as follows:
 #### Float
 
 - size: 4 byte
-- format: convert float to 4 bytes int by `Float.floatToRawIntBits`, then write as binary by little endian order.
+- format: encode the specified floating-point value according to the IEEE 754 floating-point "single format" bit layout,
+  preserving Not-a-Number (NaN) values, then write as binary by little endian order.
 
 #### Double
 
 - size: 8 byte
-- format: convert double to 8 bytes int by `Double.doubleToRawLongBits`, then write as binary by little endian order.
+- format: encode the specified floating-point value according to the IEEE 754 floating-point "double format" bit layout,
+  preserving Not-a-Number (NaN) values. then write as binary by little endian order.
 
 ### String
 
@@ -367,14 +372,8 @@ Which encoding to choose:
 Format:
 
 ```
-length(unsigned varint) | collection header | elements header | elements data
+length(unsigned varint) | elements header | elements data
 ```
-
-#### Collection header
-
-- For `ArrayList/LinkedArrayList/HashSet/LinkedHashSet`, this will be empty.
-- For `TreeSet`, this will be `Comparator`
-- For subclass of `ArrayList`, this may be extra object field info.
 
 #### Elements header
 
@@ -419,14 +418,8 @@ generic type.
 Format:
 
 ```
-| length(unsigned varint) | map header | key value pairs data |
+| length(unsigned varint) | key value chunk data | ... | key value chunk data |
 ```
-
-#### Map header
-
-- For `HashMap/LinkedHashMap`, this will be empty.
-- For `TreeMap`, this will be `Comparator`
-- For other `Map`, this may be extra object field info.
 
 #### Map Key-Value data
 

--- a/docs/protocols/xlang_object_graph_spec.md
+++ b/docs/protocols/xlang_object_graph_spec.md
@@ -16,35 +16,35 @@ also introduce more complexities compared to static serialization frameworks. So
 ### Data Types
 
 - bool: A boolean value (true or false).
-- byte: An 8-bit signed integer.
-- i16: A 16-bit signed integer.
-- i32: A 32-bit signed integer.
-- i64: A 64-bit signed integer.
-- half-float: A 16-bit floating point number.
-- float: A 32-bit floating point number.
-- double: A 64-bit floating point number including NaN and Infinity.
+- int8: An 8-bit signed integer.
+- int16: A 16-bit signed integer.
+- int32: A 32-bit signed integer.
+- int64: A 64-bit signed integer.
+- float16: A 16-bit floating point number.
+- float32: A 32-bit floating point number.
+- float64: A 64-bit floating point number including NaN and Infinity.
 - string: A text string encoded using Latin1/UTF16/UTF-8 encoding.
-- enum: a data type consisting of a set of named values. Rust enum with non-predefined field values are not supported as
-  an enum
+- enum: A data type consisting of a set of named values. Rust enum with non-predefined field values are not supported as
+  an enum.
 - list: A sequence of objects.
 - set: An unordered set of unique elements.
 - map: A map of key-value pairs.
 - time types:
-    - Duration: an absolute length of time independent of any calendar/timezone, as a count of seconds and
-      fractions of seconds at nanosecond resolution.
-    - Timestamp: a point in time independent of any calendar/timezone, as a count of seconds and fractions of
-      seconds at nanosecond resolution. The count is relative to an epoch at UTC midnight on January 1, 1970.
+    - Duration: an absolute length of time, independent of any calendar/timezone, as a count of nanoseconds.
+    - Timestamp: a point in time, independent of any calendar/timezone, as a count of nanoseconds. The count is relative
+      to an epoch at UTC midnight on January 1, 1970.
 - decimal: exact decimal value represented as an integer value in two's complement.
-- binary: binary data.
+- binary: An variable-length array of bytes.
 - array type: only allow numeric component. Other arrays will be taken as List. The implementation should support the
   interoperability between array and list.
-    - array: multiple dimension array which every subarray can have have different size.
+    - array: multidimensional array which every sub-array can have different size but all have same type.
+    - bool_array: one dimension int16 array.
     - int16_array: one dimension int16 array.
     - int32_array: one dimension int32 array.
     - int64_array: one dimension int64 array.
-    - half_float_array: one dimension half_float_16 array.
-    - float_array: one dimension float32 array.
-    - double_array: one dimension float64 array.
+    - float16_array: one dimension half_float_16 array.
+    - float32_array: one dimension float32 array.
+    - float64_array: one dimension float64 array.
 - tensor: a multidimensional dense array of fixed-size values such as a NumPy ndarray.
 - sparse tensor: a multidimensional array whose elements are almost all zeros.
 - arrow record batch: an arrow [record batch](https://arrow.apache.org/docs/cpp/tables.html#record-batches) object.

--- a/docs/protocols/xlang_object_graph_spec.md
+++ b/docs/protocols/xlang_object_graph_spec.md
@@ -131,11 +131,11 @@ Fury will write the byte order for that object into the data instead of converti
 Fury header consists starts one byte:
 
 ```
-|     4 bits    | 1 bit | 1 bit | 1 bit  | 1 bit |          optional 4 bytes          |
-+---------------+-------+-------+--------+-------+------------------------------------+
-| reserved bits |  oob  | xlang | endian | null  | unsigned int for meta start offset |
+|    2 bytes   |     4 bits    | 1 bit | 1 bit | 1 bit  | 1 bit |          optional 4 bytes          |
++--------------+---------------+-------+-------+--------+-------+------------------------------------+
+| magic number | reserved bits |  oob  | xlang | endian | null  | unsigned int for meta start offset |
 ```
-
+- magic number: used to identify fury serialization protocol, current version use `0x62d4`.
 - null flag: 1 when object is null, 0 otherwise. If an object is null, other bits won't be set.
 - endian flag: 1 when data is encoded by little endian, 0 for big endian.
 - xlang flag: 1 when serialization uses xlang format, 0 when serialization uses Fury java format.

--- a/docs/protocols/xlang_object_graph_spec.md
+++ b/docs/protocols/xlang_object_graph_spec.md
@@ -187,18 +187,18 @@ differently.
 
 ### Schema consistent
 
-- If schema consistent mode is enabled globally, type meta will be written as a fury unsigned varint of `type_id`.
-  Schema evolution related meta will be ignored.
-- If schema evolution mode is enabled globally and current class is configured to use schema consistent mode like struct
-  vs table in flatbuffers:
+- If schema consistent mode is enabled globally when creating fury, type meta will be written as a fury unsigned varint
+  of `type_id`. Schema evolution related meta will be ignored.
+- If schema evolution mode is enabled globally when creating fury, and current class is configured to use schema
+  consistent mode like `struct` vs `table` in flatbuffers:
     - Type meta will be add to `captured_type_defs`: `captured_type_defs[type def stub] = map size` ahead when
       registering type.
     - Get index of the meta in `captured_type_defs`, write that index as `| unsigned varint: index |`.
 
 ### Schema evolution
 
-If schema evolution mode is enabled globally and enabled for current type, type meta will be written using one of the
-following mode. Which mode to use is configured when creating fury.
+If schema evolution mode is enabled globally when creating fury, and enabled for current type, type meta will be written
+using one of the following mode. Which mode to use is configured when creating fury.
 
 - Normal mode(meta share not enabled):
     - If type meta hasn't been written before, add `type def`

--- a/docs/protocols/xlang_object_graph_spec.md
+++ b/docs/protocols/xlang_object_graph_spec.md
@@ -74,6 +74,29 @@ class Foo2 {
 type. When deserializing, the implementation will create an `Object` array for `objects`, but create a `ArrayList`
 for `objectList` to populate it's elements. And the serialized data of `Foo` can be deserialized into `Foo2` too.
 
+Users can also provide meta hint for fields of a type, or the type whole. Here is an example in java which use
+annotation to provide such information.
+
+```java
+
+@TypeInfo(fieldsNullable = false, trackingRef = false, polymorphic = false)
+class Foo {
+  @FieldInfo(trackingRef = false)
+  int[] intArray;
+  @FieldInfo(polymorphic = true)
+  Object object;
+  @FieldInfo(tagId = 1, nullable = true)
+  List<Object> objectList;
+}
+```
+
+Such information can be provided in other languages too:
+
+- cpp: use macro and template.
+- golang: use struct tag.
+- python: use typehint.
+- rust: use macro.
+
 ### Type ID
 
 All internal data types are expressed using a ID in range `-64~-1`. Users can use `0~32703` for representing their

--- a/docs/protocols/xlang_object_graph_spec.md
+++ b/docs/protocols/xlang_object_graph_spec.md
@@ -206,7 +206,7 @@ Meta header is a 64 bits number value encoded in little endian order.
       Fury will use fields info of those fields which aren't annotated by tag id for deserializing schema consistent
       fields, then use fields info in meta for deserializing compatible fields.
 - Field info:
-    - header(8 bits):
+    - Header(8 bits):
         - Format:
             - `reserved 1 bit + 3 bits field name encoding + polymorphism flag + nullability flag + ref tracking flag + tag id flag`.
         - Users can use annotation to provide those info.
@@ -216,7 +216,7 @@ Meta header is a 64 bits number value encoded in little endian order.
             - polymorphism: when set to 1, the actual type of field will be the declared field type even the type if
               not `final`.
             - 3 bits field name encoding will be set to meta string encoding flags when tag id is not set.
-    - type id:
+    - Type id:
         - For registered type-consistent classes, it will be the registered type id.
         - Otherwise it will be encoded as `OBJECT_ID` if it isn't `final` and `FINAL_OBJECT_ID` if it's `final`. The
           meta

--- a/docs/protocols/xlang_object_graph_spec.md
+++ b/docs/protocols/xlang_object_graph_spec.md
@@ -33,7 +33,7 @@ also introduce more complexities compared to static serialization frameworks. So
   an enum.
 - list: a sequence of objects.
 - set: an unordered set of unique elements.
-- map: a map of key-value pairs.
+- map: a map of key-value pairs. Mutable types such as `list/map/set/array/tensor/arrow` are not allowed as key of map.
 - time types:
     - duration: an absolute length of time, independent of any calendar/timezone, as a count of nanoseconds.
     - timestamp: a point in time, independent of any calendar/timezone, as a count of nanoseconds. The count is relative

--- a/docs/protocols/xlang_object_graph_spec.md
+++ b/docs/protocols/xlang_object_graph_spec.md
@@ -477,6 +477,40 @@ the actual element is the declared type in the custom type field.
 
 Based on the elements header, the serialization of elements data may skip `ref flag`/`null flag`/`element type info`.
 
+```python
+fury = ...
+buffer = ...
+elems = ...
+if element_type_is_same:
+    if not is_declared_type:
+        fury.write_type(buffer, elem_type)
+    elem_serializer = get_serializer(...)
+    if track_ref:
+        for elem in elems:
+            if not ref_resolver.write_ref_or_null(buffer, elem):
+                elem_serializer.write(buffer, elem)
+    elif has_null:
+        for elem in elems:
+            if elem is None:
+                buffer.write_byte(null_flag)
+            else:
+                buffer.write_byte(not_null_flag)
+                elem_serializer.write(buffer, elem)
+    else:
+        for elem in elems:
+            elem_serializer.write(buffer, elem)
+else:
+    if track_ref:
+        for elem in elems:
+            fury.write_ref(buffer, elem)
+    elif has_null:
+        for elem in elems:
+            fury.write_nullable(buffer, elem)
+    else:
+        for elem in elems:
+            fury.write_value(buffer, elem)
+```
+
 [`CollectionSerializer#writeElements`](https://github.com/apache/incubator-fury/blob/20a1a78b17a75a123a6f5b7094c06ff77defc0fe/java/fury-core/src/main/java/org/apache/fury/serializer/collection/AbstractCollectionSerializer.java#L302)
 can be taken as an example.
 

--- a/docs/protocols/xlang_object_graph_spec.md
+++ b/docs/protocols/xlang_object_graph_spec.md
@@ -340,6 +340,9 @@ for data.
 #### unsigned int64
 
 - size: 1~9 byte
+- Fury SLI(Small long as int) Encoding:
+    - If long is in `[0, 2147483647]`, encode as 4 bytes int: `| little-endian: ((int) value) << 1 |`
+    - Otherwise write as 9 bytes: `| 0b1 | little-endian 8 bytes long |`
 - Fury PVL(Progressive Variable-length Long) Encoding:
     - positive long format: first bit in every byte indicates whether to have the next byte. If first bit is set
       i.e. `b & 0x80 == 0x80`, then the next byte should be read until the first bit is unset.
@@ -348,10 +351,10 @@ for data.
 
 - size: 1~9 byte
 - Fury SLI(Small long as int) Encoding:
-    - If long is in [-1073741824, 1073741823], encode as 4 bytes int: `| little-endian: ((int) value) << 1 |`
+    - If long is in `[-1073741824, 1073741823]`, encode as 4 bytes int: `| little-endian: ((int) value) << 1 |`
     - Otherwise write as 9 bytes: `| 0b1 | little-endian 8 bytes long |`
 - Fury PVL(Progressive Variable-length Long) Encoding:
-    - First convert the number into positive unsigned long by ` (v << 1) ^ (v >> 63)` ZigZag algorithm to reduce cost of
+    - First convert the number into positive unsigned long by `(v << 1) ^ (v >> 63)` ZigZag algorithm to reduce cost of
       small negative numbers, then encoding it as an unsigned long.
 
 #### float32

--- a/docs/protocols/xlang_object_graph_spec.md
+++ b/docs/protocols/xlang_object_graph_spec.md
@@ -187,22 +187,23 @@ differently.
 
 ### Schema consistent
 
-If schema consistent mode is enabled globally or enabled for current type, type meta will be written as a fury unsigned
-varint of `type_id`.
+- If schema consistent mode is enabled globally, type meta will be written as a fury unsigned varint of `type_id`.
+  Schema evolution related meta will be ignored.
+- If schema evolution mode is enabled globally and current class is configured to use schema consistent mode like struct
+  vs table in flatbuffers:
+    - Type meta will be add to `captured_type_defs`: `captured_type_defs[type def stub] = map size` ahead when
+      registering type.
+    - Get index of the meta in `captured_type_defs`, write that index as `| unsigned varint: index |`.
 
 ### Schema evolution
 
-If schema evolution mode is enabled globally or enabled for current type, type meta will be written using on of the
+If schema evolution mode is enabled globally and enabled for current type, type meta will be written using one of the
 following mode. Which mode to use is configured when creating fury.
 
 - Normal mode(meta share not enabled):
     - If type meta hasn't been written before, add `type def`
-      to `captured_type_defs`: `captured_type_defs[type def] = map size`
-    - Get index of the meta in `captured_type_defs`, write that index as an unsigned varint.
-    - The meta will be written as:
-      ```
-      | unsigned varint: written index |
-      ```
+      to `captured_type_defs`: `captured_type_defs[type def] = map size`.
+    - Get index of the meta in `captured_type_defs`, write that index as `| unsigned varint: index |`.
     - After finished the serialization of the object graph, fury will start to write `captured_type_defs`:
         - Firstly, set current to `meta start offset` of fury header
         - Then write `captured_type_defs` one by one:
@@ -210,7 +211,7 @@ following mode. Which mode to use is configured when creating fury.
           buffer.write_var_uint32(len(writting_type_defs))
           for type_meta in writting_type_defs:
               type_meta.write_type_def(buffer)
-          writting_type_defs.clear()
+          writing_type_defs = schema_consistent_type_def_stubs
           ```
 - Meta share mode: the writing steps are same as the normal mode, but `captured_type_defs` will be shared across
   multiple serializations of different objects. For example, suppose we have a batch to serialize:

--- a/docs/protocols/xlang_object_graph_spec.md
+++ b/docs/protocols/xlang_object_graph_spec.md
@@ -442,10 +442,10 @@ for data.
 Format:
 
 ```
-| header: size << 2 | 2 bits encoding flags | binary data |
+| unsigned varint64: size << 2 `bitor` 2 bits encoding flags | binary data |
 ```
 
-- `size + encoding` will be concat as a long and encoded as an unsigned var long. The little 2 bits is used for
+- `size + encoding` will be concat as a long and encoded as an unsigned varint64. The little 2 bits is used for
   encoding:
   0 for `latin1(ISO-8859-1)`, 1 for `utf-16`, 2 for `utf-8`.
 - encoded string binary data based on encoding: `latin/utf-16/utf-8`.
@@ -463,7 +463,7 @@ Which encoding to choose:
 Format:
 
 ```
-length(unsigned varint) | elements header | elements data
+| unsigned varint64: length << 4 `bitor` 4 bits elements header | elements data |
 ```
 
 #### elements header

--- a/docs/protocols/xlang_object_graph_spec.md
+++ b/docs/protocols/xlang_object_graph_spec.md
@@ -241,7 +241,7 @@ Meta header is a 64 bits number value encoded in little endian order.
           meta
           for such types is written separately instead of inlining here is to reduce meta space cost if object of this
           type is serialized in current object graph multiple times, and the field value may be null too.
-    - Collection Type Info: collection type will have an extra byte for elements info.
+    - List Type Info: collection type will have an extra byte for elements info.
       Users can use annotation to provide those info.
         - elements type same
         - elements tracking ref
@@ -419,9 +419,7 @@ Which encoding to choose:
 - If the string is encoded by `utf-8`, then fury will use `utf-8` to decode the data. But currently fury doesn't enable
   utf-8 encoding by default for java. Cross-language string serialization of fury uses `utf-8` by default.
 
-### Collection
-
-> All collection serializers must extend `AbstractCollectionSerializer`.
+### List
 
 Format:
 
@@ -431,15 +429,15 @@ length(unsigned varint) | elements header | elements data
 
 #### Elements header
 
-In most cases, all collection elements are same type and not null, elements header will encode those homogeneous
+In most cases, all elements are same type and not null, elements header will encode those homogeneous
 information to avoid the cost of writing it for every element. Specifically, there are four kinds of information
 which will be encoded by elements header, each use one bit:
 
 - If track elements ref, use the first bit `0b1` of the header to flag it.
-- If the collection has null, use the second bit `0b10` of the header to flag it. If ref tracking is enabled for this
+- If the elements has null, use the second bit `0b10` of the header to flag it. If ref tracking is enabled for this
   element type, this flag is invalid.
-- If the collection element types are not declared type, use the 3rd bit `0b100` of the header to flag it.
-- If the collection element types are different, use the 4rd bit `0b1000` header to flag it.
+- If the element types are not declared type, use the 3rd bit `0b100` of the header to flag it.
+- If the element types are different, use the 4rd bit `0b1000` header to flag it.
 
 By default, all bits are unset, which means all elements won't track ref, all elements are same type, not null and
 the actual element is the declared type in the custom type field.
@@ -462,7 +460,7 @@ serializers for such types.
 
 #### Object array
 
-Object array is serialized using the collection format. Object component type will be taken as collection element
+Object array is serialized using the list format. Object component type will be taken as list element
 generic type.
 
 ### Map
@@ -477,7 +475,7 @@ Format:
 
 #### Map Key-Value data
 
-Map iteration is too expensive, Fury won't compute the header like for collection before since it introduce
+Map iteration is too expensive, Fury won't compute the header like for list since it introduce
 [considerable overhead](https://github.com/apache/incubator-fury/issues/925).
 Users can use `MapFieldInfo` annotation to provide header in advance. Otherwise Fury will use first key-value pair to
 predict header optimistically, and update the chunk header if the prediction failed at some pair.

--- a/docs/protocols/xlang_object_graph_spec.md
+++ b/docs/protocols/xlang_object_graph_spec.md
@@ -76,8 +76,8 @@ for `objectList` to populate it's elements. And the serialized data of `Foo` can
 
 ### Type ID
 
-All internal data types are expressed using unsigned ID `-64~-1`. Users can use `0~32703` for representing their types.
-At runtime, all type ids are added by `64`, represented and encoded as an unsigned int.
+All internal data types are expressed using a ID in range `-64~-1`. Users can use `0~32703` for representing their
+types. At runtime, all type ids are added by `64`, and then encoded as an unsigned varint.
 
 ### Type mapping
 

--- a/docs/protocols/xlang_object_graph_spec.md
+++ b/docs/protocols/xlang_object_graph_spec.md
@@ -211,7 +211,7 @@ using one of the following mode. Which mode to use is configured when creating f
           buffer.write_var_uint32(len(writting_type_defs))
           for type_meta in writting_type_defs:
               type_meta.write_type_def(buffer)
-          writing_type_defs = schema_consistent_type_def_stubs
+          writing_type_defs = copy(schema_consistent_type_def_stubs)
           ```
 - Meta share mode: the writing steps are same as the normal mode, but `captured_type_defs` will be shared across
   multiple serializations of different objects. For example, suppose we have a batch to serialize:

--- a/docs/protocols/xlang_object_graph_spec.md
+++ b/docs/protocols/xlang_object_graph_spec.md
@@ -207,8 +207,8 @@ Meta header is a 64 bits number value encoded in little endian order.
       fields, then use fields info in meta for deserializing compatible fields.
 - Field info:
     - header(8 bits):
-        -
-        Format: `reserved 1 bit + 3 bits field name encoding + polymorphism flag + nullability flag + ref tracking flag + tag id flag`.
+        - Format:
+            - `reserved 1 bit + 3 bits field name encoding + polymorphism flag + nullability flag + ref tracking flag + tag id flag`.
         - Users can use annotation to provide those info.
             - tag id: when set to 1, field name will be written by an unsigned varint tag id.
             - ref tracking: when set to 0, ref tracking will be disabled for this field.

--- a/docs/protocols/xlang_object_graph_spec.md
+++ b/docs/protocols/xlang_object_graph_spec.md
@@ -192,7 +192,8 @@ varint of `type_id`.
 
 ### Schema evolution
 
-If schema evolution mode is enabled globally or enabled for current type, type meta will be written as follows:
+If schema evolution mode is enabled globally or enabled for current type, type meta will be written using on of the
+following mode. Which mode to use is configured when creating fury.
 
 - Normal mode(meta share not enabled):
     - If type meta hasn't been written before, add `type def`
@@ -208,7 +209,8 @@ If schema evolution mode is enabled globally or enabled for current type, type m
           ```python
           buffer.write_var_uint32(len(writting_type_defs))
           for type_meta in writting_type_defs:
-          type_meta.write_type_def(buffer)
+              type_meta.write_type_def(buffer)
+          writting_type_defs.clear()
           ```
 - Meta share mode: the writing steps are same as the normal mode, but `captured_type_defs` will be shared across
   multiple serializations of different objects. For example, suppose we have a batch to serialize:

--- a/docs/protocols/xlang_object_graph_spec.md
+++ b/docs/protocols/xlang_object_graph_spec.md
@@ -359,10 +359,6 @@ Which encoding to choose:
 - If the string is encoded by `utf-8`, then fury will use `utf-8` to decode the data. But currently fury doesn't enable
   utf-8 encoding by default for java. Cross-language string serialization of fury uses `utf-8` by default.
 
-### Enum
-
-Enum will be serialized as an unsigned varint of the ordinal.
-
 ### List
 
 Format:

--- a/docs/protocols/xlang_object_graph_spec.md
+++ b/docs/protocols/xlang_object_graph_spec.md
@@ -617,9 +617,9 @@ class Foo2 {
 When process A received serialized `Foo2` from process B, here is how it deserialize the data:
 
 ```c++
-Foo1 &foo1 = xxx;
-std::vector<fury::FieldInfo> &field_infos = type_meta.field_infos;
-for (auto &field_info : field_infos) {
+Foo1 foo1 = ...;
+const std::vector<fury::FieldInfo> &field_infos = type_meta.field_infos;
+for (const auto &field_info : field_infos) {
   switch (field_info.field_id) {
     case 0:
       foo1.v1 = buffer.read_varint32();

--- a/docs/protocols/xlang_object_graph_spec.md
+++ b/docs/protocols/xlang_object_graph_spec.md
@@ -35,16 +35,16 @@ also introduce more complexities compared to static serialization frameworks. So
       to an epoch at UTC midnight on January 1, 1970.
 - decimal: exact decimal value represented as an integer value in two's complement.
 - binary: an variable-length array of bytes.
-- array type: only allow numeric component. Other arrays will be taken as List. The implementation should support the
+- array type: only allow numeric components. Other arrays will be taken as List. The implementation should support the
   interoperability between array and list.
-    - array: multidimensional array which every sub-array can have different size but all have same type.
-    - bool_array: one dimension int16 array.
-    - int16_array: one dimension int16 array.
-    - int32_array: one dimension int32 array.
-    - int64_array: one dimension int64 array.
-    - float16_array: one dimension half_float_16 array.
-    - float32_array: one dimension float32 array.
-    - float64_array: one dimension float64 array.
+    - array: multidimensional array which every sub-array can have different sizes but all have same type.
+    - bool_array: one dimensional int16 array.
+    - int16_array: one dimensional int16 array.
+    - int32_array: one dimensional int32 array.
+    - int64_array: one dimensional int64 array.
+    - float16_array: one dimensional half_float_16 array.
+    - float32_array: one dimensional float32 array.
+    - float64_array: one dimensional float64 array.
 - tensor: a multidimensional dense array of fixed-size values such as a NumPy ndarray.
 - sparse tensor: a multidimensional array whose elements are almost all zeros.
 - arrow record batch: an arrow [record batch](https://arrow.apache.org/docs/cpp/tables.html#record-batches) object.
@@ -70,11 +70,11 @@ class Foo2 {
 }
 ```
 
-`intArray` has `int32_array` type. But both `objects` and `objectList` field in the serialize data have `list` data
+`intArray` has an `int32_array` type. But both `objects` and `objectList` fields in the serialize data have `list` data
 type. When deserializing, the implementation will create an `Object` array for `objects`, but create a `ArrayList`
-for `objectList` to populate it's elements. And the serialized data of `Foo` can be deserialized into `Foo2` too.
+for `objectList` to populate its elements. And the serialized data of `Foo` can be deserialized into `Foo2` too.
 
-Users can also provide meta hint for fields of a type, or the type whole. Here is an example in java which use
+Users can also provide meta hints for fields of a type, or the type whole. Here is an example in java which use
 annotation to provide such information.
 
 ```java
@@ -99,7 +99,7 @@ Such information can be provided in other languages too:
 
 ### Type ID
 
-All internal data types are expressed using a ID in range `-64~-1`. Users can use `0~32703` for representing their
+All internal data types are expressed using an ID in range `-64~-1`. Users can use `0~32703` for representing their
 types. At runtime, all type ids are added by `64`, and then encoded as an unsigned varint.
 
 ### Type mapping
@@ -214,8 +214,8 @@ Meta header is a 64 bits number value encoded in little endian order.
   read more bytes for length using Fury unsigned int encoding. If current type doesn't has parent type, or parent
   type doesn't have fields to serialize, or we're in a context which serialize fields of current type
   only, num classes will be 1.
-- 5rd bit is used to indicate whether this type needs schema evolution.
-- Other 56 bits is used to store the unique hash of `flags + all layers type meta`.
+- The 5th bit is used to indicate whether this type needs schema evolution.
+- Other 56 bits are used to store the unique hash of `flags + all layers type meta`.
 - Inheritance: Fury
     - For languages
 
@@ -228,9 +228,9 @@ Meta header is a 64 bits number value encoded in little endian order.
 ```
 
 - num fields: encode `num fields` as unsigned varint.
-    - If current type is schema consistent, then num_fields will be `0` to flag it.
-    - If current type isn't schema consistent, then num_fields will be the number of compatible fields. For example,
-      users can use tag id to mark some field as compatible field in schema consistent context. In such cases, schema
+    - If the current type is schema consistent, then num_fields will be `0` to flag it.
+    - If the current type isn't schema consistent, then num_fields will be the number of compatible fields. For example,
+      users can use tag id to mark some fields as compatible fields in schema consistent context. In such cases, schema
       consistent fields will be serialized first, then compatible fields will be serialized next. At deserialization,
       Fury will use fields info of those fields which aren't annotated by tag id for deserializing schema consistent
       fields, then use fields info in meta for deserializing compatible fields.
@@ -238,8 +238,8 @@ Meta header is a 64 bits number value encoded in little endian order.
     - Header(8 bits):
         - Format:
             - `reserved 1 bit + 3 bits field name encoding + polymorphism flag + nullability flag + ref tracking flag + tag id flag`.
-        - Users can use annotation to provide those info.
-            - tag id: when set to 1, field name will be written by an unsigned varint tag id.
+        - Users can use annotation to provide that info.
+            - tag id: when set to 1, the field name will be written by an unsigned varint tag id.
             - ref tracking: when set to 0, ref tracking will be disabled for this field.
             - nullability: when set to 0, this field won't be null.
             - polymorphism: when set to 1, the actual type of field will be the declared field type even the type if
@@ -248,17 +248,16 @@ Meta header is a 64 bits number value encoded in little endian order.
     - Type id:
         - For registered type-consistent classes, it will be the registered type id.
         - Otherwise it will be encoded as `OBJECT_ID` if it isn't `final` and `FINAL_OBJECT_ID` if it's `final`. The
-          meta
-          for such types is written separately instead of inlining here is to reduce meta space cost if object of this
-          type is serialized in current object graph multiple times, and the field value may be null too.
+          meta for such types is written separately instead of inlining here is to reduce meta space cost if object of
+          this type is serialized in the current object graph multiple times, and the field value may be null too.
     - List Type Info: this type will have an extra byte for elements info.
-      Users can use annotation to provide those info.
+      Users can use annotation to provide that info.
         - elements type same
         - elements tracking ref
         - elements nullability
         - elements declared type
     - Map Type Info: this type will have an extra byte for kv items info.
-      Users can use annotation to provide those info.
+      Users can use annotation to provide that info.
         - keys type same
         - keys tracking ref
         - keys nullability
@@ -335,8 +334,8 @@ for data.
 #### Signed int
 
 - size: 1~5 byte
-- Format: First convert the number into positive unsigned int by `(v << 1) ^ (v >> 31)` ZigZag algorithm, then encoding
-  it as an unsigned int.
+- Format: First convert the number into positive unsigned int by `(v << 1) ^ (v >> 31)` ZigZag algorithm, then encode
+  it as an unsigned varint.
 
 #### Unsigned long
 
@@ -403,9 +402,9 @@ information to avoid the cost of writing it for every element. Specifically, the
 which will be encoded by elements header, each use one bit:
 
 - If track elements ref, use the first bit `0b1` of the header to flag it.
-- If the elements has null, use the second bit `0b10` of the header to flag it. If ref tracking is enabled for this
+- If the elements have null, use the second bit `0b10` of the header to flag it. If ref tracking is enabled for this
   element type, this flag is invalid.
-- If the element types are not declared type, use the 3rd bit `0b100` of the header to flag it.
+- If the element types are not the declared type, use the 3rd bit `0b100` of the header to flag it.
 - If the element types are different, use the 4rd bit `0b1000` header to flag it.
 
 By default, all bits are unset, which means all elements won't track ref, all elements are same type, not null and
@@ -446,10 +445,10 @@ Format:
 
 Map iteration is too expensive, Fury won't compute the header like for list since it introduce
 [considerable overhead](https://github.com/apache/incubator-fury/issues/925).
-Users can use `MapFieldInfo` annotation to provide header in advance. Otherwise Fury will use first key-value pair to
-predict header optimistically, and update the chunk header if the prediction failed at some pair.
+Users can use `MapFieldInfo` annotation to provide the header in advance. Otherwise Fury will use first key-value pair
+to predict header optimistically, and update the chunk header if the prediction failed at some pair.
 
-Fury will serialize map chunk by chunk, every chunk has 127 pairs at most.
+Fury will serialize the map chunk by chunk, every chunk has 127 pairs at most.
 
 ```
 |    1 byte      |     1 byte     | variable bytes  |
@@ -463,11 +462,11 @@ KV header:
 - If the key has null, use the second bit `0b10` of the header to flag it. If ref tracking is enabled for this
   key type, this flag is invalid.
 - If the key types of map are different, use the 3rd bit `0b100` of the header to flag it.
-- If the actual key type of map is not the declared key type, use the 4rd bit `0b1000` of the header to flag it.
+- If the actual key type of the map is not the declared key type, use the 4rd bit `0b1000` of the header to flag it.
 - If track value ref, use the 5th bit `0b10000` of the header to flag it.
 - If the value has null, use the 6th bit `0b100000` of the header to flag it. If ref tracking is enabled for this
   value type, this flag is invalid.
-- If the value types of map are different, use the 7rd bit `0b1000000` header to flag it.
+- If the value types of the map are different, use the 7rd bit `0b1000000` header to flag it.
 - If the value type of map is not the declared value type, use the 8rd bit `0b10000000` of the header to flag it.
 
 If streaming write is enabled, which means Fury can't update written `chunk size`. In such cases, map key-value data
@@ -480,7 +479,7 @@ format will be:
 ```
 
 `KV header` will be a header marked by `MapFieldInfo` in java. For languages such as golang, this can be computed in
-advance for non-interface types in most times.
+advance for non-interface types most times.
 
 ### Enum
 
@@ -571,20 +570,20 @@ Type will be serialized using type meta format.
 ### Fast deserialization for static languages without runtime codegen support
 
 For type evolution, the serializer will encode the type meta into the serialized data. The deserializer will compare
-this meta with class meta in current process, and use the diff to determine how to deserialize the data.
+this meta with class meta in the current process, and use the diff to determine how to deserialize the data.
 
 For java/javascript/python, we can use the diff to generate serializer code at runtime and load it as class/function for
 deserialization. In this way, the type evolution will be as fast as type consist mode.
 
 For C++/Rust, we can't generate the serializer code at runtime. So we need to generate the code at compile-time using
-meta programing. But at that time, we don't know the type schema in other processes, so we can't generate the serializer
-code for such inconsistent types. We may need to generate the code which has a loop and compare field name one by one to
-decide whether deserialize and assign the field or skip the field value.
+meta programming. But at that time, we don't know the type schema in other processes, so we can't generate the
+serializer code for such inconsistent types. We may need to generate the code which has a loop and compare field name
+one by one to decide whether to deserialize and assign the field or skip the field value.
 
 One fast way is that we can optimize the string comparison into `jump` instructions:
 
-- Assume current type has `n` fields, peer type has `n1` fields.
-- Generate an auto growing `field id` from `0` for every sorted field in current type at the compile time.
+- Assume the current type has `n` fields, and the peer type has `n1` fields.
+- Generate an auto growing `field id` from `0` for every sorted field in the current type at the compile time.
 - Compare the received type meta with current type, generate same id if the field name is same, otherwise generate an
   auto growing id starting from `n`, cache this meta at runtime.
 - Iterate the fields of received type meta, use a `switch` to compare the `field id` to deserialize data

--- a/docs/protocols/xlang_object_graph_spec.md
+++ b/docs/protocols/xlang_object_graph_spec.md
@@ -460,7 +460,8 @@ the actual element is the declared type in the custom type field.
 
 Based on the elements header, the serialization of elements data may skip `ref flag`/`null flag`/`element type info`.
 
-`CollectionSerializer#write/read` can be taken as an example.
+[`CollectionSerializer#writeElements`](https://github.com/apache/incubator-fury/blob/20a1a78b17a75a123a6f5b7094c06ff77defc0fe/java/fury-core/src/main/java/org/apache/fury/serializer/collection/AbstractCollectionSerializer.java#L302)
+can be taken as an example.
 
 ### array
 

--- a/docs/protocols/xlang_object_graph_spec.md
+++ b/docs/protocols/xlang_object_graph_spec.md
@@ -50,7 +50,7 @@ also introduce more complexities compared to static serialization frameworks. So
 - arrow record batch: an arrow [record batch](https://arrow.apache.org/docs/cpp/tables.html#record-batches) object.
 - arrow table: an arrow [table](https://arrow.apache.org/docs/cpp/tables.html#tables) object.
 
-### Type ambiguities
+### Type disambiguation
 
 Due to differences between type systems of languages, those types can't be mapped one-to-one between languages. When
 deserializing, Fury use the target data structure type and the data type in the data jointly to determine how to
@@ -59,14 +59,19 @@ deserialize and populate the target data structure. For example:
 ```java
 class Foo {
   int[] intArray;
-  Object[] objectArray;
+  Object[] objects;
+  List<Object> objectList;
+}
+class Foo2 {
+  int[] intArray;
+  List<Object> objects;
   List<Object> objectList;
 }
 ```
 
-`intArray` has `int32_array` type. But both `objectArray` and `objectList` field in the serialize data have `list` data
-type. When deserializing, the implementation will create an `Object` array for `objectArray`, but create a `ArrayList`
-for `objectList` to populate it's elements.
+`intArray` has `int32_array` type. But both `objects` and `objectList` field in the serialize data have `list` data
+type. When deserializing, the implementation will create an `Object` array for `objects`, but create a `ArrayList`
+for `objectList` to populate it's elements. And the serialized data of `Foo` can be deserialized into `Foo2` too.
 
 ### Type ID
 

--- a/docs/protocols/xlang_object_graph_spec.md
+++ b/docs/protocols/xlang_object_graph_spec.md
@@ -422,7 +422,7 @@ Format:
 
 - `size + encoding` will be concat as a long and encoded as an unsigned var long. The little 2 bits is used for
   encoding:
-  0 for `latin`, 1 for `utf-16`, 2 for `utf-8`.
+  0 for `latin1(ISO-8859-1)`, 1 for `utf-16`, 2 for `utf-8`.
 - encoded string binary data based on encoding: `latin/utf-16/utf-8`.
 
 Which encoding to choose:
@@ -430,8 +430,8 @@ Which encoding to choose:
 - For JDK8: fury detect `latin` at runtime, if string is `latin` string, then use `latin` encoding, otherwise
   use `utf-16`.
 - For JDK9+: fury use `coder` in `String` object for encoding, `latin`/`utf-16` will be used for encoding.
-- If the string is encoded by `utf-8`, then fury will use `utf-8` to decode the data. But currently fury doesn't enable
-  utf-8 encoding by default for java. Cross-language string serialization of fury uses `utf-8` by default.
+- If the string is encoded by `utf-8`, then fury will use `utf-8` to decode the data. Cross-language string
+  serialization of fury uses `utf-8` by default.
 
 ### list
 

--- a/docs/protocols/xlang_object_graph_spec.md
+++ b/docs/protocols/xlang_object_graph_spec.md
@@ -598,7 +598,7 @@ with version 2 defined as `Foo2`:
 class Foo1 {
   int32_t v1; // id 0
   std::string v2; // id 1
-}
+};
 // class Foo with version 2
 class Foo2 {
   // id 0, but will have id 2 in process A
@@ -611,7 +611,7 @@ class Foo2 {
   std::string v2;
   // id 4, but will have id 4 in process A
   std::vector<std::string> list;
-}
+};
 ```
 
 When process A received serialized `Foo2` from process B, here is how it deserialize the data:


### PR DESCRIPTION
## What does this PR do?

This PR standardizes fury cross-language serialization specification. It comes with following changes:
- Remove type tag from the protocol since it introduce space and performance overhead to the implementation. The `type tag` version can be seen in https://github.com/apache/incubator-fury/blob/6ea2e0b83d5449d63ca62296ff0dfd67b96c5bc5/docs/protocols/xlang_object_graph_spec.md .
- Fury preserves `0~63` for internal types, but let users register type by id from `0`(added by 64 automatically） to setup type mapping between languages. 
- Streamline the type systems, only `bool/byte/i16/i32/i64/half-float/float/double/string/enum/list/set/map/Duration/Timestamp/decimal/binary/array/tensor/sparse/tensor/arrow/record/batch/arrow/table` are allowed.
- Formulized the binary format for above types.
- Add type disambiguation: the deserialization are determined by data type in serialized binary and target type jointly.
- Introduce meta string encoding algorithm for field name to reduce space cost by 3/8.
- Introduce schema consist mode format for struct.
- Introduce schema envolution mode for struct: 
  - this mode can embeed meta in the data or share across multiple messages,
  - it can avoid the cost of type tag comparison in frameworks like protobuf

This protocol also supports object inheriance for xlang serializaiton. This is a feature request that users has been discussed for a long time in protobuf/flatbuffer:
- https://github.com/google/flatbuffers/issues/4006
- https://github.com/protocolbuffers/protobuf/issues/5645

Although there are some languages such as `rust/golang` doesn't support inheriance, there are many cases only langauges like `java/c#/python/javascript` are involved, and the support for inheriance is not complexed in the protocol level, so we added the inheriance support in the protocol. And in languages such as `rust/golang`, we can use some annotation to mark composition field as parent class for serialization layout, or we can disable inheriance foor such languages at the protocol level.
 
The protocol support polymorphic natively by type id, so I don't include types such as `OneOf/Union`. With this protocol, you can even serialize multiple rust `dyn trait` object which implement same trait., and get exactly the same objects when deserialization.

## Related issue
This PR Closes #1418 
