### PR TITLE
fix(java): fix slf4j on graalvm

### DIFF
--- a/ci/run_ci.sh
+++ b/ci/run_ci.sh
@@ -99,7 +99,7 @@ graalvm_test() {
   mvn -T10 -B --no-transfer-progress clean install -DskipTests
   echo "Start to build graalvm native image"
   cd "$ROOT"/integration_tests/graalvm_tests
-  mvn -DskipTests=true -Pnative package
+  mvn -DskipTests=true --no-transfer-progress -Pnative package
   echo "Built graalvm native image"
   echo "Start to run graalvm native image"
   ./target/main

--- a/java/fury-core/src/main/java/org/apache/fury/util/LoggerFactory.java
+++ b/java/fury-core/src/main/java/org/apache/fury/util/LoggerFactory.java
@@ -24,7 +24,6 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-
 import org.slf4j.Logger;
 import org.slf4j.helpers.NOPLogger;
 
@@ -48,8 +47,8 @@ public class LoggerFactory {
     } else {
       if (GraalvmSupport.IN_GRAALVM_NATIVE_IMAGE) {
         return (Logger)
-          Proxy.newProxyInstance(
-            clazz.getClassLoader(), new Class[]{Logger.class}, new GraalvmLogger(clazz));
+            Proxy.newProxyInstance(
+                clazz.getClassLoader(), new Class[] {Logger.class}, new GraalvmLogger(clazz));
       }
       return org.slf4j.LoggerFactory.getLogger(clazz);
     }
@@ -57,7 +56,7 @@ public class LoggerFactory {
 
   private static final class GraalvmLogger implements InvocationHandler {
     private static final DateTimeFormatter dateTimeFormatter =
-      DateTimeFormatter.ofPattern("yyyy-MM-dd hh:mm:ss");
+        DateTimeFormatter.ofPattern("yyyy-MM-dd hh:mm:ss");
     private final Class<?> targetClass;
 
     private GraalvmLogger(Class<?> targetClass) {

--- a/java/fury-core/src/main/resources/META-INF/native-image/org.apache.fury/fury-core/native-image.properties
+++ b/java/fury-core/src/main/resources/META-INF/native-image/org.apache.fury/fury-core/native-image.properties
@@ -106,6 +106,7 @@ Args=--initialize-at-build-time=org.apache.fury.memory.MemoryBuffer,\
     org.apache.fury.shaded.org.codehaus.janino.Java$Invocation,\
     org.apache.fury.shaded.org.codehaus.janino.ReflectionIClass,\
     org.apache.fury.util.record.RecordUtils,\
+    org.apache.fury.util.LoggerFactory$GraalvmLogger,\
     org.apache.fury.shaded.org.codehaus.janino.Java$Literal,\
     org.apache.fury.shaded.org.codehaus.janino.IClassLoader,\
     org.apache.fury.shaded.org.codehaus.janino.Java$PrimitiveType,\

--- a/java/fury-test-core/pom.xml
+++ b/java/fury-test-core/pom.xml
@@ -96,7 +96,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
       <version>${log4j.version}</version>
     </dependency>
   </dependencies>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -91,7 +91,7 @@
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>1.7.30</version>
+        <version>2.0.12</version>
       </dependency>
       <dependency>
         <groupId>com.google.guava</groupId>


### PR DESCRIPTION
This PR closes #1404 by:
- Upgrade slf4j to 2.0.12
- Using print instead of slf4j for graalvm