### PR TITLE
feat(java): carry read objects when deserialization fail for better trouble shooting

### DIFF
--- a/java/fury-core/src/main/java/org/apache/fury/collection/ObjectArray.java
+++ b/java/fury-core/src/main/java/org/apache/fury/collection/ObjectArray.java
@@ -109,4 +109,12 @@ public final class ObjectArray {
       }
     }
   }
+
+  @Override
+  public String toString() {
+    if (size == 0) {
+      return "[]";
+    }
+    return Arrays.asList(objects).subList(0, size).toString();
+  }
 }

--- a/java/fury-core/src/main/java/org/apache/fury/exception/DeserializationException.java
+++ b/java/fury-core/src/main/java/org/apache/fury/exception/DeserializationException.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fury.exception;
+
+import java.util.List;
+
+public class DeserializationException extends FuryException {
+
+  private List<Object> readObjects;
+
+  public DeserializationException(String message) {
+    super(message);
+  }
+
+  public DeserializationException(Throwable cause) {
+    super(cause);
+  }
+
+  public DeserializationException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  // if `readObjects` too big, generate message lazily to avoid big string creation cost.
+  public DeserializationException(List<Object> readObjects, Throwable cause) {
+    super(cause);
+    this.readObjects = readObjects;
+  }
+
+  @Override
+  public String getMessage() {
+    if (readObjects == null) {
+      return super.getMessage();
+    } else {
+      return "Deserialize failed, read objects are: " + readObjects;
+    }
+  }
+}

--- a/java/fury-core/src/main/java/org/apache/fury/resolver/MapRefResolver.java
+++ b/java/fury-core/src/main/java/org/apache/fury/resolver/MapRefResolver.java
@@ -211,6 +211,10 @@ public final class MapRefResolver implements RefResolver {
     }
   }
 
+  public ObjectArray getReadObjects() {
+    return readObjects;
+  }
+
   @Override
   public void reset() {
     resetWrite();

--- a/java/fury-core/src/test/java/org/apache/fury/FuryTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/FuryTest.java
@@ -56,6 +56,7 @@ import org.apache.fury.annotation.Ignore;
 import org.apache.fury.builder.Generated;
 import org.apache.fury.config.FuryBuilder;
 import org.apache.fury.config.Language;
+import org.apache.fury.exception.FuryException;
 import org.apache.fury.exception.InsecureException;
 import org.apache.fury.memory.MemoryBuffer;
 import org.apache.fury.memory.MemoryUtils;
@@ -662,5 +663,31 @@ public class FuryTest extends FuryTestBase {
     MemoryBuffer buffer = (MemoryBuffer) buf;
     assert buffer != null;
     assertTrue(buffer.size() < 1000 * 1000);
+  }
+
+  @Data
+  static class PrintReadObject {
+    public PrintReadObject() {
+      throw new RuntimeException();
+    }
+
+    public PrintReadObject(boolean b) {}
+  }
+
+  @Test
+  public void testPrintReadObjectsWhenFailed() {
+    Fury fury =
+        Fury.builder()
+            .withRefTracking(true)
+            .withCodegen(false)
+            .requireClassRegistration(false)
+            .build();
+    PrintReadObject o = new PrintReadObject(true);
+    try {
+      serDe(fury, ImmutableList.of(ImmutableList.of("a", "b"), o));
+      Assert.fail();
+    } catch (FuryException e) {
+      Assert.assertTrue(e.getMessage().contains("[a, b]"));
+    }
   }
 }


### PR DESCRIPTION
This PR carry read objects when deserialization fail for better trouble shooting.

Closes #1419 