### PR TITLE
fix: use blazingly instead of blazing

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -19,7 +19,7 @@
 
 github:
   description: >-
-    A blazing fast multi-language serialization framework powered by JIT and zero-copy.
+    A blazingly fast multi-language serialization framework powered by JIT and zero-copy.
   homepage: https://fury.apache.org/
   labels:
     - javascript

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Maven Version](https://img.shields.io/maven-central/v/org.furyio/fury-core?style=for-the-badge)](https://search.maven.org/#search|gav|1|g:"org.furyio"%20AND%20a:"fury-core")
 
 
-**Apache Fury (incubating)** is a blazing-fast multi-language serialization framework powered by **JIT** (just-in-time compilation) and **zero-copy**, providing up to 170x performance and ultimate ease of use.
+**Apache Fury (incubating)** is a blazingly-fast multi-language serialization framework powered by **JIT** (just-in-time compilation) and **zero-copy**, providing up to 170x performance and ultimate ease of use.
 
 https://fury.apache.org
 

--- a/go/README.md
+++ b/go/README.md
@@ -1,6 +1,6 @@
 # Apache Fury™ Go
 
-Fury is a blazing fast multi-language serialization framework powered by just-in-time compilation and zero-copy.
+Fury is a blazingly fast multi-language serialization framework powered by just-in-time compilation and zero-copy.
 
 Currently, Fury Go is implemented using reflection. In the future, we plan to implement a static code generator
 to generate serializer code ahead to speed up serialization, or implement a JIT framework which generate ASM

--- a/java/fury-core/pom.xml
+++ b/java/fury-core/pom.xml
@@ -32,7 +32,7 @@
   <artifactId>fury-core</artifactId>
 
   <description>
-    Apache Fury™ is a blazing fast multi-language serialization framework powered by jit and zero-copy.
+    Apache Fury™ is a blazingly fast multi-language serialization framework powered by jit and zero-copy.
 
     Apache Fury (incubating) is an effort undergoing incubation at the Apache
     Software Foundation (ASF), sponsored by the Apache Incubator PMC.

--- a/java/fury-format/pom.xml
+++ b/java/fury-format/pom.xml
@@ -32,7 +32,7 @@
   <artifactId>fury-format</artifactId>
 
   <description>
-    Apache Fury™ is a blazing fast multi-language serialization framework powered by jit and zero-copy.
+    Apache Fury™ is a blazingly fast multi-language serialization framework powered by jit and zero-copy.
 
     Apache Fury (incubating) is an effort undergoing incubation at the Apache
     Software Foundation (ASF), sponsored by the Apache Incubator PMC.

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -36,7 +36,7 @@
   <version>0.5.0-SNAPSHOT</version>
   <name>Fury Project Parent POM</name>
   <description>
-    Apache Fury™ is a blazing fast multi-language serialization framework powered by jit and zero-copy.
+    Apache Fury™ is a blazingly fast multi-language serialization framework powered by jit and zero-copy.
 
     Apache Fury (incubating) is an effort undergoing incubation at the Apache
     Software Foundation (ASF), sponsored by the Apache Incubator PMC.

--- a/javascript/packages/fury/package.json
+++ b/javascript/packages/fury/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@furyjs/fury",
   "version": "0.5.9-beta",
-  "description": "Apache Fury™(incubating) is a blazing fast multi-language serialization framework powered by jit and zero-copy",
+  "description": "Apache Fury™(incubating) is a blazingly fast multi-language serialization framework powered by jit and zero-copy",
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",

--- a/python/setup.py
+++ b/python/setup.py
@@ -141,7 +141,7 @@ setup(
     },
     include_package_data=True,
     packages=find_packages(),
-    description="Apache Fury™(incubating) is a blazing fast multi-language serialization "
+    description="Apache Fury™(incubating) is a blazingly fast multi-language serialization "
     + "framework powered by jit and zero-copy",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,6 +1,6 @@
 # Apache Fury™ Rust
 
-Fury is a blazing fast multi-language serialization framework powered by just-in-time compilation and zero-copy.
+Fury is a blazingly fast multi-language serialization framework powered by just-in-time compilation and zero-copy.
 
 Fury Rust can be implemented by steps:
 


### PR DESCRIPTION
As a native English speaker, the existing text doesn't read properly for me.

Blazing is being used as an adverb so should become Blazingly.

https://en.wiktionary.org/wiki/blazingly

For instance, if you wanted to use `incredible` - you would say `incredibly fast`, not `incredible fast`.