### PR TITLE
chore(java): rename MemoryBuffer read/write/put/getType with read/write/put/getTypeNumber 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
           java-version: 8
           distribution: 'temurin'
       - name: Install fury java
-        run: cd java && mvn -T10 clean install -DskipTests && cd -
+        run: cd java && mvn -T10 --no-transfer-progress clean install -DskipTests && cd -
       - name: Test
         run: |
           # Avoid sbt download jackson-databind error

--- a/NOTICE
+++ b/NOTICE
@@ -28,10 +28,6 @@ The text of each license is the standard Apache 2.0 license.
       java/fury-core/src/main/java/org/apache/fury/util/Platform.java
       java/fury-format/src/main/java/org/apache/fury/format/vectorized/ArrowWriter.java
 
-* flink (https://github.com/apache/flink)
-    Files:
-      java/fury-core/src/main/java/org/apache/fury/memory/MemoryBuffer.java
-
 * commons-io (https://github.com/apache/commons-io)
     Files:
       java/fury-core/src/main/java/org/apache/fury/io/ClassLoaderObjectInputStream.java

--- a/cpp/fury/util/buffer.h
+++ b/cpp/fury/util/buffer.h
@@ -133,7 +133,7 @@ public:
 
   inline double GetDouble(uint32_t offset) { return Get<double>(offset); }
 
-  inline uint32_t PutPositiveVarInt32(uint32_t offset, int32_t value) {
+  inline uint32_t PutVarUint32(uint32_t offset, int32_t value) {
     if (value >> 7 == 0) {
       data_[offset] = (int8_t)value;
       return 1;
@@ -164,7 +164,7 @@ public:
     return 5;
   }
 
-  inline int32_t GetPositiveVarInt32(uint32_t offset,
+  inline int32_t GetVarUint32(uint32_t offset,
                                      uint32_t *readBytesLength) {
     uint32_t position = offset;
     int b = data_[position++];

--- a/cpp/fury/util/buffer.h
+++ b/cpp/fury/util/buffer.h
@@ -164,8 +164,7 @@ public:
     return 5;
   }
 
-  inline int32_t GetVarUint32(uint32_t offset,
-                                     uint32_t *readBytesLength) {
+  inline int32_t GetVarUint32(uint32_t offset, uint32_t *readBytesLength) {
     uint32_t position = offset;
     int b = data_[position++];
     int result = b & 0x7F;

--- a/cpp/fury/util/buffer_test.cc
+++ b/cpp/fury/util/buffer_test.cc
@@ -39,7 +39,7 @@ TEST(Buffer, ToString) {
 }
 
 void checkVarUint32(int32_t startOffset, std::shared_ptr<Buffer> buffer,
-                         int32_t value, uint32_t bytesWritten) {
+                    int32_t value, uint32_t bytesWritten) {
   uint32_t actualBytesWritten = buffer->PutVarUint32(startOffset, value);
   EXPECT_EQ(actualBytesWritten, bytesWritten);
   uint32_t readBytesLength;

--- a/cpp/fury/util/buffer_test.cc
+++ b/cpp/fury/util/buffer_test.cc
@@ -38,30 +38,30 @@ TEST(Buffer, ToString) {
   EXPECT_EQ(buffer->Get<float>(0), f);
 }
 
-void checkPositiveVarInt(int32_t startOffset, std::shared_ptr<Buffer> buffer,
+void checkVarUint32(int32_t startOffset, std::shared_ptr<Buffer> buffer,
                          int32_t value, uint32_t bytesWritten) {
-  uint32_t actualBytesWritten = buffer->PutPositiveVarInt32(startOffset, value);
+  uint32_t actualBytesWritten = buffer->PutVarUint32(startOffset, value);
   EXPECT_EQ(actualBytesWritten, bytesWritten);
   uint32_t readBytesLength;
-  int32_t varInt = buffer->GetPositiveVarInt32(startOffset, &readBytesLength);
+  int32_t varInt = buffer->GetVarUint32(startOffset, &readBytesLength);
   EXPECT_EQ(value, varInt);
   EXPECT_EQ(readBytesLength, bytesWritten);
 }
 
-TEST(Buffer, TestPositiveVarInt) {
+TEST(Buffer, TestVarUint) {
   std::shared_ptr<Buffer> buffer;
   AllocateBuffer(64, &buffer);
   for (int i = 0; i < 32; ++i) {
-    checkPositiveVarInt(i, buffer, 1, 1);
-    checkPositiveVarInt(i, buffer, 1 << 6, 1);
-    checkPositiveVarInt(i, buffer, 1 << 7, 2);
-    checkPositiveVarInt(i, buffer, 1 << 13, 2);
-    checkPositiveVarInt(i, buffer, 1 << 14, 3);
-    checkPositiveVarInt(i, buffer, 1 << 20, 3);
-    checkPositiveVarInt(i, buffer, 1 << 21, 4);
-    checkPositiveVarInt(i, buffer, 1 << 27, 4);
-    checkPositiveVarInt(i, buffer, 1 << 28, 5);
-    checkPositiveVarInt(i, buffer, 1 << 30, 5);
+    checkVarUint32(i, buffer, 1, 1);
+    checkVarUint32(i, buffer, 1 << 6, 1);
+    checkVarUint32(i, buffer, 1 << 7, 2);
+    checkVarUint32(i, buffer, 1 << 13, 2);
+    checkVarUint32(i, buffer, 1 << 14, 3);
+    checkVarUint32(i, buffer, 1 << 20, 3);
+    checkVarUint32(i, buffer, 1 << 21, 4);
+    checkVarUint32(i, buffer, 1 << 27, 4);
+    checkVarUint32(i, buffer, 1 << 28, 5);
+    checkVarUint32(i, buffer, 1 << 30, 5);
   }
 }
 

--- a/docs/guide/java_object_graph_guide.md
+++ b/docs/guide/java_object_graph_guide.md
@@ -203,7 +203,7 @@ class FooSerializer extends Serializer<Foo> {
 
   @Override
   public void write(MemoryBuffer buffer, Foo value) {
-    buffer.writeLong(value.f1);
+    buffer.writeInt64(value.f1);
   }
 
   @Override

--- a/docs/guide/java_object_graph_guide.md
+++ b/docs/guide/java_object_graph_guide.md
@@ -209,7 +209,7 @@ class FooSerializer extends Serializer<Foo> {
   @Override
   public Foo read(MemoryBuffer buffer) {
     Foo foo = new Foo();
-    foo.f1 = buffer.readLong();
+    foo.f1 = buffer.readInt64();
     return foo;
   }
 }

--- a/docs/guide/java_object_graph_guide.md
+++ b/docs/guide/java_object_graph_guide.md
@@ -381,13 +381,13 @@ But if you do want to upgrade fury for better performance and smaller size, you 
 using code like following to keep binary compatibility:
 ```java
 MemoryBuffer buffer = xxx;
-buffer.writeVarInt(2);
+buffer.writeVarInt32(2);
 fury.serialize(buffer, obj);
 ```
 Then for deserialization, you need:
 ```java
 MemoryBuffer buffer = xxx;
-int furyVersion = buffer.readVarInt()
+int furyVersion = buffer.readVarInt32()
 Fury fury = getFury(furyVersion);
 fury.deserialize(buffer);
 ```

--- a/go/fury/buffer.go
+++ b/go/fury/buffer.go
@@ -249,7 +249,7 @@ func (b *ByteBuffer) PutInt32(index int, value int32) {
 	binary.LittleEndian.PutUint32(b.data[index:], uint32(value))
 }
 
-// WriteVarInt32 WritePositiveVarInt writes a 1-5 byte int, returns the number of bytes written.
+// WriteVarInt32 WriteVarUint writes a 1-5 byte int, returns the number of bytes written.
 func (b *ByteBuffer) WriteVarInt32(value int32) int8 {
 	if value>>7 == 0 {
 		b.grow(1)

--- a/java/benchmark/src/main/java/org/apache/fury/benchmark/ArraySuite.java
+++ b/java/benchmark/src/main/java/org/apache/fury/benchmark/ArraySuite.java
@@ -130,7 +130,7 @@ public class ArraySuite {
     for (int i = 0; i < size; i++) {
       Integer o = list.get(i);
       if (o != null) {
-        buffer.writeVarInt(o);
+        buffer.writeVarInt32(o);
       }
     }
     return buffer;

--- a/java/benchmark/src/main/java/org/apache/fury/benchmark/MemorySuite.java
+++ b/java/benchmark/src/main/java/org/apache/fury/benchmark/MemorySuite.java
@@ -211,7 +211,7 @@ public class MemorySuite {
     buffer1.readerIndex(0);
     int size = buffer1.size();
     for (int i = 0; i < size / 2; i++) {
-      x += buffer1.readShort();
+      x += buffer1.readInt16();
     }
     return x;
   }
@@ -233,7 +233,7 @@ public class MemorySuite {
     buffer1.readerIndex(0);
     int size = buffer1.size();
     for (int i = 0; i < size / 4; i++) {
-      x += buffer1.readInt();
+      x += buffer1.readInt32();
     }
     return x;
   }

--- a/java/benchmark/src/main/java/org/apache/fury/benchmark/data/CustomJDKSerialization.java
+++ b/java/benchmark/src/main/java/org/apache/fury/benchmark/data/CustomJDKSerialization.java
@@ -33,6 +33,6 @@ public class CustomJDKSerialization implements Serializable {
 
   private void readObject(java.io.ObjectInputStream s) throws Exception {
     s.defaultReadObject();
-    this.age = s.readInt32();
+    this.age = s.readInt();
   }
 }

--- a/java/benchmark/src/main/java/org/apache/fury/benchmark/data/CustomJDKSerialization.java
+++ b/java/benchmark/src/main/java/org/apache/fury/benchmark/data/CustomJDKSerialization.java
@@ -33,6 +33,6 @@ public class CustomJDKSerialization implements Serializable {
 
   private void readObject(java.io.ObjectInputStream s) throws Exception {
     s.defaultReadObject();
-    this.age = s.readInt();
+    this.age = s.readInt32();
   }
 }

--- a/java/benchmark/src/main/java/org/apache/fury/benchmark/data/SerializableByteBuffer.java
+++ b/java/benchmark/src/main/java/org/apache/fury/benchmark/data/SerializableByteBuffer.java
@@ -49,7 +49,7 @@ public class SerializableByteBuffer implements Externalizable {
 
   @Override
   public void readExternal(ObjectInput in) throws IOException {
-    int size = in.readInt();
+    int size = in.readInt32();
     byte[] bytes = new byte[size];
     int read = 0;
     while (read != size) {

--- a/java/benchmark/src/main/java/org/apache/fury/benchmark/data/SerializableByteBuffer.java
+++ b/java/benchmark/src/main/java/org/apache/fury/benchmark/data/SerializableByteBuffer.java
@@ -49,7 +49,7 @@ public class SerializableByteBuffer implements Externalizable {
 
   @Override
   public void readExternal(ObjectInput in) throws IOException {
-    int size = in.readInt32();
+    int size = in.readInt();
     byte[] bytes = new byte[size];
     int read = 0;
     while (read != size) {

--- a/java/fury-core/src/main/java/org/apache/fury/Fury.java
+++ b/java/fury-core/src/main/java/org/apache/fury/Fury.java
@@ -309,7 +309,7 @@ public final class Fury implements BaseFury {
   private void write(MemoryBuffer buffer, Object obj) {
     if (config.shareMetaContext()) {
       int startOffset = buffer.writerIndex();
-      buffer.writeInt(-1); // preserve 4-byte for nativeObjects start offsets.
+      buffer.writeInt32(-1); // preserve 4-byte for nativeObjects start offsets.
       writeRef(buffer, obj);
       buffer.putInt(startOffset, buffer.writerIndex());
       classResolver.writeClassDefs(buffer);
@@ -320,8 +320,8 @@ public final class Fury implements BaseFury {
 
   private void xserializeInternal(MemoryBuffer buffer, Object obj) {
     int startOffset = buffer.writerIndex();
-    buffer.writeInt(-1); // preserve 4-byte for nativeObjects start offsets.
-    buffer.writeInt(-1); // preserve 4-byte for nativeObjects size
+    buffer.writeInt32(-1); // preserve 4-byte for nativeObjects start offsets.
+    buffer.writeInt32(-1); // preserve 4-byte for nativeObjects size
     xwriteRef(buffer, obj);
     buffer.putInt(startOffset, buffer.writerIndex());
     buffer.putInt(startOffset + 4, nativeObjects.size());
@@ -485,7 +485,7 @@ public final class Fury implements BaseFury {
       serializer = classResolver.getSerializer(cls);
     }
     short typeId = serializer.getXtypeId();
-    buffer.writeShort(typeId);
+    buffer.writeInt16(typeId);
     if (typeId != NOT_SUPPORT_CROSS_LANGUAGE) {
       if (typeId == FURY_TYPE_TAG_ID) {
         classResolver.xwriteTypeTag(buffer, cls);
@@ -522,23 +522,23 @@ public final class Fury implements BaseFury {
         buffer.writeChar((Character) obj);
         break;
       case ClassResolver.SHORT_CLASS_ID:
-        buffer.writeShort((Short) obj);
+        buffer.writeInt16((Short) obj);
         break;
       case ClassResolver.INTEGER_CLASS_ID:
         if (compressInt) {
           buffer.writeVarInt32((Integer) obj);
         } else {
-          buffer.writeInt((Integer) obj);
+          buffer.writeInt32((Integer) obj);
         }
         break;
       case ClassResolver.FLOAT_CLASS_ID:
-        buffer.writeFloat((Float) obj);
+        buffer.writeFloat32((Float) obj);
         break;
       case ClassResolver.LONG_CLASS_ID:
-        LongSerializer.writeLong(buffer, (Long) obj, longEncoding);
+        LongSerializer.writeInt64(buffer, (Long) obj, longEncoding);
         break;
       case ClassResolver.DOUBLE_CLASS_ID:
-        buffer.writeDouble((Double) obj);
+        buffer.writeFloat64((Double) obj);
         break;
       case ClassResolver.STRING_CLASS_ID:
         stringSerializer.writeJavaString(buffer, (String) obj);
@@ -666,8 +666,8 @@ public final class Fury implements BaseFury {
     return stringSerializer.readJavaString(buffer);
   }
 
-  public void writeLong(MemoryBuffer buffer, long value) {
-    LongSerializer.writeLong(buffer, value, longEncoding);
+  public void writeInt64(MemoryBuffer buffer, long value) {
+    LongSerializer.writeInt64(buffer, value, longEncoding);
   }
 
   public long readInt64(MemoryBuffer buffer) {
@@ -1028,7 +1028,7 @@ public final class Fury implements BaseFury {
       }
       if (config.shareMetaContext()) {
         int startOffset = buffer.writerIndex();
-        buffer.writeInt(-1); // preserve 4-byte for nativeObjects start offsets.
+        buffer.writeInt32(-1); // preserve 4-byte for nativeObjects start offsets.
         if (!refResolver.writeRefOrNull(buffer, obj)) {
           ClassInfo classInfo = classResolver.getOrUpdateClassInfo(obj.getClass());
           writeData(buffer, classInfo, obj);

--- a/java/fury-core/src/main/java/org/apache/fury/Fury.java
+++ b/java/fury-core/src/main/java/org/apache/fury/Fury.java
@@ -503,7 +503,7 @@ public final class Fury implements BaseFury {
       // fields/objects deserialization will use wrong reference id since we skip opaque objects
       // deserialization.
       // So we stash native objects and serialize all those object at the last.
-      buffer.writePositiveVarInt(nativeObjects.size());
+      buffer.writeVarUint32(nativeObjects.size());
       nativeObjects.add(obj);
     }
     depth--;
@@ -526,7 +526,7 @@ public final class Fury implements BaseFury {
         break;
       case ClassResolver.INTEGER_CLASS_ID:
         if (compressInt) {
-          buffer.writeVarInt((Integer) obj);
+          buffer.writeVarInt32((Integer) obj);
         } else {
           buffer.writeInt((Integer) obj);
         }
@@ -560,9 +560,9 @@ public final class Fury implements BaseFury {
       // efficient
       // TODO(chaokunyang) Remove branch when other languages support aligned varint.
       if (language == Language.JAVA) {
-        buffer.writePositiveVarIntAligned(totalBytes);
+        buffer.writeVarUint32Aligned(totalBytes);
       } else {
-        buffer.writePositiveVarInt(totalBytes);
+        buffer.writeVarUint32(totalBytes);
       }
       int writerIndex = buffer.writerIndex();
       buffer.ensure(writerIndex + bufferObject.totalBytes());
@@ -584,9 +584,9 @@ public final class Fury implements BaseFury {
       // efficient
       // TODO(chaokunyang) Remove branch when other languages support aligned varint.
       if (language == Language.JAVA) {
-        buffer.writePositiveVarIntAligned(totalBytes);
+        buffer.writeVarUint32Aligned(totalBytes);
       } else {
-        buffer.writePositiveVarInt(totalBytes);
+        buffer.writeVarUint32(totalBytes);
       }
       bufferObject.writeTo(buffer);
     } else {
@@ -602,7 +602,7 @@ public final class Fury implements BaseFury {
       if (language == Language.JAVA) {
         size = buffer.readPositiveAlignedVarInt();
       } else {
-        size = buffer.readPositiveVarInt();
+        size = buffer.readVarUint32();
       }
       MemoryBuffer slice = buffer.slice(buffer.readerIndex(), size);
       buffer.readerIndex(buffer.readerIndex() + size);
@@ -906,7 +906,7 @@ public final class Fury implements BaseFury {
         return buffer.readShort();
       case ClassResolver.INTEGER_CLASS_ID:
         if (compressInt) {
-          return buffer.readVarInt();
+          return buffer.readVarInt32();
         } else {
           return buffer.readInt();
         }
@@ -1000,7 +1000,7 @@ public final class Fury implements BaseFury {
       return o;
     } else {
       String className = classResolver.xreadClassName(buffer);
-      int ordinal = buffer.readPositiveVarInt();
+      int ordinal = buffer.readVarUint32();
       if (peerLanguage != Language.JAVA) {
         return OpaqueObjects.of(peerLanguage, className, ordinal);
       } else {

--- a/java/fury-core/src/main/java/org/apache/fury/Fury.java
+++ b/java/fury-core/src/main/java/org/apache/fury/Fury.java
@@ -600,7 +600,7 @@ public final class Fury implements BaseFury {
       int size;
       // TODO(chaokunyang) Remove branch when other languages support aligned varint.
       if (language == Language.JAVA) {
-        size = buffer.readPositiveAlignedVarInt();
+        size = buffer.readAlignedVarUint();
       } else {
         size = buffer.readVarUint32();
       }

--- a/java/fury-core/src/main/java/org/apache/fury/Fury.java
+++ b/java/fury-core/src/main/java/org/apache/fury/Fury.java
@@ -670,8 +670,8 @@ public final class Fury implements BaseFury {
     LongSerializer.writeLong(buffer, value, longEncoding);
   }
 
-  public long readLong(MemoryBuffer buffer) {
-    return LongSerializer.readLong(buffer, longEncoding);
+  public long readInt64(MemoryBuffer buffer) {
+    return LongSerializer.readInt64(buffer, longEncoding);
   }
 
   @Override
@@ -797,8 +797,8 @@ public final class Fury implements BaseFury {
 
   private Object xdeserializeInternal(MemoryBuffer buffer) {
     Object obj;
-    int nativeObjectsStartOffset = buffer.readInt();
-    int nativeObjectsSize = buffer.readInt();
+    int nativeObjectsStartOffset = buffer.readInt32();
+    int nativeObjectsSize = buffer.readInt32();
     int endReaderIndex = nativeObjectsStartOffset;
     if (peerLanguage == Language.JAVA) {
       int readerIndex = buffer.readerIndex();
@@ -903,19 +903,19 @@ public final class Fury implements BaseFury {
       case ClassResolver.CHAR_CLASS_ID:
         return buffer.readChar();
       case ClassResolver.SHORT_CLASS_ID:
-        return buffer.readShort();
+        return buffer.readInt16();
       case ClassResolver.INTEGER_CLASS_ID:
         if (compressInt) {
           return buffer.readVarInt32();
         } else {
-          return buffer.readInt();
+          return buffer.readInt32();
         }
       case ClassResolver.FLOAT_CLASS_ID:
-        return buffer.readFloat();
+        return buffer.readFloat32();
       case ClassResolver.LONG_CLASS_ID:
-        return LongSerializer.readLong(buffer, longEncoding);
+        return LongSerializer.readInt64(buffer, longEncoding);
       case ClassResolver.DOUBLE_CLASS_ID:
-        return buffer.readDouble();
+        return buffer.readFloat64();
       case ClassResolver.STRING_CLASS_ID:
         return stringSerializer.readJavaString(buffer);
         // TODO(add fastpath for other types)
@@ -970,7 +970,7 @@ public final class Fury implements BaseFury {
 
   public Object xreadNonRef(MemoryBuffer buffer, Serializer<?> serializer) {
     depth++;
-    short typeId = buffer.readShort();
+    short typeId = buffer.readInt16();
     ClassResolver classResolver = this.classResolver;
     if (typeId != NOT_SUPPORT_CROSS_LANGUAGE) {
       Class<?> cls = null;

--- a/java/fury-core/src/main/java/org/apache/fury/builder/BaseObjectCodecBuilder.java
+++ b/java/fury-core/src/main/java/org/apache/fury/builder/BaseObjectCodecBuilder.java
@@ -370,16 +370,16 @@ public abstract class BaseObjectCodecBuilder extends CodecBuilder {
       } else if (clz == char.class || clz == Character.class) {
         return new Invoke(buffer, "writeChar", inputObject);
       } else if (clz == short.class || clz == Short.class) {
-        return new Invoke(buffer, "writeShort", inputObject);
+        return new Invoke(buffer, "writeInt16", inputObject);
       } else if (clz == int.class || clz == Integer.class) {
-        String func = fury.compressInt() ? "writeVarInt32" : "writeInt";
+        String func = fury.compressInt() ? "writeVarInt32" : "writeInt32";
         return new Invoke(buffer, func, inputObject);
       } else if (clz == long.class || clz == Long.class) {
-        return LongSerializer.writeLong(buffer, inputObject, fury.longEncoding(), true);
+        return LongSerializer.writeInt64(buffer, inputObject, fury.longEncoding(), true);
       } else if (clz == float.class || clz == Float.class) {
-        return new Invoke(buffer, "writeFloat", inputObject);
+        return new Invoke(buffer, "writeFloat32", inputObject);
       } else if (clz == double.class || clz == Double.class) {
-        return new Invoke(buffer, "writeDouble", inputObject);
+        return new Invoke(buffer, "writeFloat64", inputObject);
       } else {
         throw new IllegalStateException("impossible");
       }

--- a/java/fury-core/src/main/java/org/apache/fury/builder/BaseObjectCodecBuilder.java
+++ b/java/fury-core/src/main/java/org/apache/fury/builder/BaseObjectCodecBuilder.java
@@ -372,7 +372,7 @@ public abstract class BaseObjectCodecBuilder extends CodecBuilder {
       } else if (clz == short.class || clz == Short.class) {
         return new Invoke(buffer, "writeShort", inputObject);
       } else if (clz == int.class || clz == Integer.class) {
-        String func = fury.compressInt() ? "writeVarInt" : "writeInt";
+        String func = fury.compressInt() ? "writeVarInt32" : "writeInt";
         return new Invoke(buffer, func, inputObject);
       } else if (clz == long.class || clz == Long.class) {
         return LongSerializer.writeLong(buffer, inputObject, fury.longEncoding(), true);
@@ -1137,7 +1137,7 @@ public abstract class BaseObjectCodecBuilder extends CodecBuilder {
       } else if (cls == short.class || cls == Short.class) {
         return readShort(buffer);
       } else if (cls == int.class || cls == Integer.class) {
-        return fury.compressInt() ? readVarInt(buffer) : readInt(buffer);
+        return fury.compressInt() ? readVarInt32(buffer) : readInt(buffer);
       } else if (cls == long.class || cls == Long.class) {
         return LongSerializer.readLong(buffer, fury.longEncoding());
       } else if (cls == float.class || cls == Float.class) {

--- a/java/fury-core/src/main/java/org/apache/fury/builder/BaseObjectCodecBuilder.java
+++ b/java/fury-core/src/main/java/org/apache/fury/builder/BaseObjectCodecBuilder.java
@@ -1135,15 +1135,15 @@ public abstract class BaseObjectCodecBuilder extends CodecBuilder {
       } else if (cls == char.class || cls == Character.class) {
         return readChar(buffer);
       } else if (cls == short.class || cls == Short.class) {
-        return readShort(buffer);
+        return readInt16(buffer);
       } else if (cls == int.class || cls == Integer.class) {
-        return fury.compressInt() ? readVarInt32(buffer) : readInt(buffer);
+        return fury.compressInt() ? readVarInt32(buffer) : readInt32(buffer);
       } else if (cls == long.class || cls == Long.class) {
-        return LongSerializer.readLong(buffer, fury.longEncoding());
+        return LongSerializer.readInt64(buffer, fury.longEncoding());
       } else if (cls == float.class || cls == Float.class) {
-        return readFloat(buffer);
+        return readFloat32(buffer);
       } else if (cls == double.class || cls == Double.class) {
-        return readDouble(buffer);
+        return readFloat64(buffer);
       } else {
         throw new IllegalStateException("impossible");
       }

--- a/java/fury-core/src/main/java/org/apache/fury/builder/CodecBuilder.java
+++ b/java/fury-core/src/main/java/org/apache/fury/builder/CodecBuilder.java
@@ -627,18 +627,18 @@ public abstract class CodecBuilder {
     return new Invoke(buffer, func, PRIMITIVE_CHAR_TYPE);
   }
 
-  protected Expression readShort(Expression buffer) {
-    String func = Platform.IS_LITTLE_ENDIAN ? "readShortOnLE" : "readShortOnBE";
+  protected Expression readInt16(Expression buffer) {
+    String func = Platform.IS_LITTLE_ENDIAN ? "readInt16OnLE" : "readInt16OnBE";
     return new Invoke(buffer, func, PRIMITIVE_SHORT_TYPE);
   }
 
-  protected Expression readInt(Expression buffer) {
-    String func = Platform.IS_LITTLE_ENDIAN ? "readIntOnLE" : "readIntOnBE";
+  protected Expression readInt32(Expression buffer) {
+    String func = Platform.IS_LITTLE_ENDIAN ? "readInt32OnLE" : "readInt32OnBE";
     return new Invoke(buffer, func, PRIMITIVE_INT_TYPE);
   }
 
   public static String readIntFunc() {
-    return Platform.IS_LITTLE_ENDIAN ? "readIntOnLE" : "readIntOnBE";
+    return Platform.IS_LITTLE_ENDIAN ? "readInt32OnLE" : "readInt32OnBE";
   }
 
   protected Expression readVarInt32(Expression buffer) {
@@ -646,21 +646,21 @@ public abstract class CodecBuilder {
     return new Invoke(buffer, func, PRIMITIVE_INT_TYPE);
   }
 
-  protected Expression readLong(Expression buffer) {
+  protected Expression readInt64(Expression buffer) {
     return new Invoke(buffer, readLongFunc(), PRIMITIVE_LONG_TYPE);
   }
 
   public static String readLongFunc() {
-    return Platform.IS_LITTLE_ENDIAN ? "readLongOnLE" : "readLongOnBE";
+    return Platform.IS_LITTLE_ENDIAN ? "readInt64OnLE" : "readInt64OnBE";
   }
 
-  protected Expression readFloat(Expression buffer) {
-    String func = Platform.IS_LITTLE_ENDIAN ? "readFloatOnLE" : "readFloatOnBE";
+  protected Expression readFloat32(Expression buffer) {
+    String func = Platform.IS_LITTLE_ENDIAN ? "readFloat32OnLE" : "readFloat32OnBE";
     return new Invoke(buffer, func, PRIMITIVE_FLOAT_TYPE);
   }
 
-  protected Expression readDouble(Expression buffer) {
-    String func = Platform.IS_LITTLE_ENDIAN ? "readDoubleOnLE" : "readDoubleOnBE";
+  protected Expression readFloat64(Expression buffer) {
+    String func = Platform.IS_LITTLE_ENDIAN ? "readFloat64OnLE" : "readFloat64OnBE";
     return new Invoke(buffer, func, PRIMITIVE_DOUBLE_TYPE);
   }
 }

--- a/java/fury-core/src/main/java/org/apache/fury/builder/CodecBuilder.java
+++ b/java/fury-core/src/main/java/org/apache/fury/builder/CodecBuilder.java
@@ -650,7 +650,7 @@ public abstract class CodecBuilder {
   }
 
   public static String readLongFunc() {
-    return Platform.IS_LITTLE_ENDIAN ? "readInt64OnLE" : "readInt64OnBE";
+    return Platform.IS_LITTLE_ENDIAN ? "_readInt64OnLE" : "_readInt64OnBE";
   }
 
   protected Expression readFloat32(Expression buffer) {

--- a/java/fury-core/src/main/java/org/apache/fury/builder/CodecBuilder.java
+++ b/java/fury-core/src/main/java/org/apache/fury/builder/CodecBuilder.java
@@ -649,8 +649,8 @@ public abstract class CodecBuilder {
     return Platform.IS_LITTLE_ENDIAN ? "readIntOnLE" : "readIntOnBE";
   }
 
-  protected Expression readVarInt(Expression buffer) {
-    String func = Platform.IS_LITTLE_ENDIAN ? "readVarIntOnLE" : "readVarIntOnBE";
+  protected Expression readVarInt32(Expression buffer) {
+    String func = Platform.IS_LITTLE_ENDIAN ? "readVarInt32OnLE" : "readVarInt32OnBE";
     return new Invoke(buffer, func, PRIMITIVE_INT_TYPE);
   }
 

--- a/java/fury-core/src/main/java/org/apache/fury/builder/CodecBuilder.java
+++ b/java/fury-core/src/main/java/org/apache/fury/builder/CodecBuilder.java
@@ -530,9 +530,7 @@ public abstract class CodecBuilder {
                 .inline());
   }
 
-  /**
-   * Build unsafePut operation.
-   */
+  /** Build unsafePut operation. */
   protected Expression unsafePut(Expression base, Expression pos, Expression value) {
     return new StaticInvoke(Platform.class, "put", base, pos, value);
   }
@@ -561,9 +559,7 @@ public abstract class CodecBuilder {
     return new StaticInvoke(Platform.class, "putFloat", base, pos, value);
   }
 
-  /**
-   * Build unsafePutDouble operation.
-   */
+  /** Build unsafePutDouble operation. */
   protected Expression unsafePutDouble(Expression base, Expression pos, Expression value) {
     return new StaticInvoke(Platform.class, "putDouble", base, pos, value);
   }

--- a/java/fury-core/src/main/java/org/apache/fury/builder/CodecBuilder.java
+++ b/java/fury-core/src/main/java/org/apache/fury/builder/CodecBuilder.java
@@ -623,8 +623,7 @@ public abstract class CodecBuilder {
   }
 
   protected Expression readChar(Expression buffer) {
-    String func = Platform.IS_LITTLE_ENDIAN ? "readCharOnLE" : "readCharOnBE";
-    return new Invoke(buffer, func, PRIMITIVE_CHAR_TYPE);
+    return new Invoke(buffer, "readChar", PRIMITIVE_CHAR_TYPE);
   }
 
   protected Expression readInt16(Expression buffer) {
@@ -642,7 +641,7 @@ public abstract class CodecBuilder {
   }
 
   protected Expression readVarInt32(Expression buffer) {
-    String func = Platform.IS_LITTLE_ENDIAN ? "readVarInt32OnLE" : "readVarInt32OnBE";
+    String func = Platform.IS_LITTLE_ENDIAN ? "_readVarInt32OnLE" : "_readVarInt32OnBE";
     return new Invoke(buffer, func, PRIMITIVE_INT_TYPE);
   }
 
@@ -655,12 +654,12 @@ public abstract class CodecBuilder {
   }
 
   protected Expression readFloat32(Expression buffer) {
-    String func = Platform.IS_LITTLE_ENDIAN ? "readFloat32OnLE" : "readFloat32OnBE";
+    String func = Platform.IS_LITTLE_ENDIAN ? "_readFloat32OnLE" : "_readFloat32OnBE";
     return new Invoke(buffer, func, PRIMITIVE_FLOAT_TYPE);
   }
 
   protected Expression readFloat64(Expression buffer) {
-    String func = Platform.IS_LITTLE_ENDIAN ? "readFloat64OnLE" : "readFloat64OnBE";
+    String func = Platform.IS_LITTLE_ENDIAN ? "_readFloat64OnLE" : "_readFloat64OnBE";
     return new Invoke(buffer, func, PRIMITIVE_DOUBLE_TYPE);
   }
 }

--- a/java/fury-core/src/main/java/org/apache/fury/builder/CodecBuilder.java
+++ b/java/fury-core/src/main/java/org/apache/fury/builder/CodecBuilder.java
@@ -532,44 +532,40 @@ public abstract class CodecBuilder {
 
   /**
    * Build unsafePut operation.
-   *
-   * @see MemoryBuffer#unsafePut(Object, long, byte)
    */
   protected Expression unsafePut(Expression base, Expression pos, Expression value) {
-    return new StaticInvoke(MemoryBuffer.class, "unsafePut", base, pos, value);
+    return new StaticInvoke(Platform.class, "put", base, pos, value);
   }
 
   protected Expression unsafePutBoolean(Expression base, Expression pos, Expression value) {
-    return new StaticInvoke(MemoryBuffer.class, "unsafePutBoolean", base, pos, value);
+    return new StaticInvoke(Platform.class, "putBoolean", base, pos, value);
   }
 
   protected Expression unsafePutChar(Expression base, Expression pos, Expression value) {
-    return new StaticInvoke(MemoryBuffer.class, "unsafePutChar", base, pos, value);
+    return new StaticInvoke(Platform.class, "putChar", base, pos, value);
   }
 
   protected Expression unsafePutShort(Expression base, Expression pos, Expression value) {
-    return new StaticInvoke(MemoryBuffer.class, "unsafePutShort", base, pos, value);
+    return new StaticInvoke(Platform.class, "putShort", base, pos, value);
   }
 
   protected Expression unsafePutInt(Expression base, Expression pos, Expression value) {
-    return new StaticInvoke(MemoryBuffer.class, "unsafePutInt", base, pos, value);
+    return new StaticInvoke(Platform.class, "putInt", base, pos, value);
   }
 
   protected Expression unsafePutLong(Expression base, Expression pos, Expression value) {
-    return new StaticInvoke(MemoryBuffer.class, "unsafePutLong", base, pos, value);
+    return new StaticInvoke(Platform.class, "putLong", base, pos, value);
   }
 
   protected Expression unsafePutFloat(Expression base, Expression pos, Expression value) {
-    return new StaticInvoke(MemoryBuffer.class, "unsafePutFloat", base, pos, value);
+    return new StaticInvoke(Platform.class, "putFloat", base, pos, value);
   }
 
   /**
    * Build unsafePutDouble operation.
-   *
-   * @see MemoryBuffer#unsafePutDouble(Object, long, double)
    */
   protected Expression unsafePutDouble(Expression base, Expression pos, Expression value) {
-    return new StaticInvoke(MemoryBuffer.class, "unsafePutDouble", base, pos, value);
+    return new StaticInvoke(Platform.class, "putDouble", base, pos, value);
   }
 
   /** Build unsafeGet operation. */

--- a/java/fury-core/src/main/java/org/apache/fury/builder/CodecBuilder.java
+++ b/java/fury-core/src/main/java/org/apache/fury/builder/CodecBuilder.java
@@ -532,7 +532,7 @@ public abstract class CodecBuilder {
 
   /** Build unsafePut operation. */
   protected Expression unsafePut(Expression base, Expression pos, Expression value) {
-    return new StaticInvoke(Platform.class, "put", base, pos, value);
+    return new StaticInvoke(Platform.class, "putByte", base, pos, value);
   }
 
   protected Expression unsafePutBoolean(Expression base, Expression pos, Expression value) {

--- a/java/fury-core/src/main/java/org/apache/fury/builder/CompatibleCodecBuilder.java
+++ b/java/fury-core/src/main/java/org/apache/fury/builder/CompatibleCodecBuilder.java
@@ -530,7 +530,7 @@ public class CompatibleCodecBuilder extends BaseObjectCodecBuilder {
    *   if (fieldResolver.skipDataBy4(buffer, (int) partFieldInfo)) {
    *     return bean;
    *   }
-   *   partFieldInfo = buffer.readInt();
+   *   partFieldInfo = buffer.readInt32();
    * }
    * }</pre>
    */
@@ -573,7 +573,7 @@ public class CompatibleCodecBuilder extends BaseObjectCodecBuilder {
    *   if (fieldResolver.skipDataBy4(buffer, (int) partFieldInfo)) {
    *     return bean;
    *   }
-   *   partFieldInfo = buffer.readInt();
+   *   partFieldInfo = buffer.readInt32();
    * }
    * }</pre>
    */
@@ -912,7 +912,7 @@ public class CompatibleCodecBuilder extends BaseObjectCodecBuilder {
    *   if (fieldResolver.skipDataBy8(buffer, partFieldInfo)) {
    *     return bean;
    *   }
-   *   partFieldInfo = buffer.readLong();
+   *   partFieldInfo = buffer.readInt64();
    * }
    * }</pre>
    */

--- a/java/fury-core/src/main/java/org/apache/fury/builder/CompatibleCodecBuilder.java
+++ b/java/fury-core/src/main/java/org/apache/fury/builder/CompatibleCodecBuilder.java
@@ -196,7 +196,7 @@ public class CompatibleCodecBuilder extends BaseObjectCodecBuilder {
                           groupExpressions.add(
                               new Invoke(
                                   buffer,
-                                  "writeInt",
+                                  "writeInt32",
                                   new Literal(
                                       (int) fieldInfo.getEncodedFieldInfo(), PRIMITIVE_INT_TYPE)));
                           groupExpressions.add(writeEmbedTypeFieldValue(bean, buffer, fieldInfo));
@@ -218,7 +218,7 @@ public class CompatibleCodecBuilder extends BaseObjectCodecBuilder {
                           groupExpressions.add(
                               new Invoke(
                                   buffer,
-                                  "writeLong",
+                                  "writeInt64",
                                   new Literal(
                                       fieldInfo.getEncodedFieldInfo(), PRIMITIVE_LONG_TYPE)));
                           groupExpressions.add(writeEmbedTypeFieldValue(bean, buffer, fieldInfo));
@@ -240,7 +240,7 @@ public class CompatibleCodecBuilder extends BaseObjectCodecBuilder {
                           groupExpressions.add(
                               new Invoke(
                                   buffer,
-                                  "writeLong",
+                                  "writeInt64",
                                   new Literal(
                                       fieldInfo.getEncodedFieldInfo(), PRIMITIVE_LONG_TYPE)));
                           groupExpressions.add(writeEmbedTypeFieldValue(bean, buffer, fieldInfo));
@@ -262,7 +262,7 @@ public class CompatibleCodecBuilder extends BaseObjectCodecBuilder {
                           groupExpressions.add(
                               new Invoke(
                                   buffer,
-                                  "writeLong",
+                                  "writeInt64",
                                   new Literal(
                                       fieldInfo.getEncodedFieldInfo(), PRIMITIVE_LONG_TYPE)));
                           Descriptor descriptor = createDescriptor(fieldInfo);
@@ -340,7 +340,7 @@ public class CompatibleCodecBuilder extends BaseObjectCodecBuilder {
             });
     expressions.add(
         new Invoke(
-            buffer, "writeLong", new Literal(fieldResolver.getEndTag(), PRIMITIVE_LONG_TYPE)));
+            buffer, "writeInt64", new Literal(fieldResolver.getEndTag(), PRIMITIVE_LONG_TYPE)));
     return expressions;
   }
 

--- a/java/fury-core/src/main/java/org/apache/fury/builder/ObjectCodecBuilder.java
+++ b/java/fury-core/src/main/java/org/apache/fury/builder/ObjectCodecBuilder.java
@@ -144,7 +144,7 @@ public class ObjectCodecBuilder extends BaseObjectCodecBuilder {
     Expression bean = tryCastIfPublic(inputObject, beanType, ctx.newName(beanClass));
     expressions.add(bean);
     if (fury.checkClassVersion()) {
-      expressions.add(new Invoke(buffer, "writeInt", classVersionHash));
+      expressions.add(new Invoke(buffer, "writeInt32", classVersionHash));
     }
     expressions.addAll(serializePrimitives(bean, buffer, objectCodecOptimizer.primitiveGroups));
     int numGroups = getNumGroups(objectCodecOptimizer);
@@ -366,7 +366,7 @@ public class ObjectCodecBuilder extends BaseObjectCodecBuilder {
               compressStarted = true;
             }
             groupExpressions.add(
-                LongSerializer.writeLong(buffer, fieldValue, fury.longEncoding(), false));
+                LongSerializer.writeInt64(buffer, fieldValue, fury.longEncoding(), false));
           }
         } else {
           throw new IllegalStateException("impossible");

--- a/java/fury-core/src/main/java/org/apache/fury/builder/ObjectCodecBuilder.java
+++ b/java/fury-core/src/main/java/org/apache/fury/builder/ObjectCodecBuilder.java
@@ -352,7 +352,7 @@ public class ObjectCodecBuilder extends BaseObjectCodecBuilder {
               addIncWriterIndexExpr(groupExpressions, buffer, acc);
               compressStarted = true;
             }
-            groupExpressions.add(new Invoke(buffer, "unsafeWriteVarInt", fieldValue));
+            groupExpressions.add(new Invoke(buffer, "_unsafeWriteVarInt", fieldValue));
             acc += 0;
           }
         } else if (clz == long.class) {

--- a/java/fury-core/src/main/java/org/apache/fury/builder/ObjectCodecBuilder.java
+++ b/java/fury-core/src/main/java/org/apache/fury/builder/ObjectCodecBuilder.java
@@ -695,7 +695,7 @@ public class ObjectCodecBuilder extends BaseObjectCodecBuilder {
               compressStarted = true;
               addIncReaderIndexExpr(groupExpressions, buffer, acc);
             }
-            fieldValue = readVarInt(buffer);
+            fieldValue = readVarInt32(buffer);
           }
         } else if (clz == long.class) {
           if (!fury.compressLong()) {

--- a/java/fury-core/src/main/java/org/apache/fury/builder/ObjectCodecBuilder.java
+++ b/java/fury-core/src/main/java/org/apache/fury/builder/ObjectCodecBuilder.java
@@ -706,7 +706,7 @@ public class ObjectCodecBuilder extends BaseObjectCodecBuilder {
               compressStarted = true;
               addIncReaderIndexExpr(groupExpressions, buffer, acc);
             }
-            fieldValue = LongSerializer.readLong(buffer, fury.longEncoding());
+            fieldValue = LongSerializer.readInt64(buffer, fury.longEncoding());
           }
         } else {
           throw new IllegalStateException("impossible");

--- a/java/fury-core/src/main/java/org/apache/fury/io/MemoryBufferObjectInput.java
+++ b/java/fury-core/src/main/java/org/apache/fury/io/MemoryBufferObjectInput.java
@@ -118,13 +118,13 @@ public class MemoryBufferObjectInput extends InputStream implements ObjectInput 
   }
 
   @Override
-  public short readShort() throws IOException {
-    return buffer.readShort();
+  public short readInt16() throws IOException {
+    return buffer.readInt16();
   }
 
   @Override
   public int readUnsignedShort() throws IOException {
-    return buffer.readShort() & 0xffff;
+    return buffer.readInt16() & 0xffff;
   }
 
   @Override
@@ -133,23 +133,23 @@ public class MemoryBufferObjectInput extends InputStream implements ObjectInput 
   }
 
   @Override
-  public int readInt() throws IOException {
-    return buffer.readInt();
+  public int readInt32() throws IOException {
+    return buffer.readInt32();
   }
 
   @Override
-  public long readLong() throws IOException {
-    return buffer.readLong();
+  public long readInt64() throws IOException {
+    return buffer.readInt64();
   }
 
   @Override
-  public float readFloat() throws IOException {
-    return buffer.readFloat();
+  public float readFloat32() throws IOException {
+    return buffer.readFloat32();
   }
 
   @Override
-  public double readDouble() throws IOException {
-    return buffer.readDouble();
+  public double readFloat64() throws IOException {
+    return buffer.readFloat64();
   }
 
   @Override

--- a/java/fury-core/src/main/java/org/apache/fury/io/MemoryBufferObjectInput.java
+++ b/java/fury-core/src/main/java/org/apache/fury/io/MemoryBufferObjectInput.java
@@ -118,7 +118,7 @@ public class MemoryBufferObjectInput extends InputStream implements ObjectInput 
   }
 
   @Override
-  public short readInt16() throws IOException {
+  public short readShort() throws IOException {
     return buffer.readInt16();
   }
 
@@ -133,22 +133,22 @@ public class MemoryBufferObjectInput extends InputStream implements ObjectInput 
   }
 
   @Override
-  public int readInt32() throws IOException {
+  public int readInt() throws IOException {
     return buffer.readInt32();
   }
 
   @Override
-  public long readInt64() throws IOException {
+  public long readLong() throws IOException {
     return buffer.readInt64();
   }
 
   @Override
-  public float readFloat32() throws IOException {
+  public float readFloat() throws IOException {
     return buffer.readFloat32();
   }
 
   @Override
-  public double readFloat64() throws IOException {
+  public double readDouble() throws IOException {
     return buffer.readFloat64();
   }
 

--- a/java/fury-core/src/main/java/org/apache/fury/io/MemoryBufferObjectOutput.java
+++ b/java/fury-core/src/main/java/org/apache/fury/io/MemoryBufferObjectOutput.java
@@ -81,7 +81,7 @@ public class MemoryBufferObjectOutput extends OutputStream implements ObjectOutp
 
   @Override
   public void writeShort(int v) throws IOException {
-    buffer.writeShort((short) v);
+    buffer.writeInt16((short) v);
   }
 
   @Override
@@ -91,22 +91,22 @@ public class MemoryBufferObjectOutput extends OutputStream implements ObjectOutp
 
   @Override
   public void writeInt(int v) throws IOException {
-    buffer.writeInt(v);
+    buffer.writeInt32(v);
   }
 
   @Override
   public void writeLong(long v) throws IOException {
-    buffer.writeLong(v);
+    buffer.writeInt64(v);
   }
 
   @Override
   public void writeFloat(float v) throws IOException {
-    buffer.writeFloat(v);
+    buffer.writeFloat32(v);
   }
 
   @Override
   public void writeDouble(double v) throws IOException {
-    buffer.writeDouble(v);
+    buffer.writeFloat64(v);
   }
 
   @Override

--- a/java/fury-core/src/main/java/org/apache/fury/memory/BigEndian.java
+++ b/java/fury-core/src/main/java/org/apache/fury/memory/BigEndian.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fury.memory;
+
+public class BigEndian {
+  /** Get short in big endian order from provided buffer. */
+  public static short getShortB(byte[] b, int off) {
+    return (short) ((b[off + 1] & 0xFF) + (b[off] << 8));
+  }
+}

--- a/java/fury-core/src/main/java/org/apache/fury/memory/LittleEndian.java
+++ b/java/fury-core/src/main/java/org/apache/fury/memory/LittleEndian.java
@@ -57,24 +57,24 @@ public class LittleEndian {
     return 5;
   }
 
-  public static void putInt(Object o, long pos, int value) {
+  public static void putInt32(Object o, long pos, int value) {
     if (!Platform.IS_LITTLE_ENDIAN) {
       value = Integer.reverseBytes(value);
     }
     Platform.putInt(o, pos, value);
   }
 
-  public static int getInt(Object o, long pos) {
+  public static int getInt32(Object o, long pos) {
     int i = Platform.getInt(o, pos);
     return Platform.IS_LITTLE_ENDIAN ? i : Integer.reverseBytes(i);
   }
 
-  public static long getLong(Object o, long pos) {
+  public static long getInt64(Object o, long pos) {
     long v = Platform.getLong(o, pos);
     return Platform.IS_LITTLE_ENDIAN ? v : Long.reverseBytes(v);
   }
 
-  public static void putFloat(Object o, long pos, float value) {
+  public static void putFloat32(Object o, long pos, float value) {
     int v = Float.floatToRawIntBits(value);
     if (!Platform.IS_LITTLE_ENDIAN) {
       v = Integer.reverseBytes(v);
@@ -82,7 +82,7 @@ public class LittleEndian {
     Platform.putInt(o, pos, v);
   }
 
-  public static void putDouble(Object o, long pos, double value) {
+  public static void putFloat64(Object o, long pos, double value) {
     long v = Double.doubleToRawLongBits(value);
     if (!Platform.IS_LITTLE_ENDIAN) {
       v = Long.reverseBytes(v);

--- a/java/fury-core/src/main/java/org/apache/fury/memory/LittleEndian.java
+++ b/java/fury-core/src/main/java/org/apache/fury/memory/LittleEndian.java
@@ -1,0 +1,92 @@
+package org.apache.fury.memory;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.fury.util.Platform;
+
+public class LittleEndian {
+  public static int putVarUint36Small(byte[] arr, int index, long v) {
+    if (v >>> 7 == 0) {
+      arr[index] = (byte) v;
+      return 1;
+    }
+    if (v >>> 14 == 0) {
+      arr[index++] = (byte) ((v & 0x7F) | 0x80);
+      arr[index] = (byte) (v >>> 7);
+      return 2;
+    }
+    return bigWriteUint36(arr, index, v);
+  }
+
+  private static int bigWriteUint36(byte[] arr, int index, long v) {
+    if (v >>> 21 == 0) {
+      arr[index++] = (byte) ((v & 0x7F) | 0x80);
+      arr[index++] = (byte) (v >>> 7 | 0x80);
+      arr[index] = (byte) (v >>> 14);
+      return 3;
+    }
+    if (v >>> 28 == 0) {
+      arr[index++] = (byte) ((v & 0x7F) | 0x80);
+      arr[index++] = (byte) (v >>> 7 | 0x80);
+      arr[index++] = (byte) (v >>> 14 | 0x80);
+      arr[index] = (byte) (v >>> 21);
+      return 4;
+    }
+    arr[index++] = (byte) ((v & 0x7F) | 0x80);
+    arr[index++] = (byte) (v >>> 7 | 0x80);
+    arr[index++] = (byte) (v >>> 14 | 0x80);
+    arr[index++] = (byte) (v >>> 21 | 0x80);
+    arr[index] = (byte) (v >>> 28);
+    return 5;
+  }
+
+  public static void putInt(Object o, long pos, int value) {
+    if (!Platform.IS_LITTLE_ENDIAN) {
+      value = Integer.reverseBytes(value);
+    }
+    Platform.putInt(o, pos, value);
+  }
+
+  public static int getInt(Object o, long pos) {
+    int i = Platform.getInt(o, pos);
+    return Platform.IS_LITTLE_ENDIAN ? i : Integer.reverseBytes(i);
+  }
+
+  public static long getLong(Object o, long pos) {
+    long v = Platform.getLong(o, pos);
+    return Platform.IS_LITTLE_ENDIAN ? v : Long.reverseBytes(v);
+  }
+
+  public static void putFloat(Object o, long pos, float value) {
+    int v = Float.floatToRawIntBits(value);
+    if (!Platform.IS_LITTLE_ENDIAN) {
+      v = Integer.reverseBytes(v);
+    }
+    Platform.putInt(o, pos, v);
+  }
+
+  public static void putDouble(Object o, long pos, double value) {
+    long v = Double.doubleToRawLongBits(value);
+    if (!Platform.IS_LITTLE_ENDIAN) {
+      v = Long.reverseBytes(v);
+    }
+    Platform.putLong(o, pos, v);
+  }
+}

--- a/java/fury-core/src/main/java/org/apache/fury/memory/MemoryBuffer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/memory/MemoryBuffer.java
@@ -1332,38 +1332,8 @@ public final class MemoryBuffer {
       streamReader.fillBuffer(2 - remaining);
     }
     readerIndex = readerIdx + 2;
-    final long pos = address + readerIdx;
-    if (LITTLE_ENDIAN) {
-      return UNSAFE.getChar(heapMemory, pos);
-    } else {
-      return Character.reverseBytes(UNSAFE.getChar(heapMemory, pos));
-    }
-  }
-
-  // Reduce method body for better inline in the caller.
-  @CodegenInvoke
-  public char readCharOnLE() {
-    int readerIdx = readerIndex;
-    // use subtract to avoid overflow
-    int remaining = size - readerIdx;
-    if (remaining < 2) {
-      streamReader.fillBuffer(2 - remaining);
-    }
-    readerIndex = readerIdx + 2;
-    return UNSAFE.getChar(heapMemory, address + readerIdx);
-  }
-
-  // Reduce method body for better inline in the caller.
-  @CodegenInvoke
-  public char readCharOnBE() {
-    int readerIdx = readerIndex;
-    // use subtract to avoid overflow
-    int remaining = size - readerIdx;
-    if (remaining < 2) {
-      streamReader.fillBuffer(2 - remaining);
-    }
-    readerIndex = readerIdx + 2;
-    return Character.reverseBytes(UNSAFE.getChar(heapMemory, address + readerIdx));
+    char c = UNSAFE.getChar(heapMemory, address + readerIdx);
+    return LITTLE_ENDIAN ? c : Character.reverseBytes(c);
   }
 
   public short readInt16() {
@@ -1495,14 +1465,14 @@ public final class MemoryBuffer {
   /** Read fury SLI(Small Long as Int) encoded long. */
   public long readSliInt64() {
     if (LITTLE_ENDIAN) {
-      return readSliInt64OnLE();
+      return _readSliInt64OnLE();
     } else {
-      return readSliInt64OnBE();
+      return _readSliInt64OnBE();
     }
   }
 
   @CodegenInvoke
-  public long readSliInt64OnLE() {
+  public long _readSliInt64OnLE() {
     // Duplicate and manual inline for performance.
     // noinspection Duplicates
     final int readIdx = readerIndex;
@@ -1523,7 +1493,7 @@ public final class MemoryBuffer {
   }
 
   @CodegenInvoke
-  public long readSliInt64OnBE() {
+  public long _readSliInt64OnBE() {
     // noinspection Duplicates
     final int readIdx = readerIndex;
     int diff = size - readIdx;
@@ -1560,7 +1530,7 @@ public final class MemoryBuffer {
 
   // Reduce method body for better inline in the caller.
   @CodegenInvoke
-  public float readFloat32OnLE() {
+  public float _readFloat32OnLE() {
     int readerIdx = readerIndex;
     // use subtract to avoid overflow
     int remaining = size - readerIdx;
@@ -1573,7 +1543,7 @@ public final class MemoryBuffer {
 
   // Reduce method body for better inline in the caller.
   @CodegenInvoke
-  public float readFloat32OnBE() {
+  public float _readFloat32OnBE() {
     int readerIdx = readerIndex;
     // use subtract to avoid overflow
     int remaining = size - readerIdx;
@@ -1582,7 +1552,7 @@ public final class MemoryBuffer {
     }
     readerIndex = readerIdx + 4;
     return Float.intBitsToFloat(
-        Integer.reverseBytes(UNSAFE.getInt(heapMemory, address + readerIdx)));
+      Integer.reverseBytes(UNSAFE.getInt(heapMemory, address + readerIdx)));
   }
 
   public double readFloat64() {
@@ -1603,7 +1573,7 @@ public final class MemoryBuffer {
 
   // Reduce method body for better inline in the caller.
   @CodegenInvoke
-  public double readFloat64OnLE() {
+  public double _readFloat64OnLE() {
     int readerIdx = readerIndex;
     // use subtract to avoid overflow
     int remaining = size - readerIdx;
@@ -1616,7 +1586,7 @@ public final class MemoryBuffer {
 
   // Reduce method body for better inline in the caller.
   @CodegenInvoke
-  public double readFloat64OnBE() {
+  public double _readFloat64OnBE() {
     int readerIdx = readerIndex;
     // use subtract to avoid overflow
     int remaining = size - readerIdx;
@@ -1632,15 +1602,15 @@ public final class MemoryBuffer {
   @CodegenInvoke
   public int readVarInt32() {
     if (LITTLE_ENDIAN) {
-      return readVarInt32OnLE();
+      return _readVarInt32OnLE();
     } else {
-      return readVarInt32OnBE();
+      return _readVarInt32OnBE();
     }
   }
 
   /** Reads the 1-5 byte as a varint on a little endian mache. */
   @CodegenInvoke
-  public int readVarInt32OnLE() {
+  public int _readVarInt32OnLE() {
     // noinspection Duplicates
     int readIdx = readerIndex;
     int result;
@@ -1681,7 +1651,7 @@ public final class MemoryBuffer {
 
   /** Reads the 1-5 byte as a varint on a big endian mache. */
   @CodegenInvoke
-  public int readVarInt32OnBE() {
+  public int _readVarInt32OnBE() {
     // noinspection Duplicates
     int readIdx = readerIndex;
     int result;
@@ -1878,11 +1848,11 @@ public final class MemoryBuffer {
 
   /** Reads the 1-9 byte int part of a var long. */
   public long readVarInt64() {
-    return LITTLE_ENDIAN ? readVarInt64OnLE() : readVarInt64OnBE();
+    return LITTLE_ENDIAN ? _readVarInt64OnLE() : _readVarInt64OnBE();
   }
 
   @CodegenInvoke
-  public long readVarInt64OnLE() {
+  public long _readVarInt64OnLE() {
     // Duplicate and manual inline for performance.
     // noinspection Duplicates
     int readIdx = readerIndex;
@@ -1912,7 +1882,7 @@ public final class MemoryBuffer {
   }
 
   @CodegenInvoke
-  public long readVarInt64OnBE() {
+  public long _readVarInt64OnBE() {
     int readIdx = readerIndex;
     long result;
     if (size - readIdx < 9) {

--- a/java/fury-core/src/main/java/org/apache/fury/memory/MemoryBuffer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/memory/MemoryBuffer.java
@@ -408,7 +408,9 @@ public final class MemoryBuffer {
     Platform.copyMemory(src, arrayAddress, heapMemory, pos, length);
   }
 
+  // CHECKSTYLE.OFF:MethodName
   public void _unsafePut(int index, byte b) {
+    // CHECKSTYLE.ON:MethodName
     final long pos = address + index;
     UNSAFE.putByte(heapMemory, pos, b);
   }
@@ -457,7 +459,9 @@ public final class MemoryBuffer {
     }
   }
 
+  // CHECKSTYLE.OFF:MethodName
   public void _unsafePutShort(int index, short value) {
+    // CHECKSTYLE.ON:MethodName
     final long pos = address + index;
     if (LITTLE_ENDIAN) {
       UNSAFE.putShort(heapMemory, pos, value);
@@ -524,7 +528,9 @@ public final class MemoryBuffer {
     }
   }
 
+  // CHECKSTYLE.OFF:MethodName
   long _unsafeGetLong(int index) {
+    // CHECKSTYLE.ON:MethodName
     final long pos = address + index;
     if (LITTLE_ENDIAN) {
       return UNSAFE.getLong(heapMemory, pos);
@@ -533,7 +539,9 @@ public final class MemoryBuffer {
     }
   }
 
+  // CHECKSTYLE.OFF:MethodName
   public void _unsafePutLong(int index, long value) {
+    // CHECKSTYLE.ON:MethodName
     final long pos = address + index;
     if (LITTLE_ENDIAN) {
       UNSAFE.putLong(heapMemory, pos, value);
@@ -648,7 +656,9 @@ public final class MemoryBuffer {
     writerIndex = newIdx;
   }
 
+  // CHECKSTYLE.OFF:MethodName
   public void _unsafeWriteByte(byte value) {
+    // CHECKSTYLE.ON:MethodName
     final int writerIdx = writerIndex;
     final int newIdx = writerIdx + 1;
     final long pos = address + writerIdx;
@@ -774,7 +784,9 @@ public final class MemoryBuffer {
    * to avoid using two memory operations.
    */
   @CodegenInvoke
+  // CHECKSTYLE.OFF:MethodName
   public int _unsafeWriteVarInt(int v) {
+    // CHECKSTYLE.ON:MethodName
     // Ensure negatives close to zero is encode in little bytes.
     v = (v << 1) ^ (v >> 31);
     return _unsafeWriteVarUint32(v);
@@ -784,7 +796,9 @@ public final class MemoryBuffer {
    * For implementation efficiency, this method needs at most 8 bytes for writing 5 bytes using long
    * to avoid using two memory operations.
    */
+  // CHECKSTYLE.OFF:MethodName
   public int _unsafeWriteVarUint32(int v) {
+    // CHECKSTYLE.ON:MethodName
     int varintBytes = _unsafePutVarUint36Small(writerIndex, v);
     writerIndex += varintBytes;
     return varintBytes;
@@ -793,7 +807,9 @@ public final class MemoryBuffer {
   /**
    * Caller must ensure there must be at least 8 bytes for writing, otherwise the crash may occur.
    */
+  // CHECKSTYLE.OFF:MethodName
   public int _unsafePutVarUint36Small(int index, long value) {
+    // CHECKSTYLE.ON:MethodName
     long encoded = (value & 0x7F);
     if (value >>> 7 == 0) {
       UNSAFE.putByte(heapMemory, address + index, (byte) value);
@@ -1038,7 +1054,9 @@ public final class MemoryBuffer {
     return _unsafeWriteVarUint64(value);
   }
 
+  // CHECKSTYLE.OFF:MethodName
   private int _unsafeWriteVarUint64(long value) {
+    // CHECKSTYLE.ON:MethodName
     final int writerIndex = this.writerIndex;
     int varInt;
     varInt = (int) (value & 0x7F);
@@ -1112,7 +1130,9 @@ public final class MemoryBuffer {
   private static final byte BIG_LONG_FLAG = 0b1; // bit 0 set, means big long.
 
   /** Write long using fury SLI(Small Long as Int) encoding. */
+  // CHECKSTYLE.OFF:MethodName
   public int _unsafeWriteSliLong(long value) {
+    // CHECKSTYLE.ON:MethodName
     final int writerIndex = this.writerIndex;
     final long pos = address + writerIndex;
     final byte[] heapMemory = this.heapMemory;

--- a/java/fury-core/src/main/java/org/apache/fury/memory/MemoryBuffer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/memory/MemoryBuffer.java
@@ -1055,7 +1055,8 @@ public final class MemoryBuffer {
   }
 
   // CHECKSTYLE.OFF:MethodName
-  private int _unsafeWriteVarUint64(long value) {
+  @CodegenInvoke
+  public int _unsafeWriteVarUint64(long value) {
     // CHECKSTYLE.ON:MethodName
     final int writerIndex = this.writerIndex;
     int varInt;

--- a/java/fury-core/src/main/java/org/apache/fury/memory/MemoryBuffer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/memory/MemoryBuffer.java
@@ -692,7 +692,7 @@ public final class MemoryBuffer {
     writerIndex = newIdx;
   }
 
-  public void writeShort(short value) {
+  public void writeInt16(short value) {
     final int writerIdx = writerIndex;
     final int newIdx = writerIdx + 2;
     ensure(newIdx);
@@ -705,7 +705,7 @@ public final class MemoryBuffer {
     writerIndex = newIdx;
   }
 
-  public void writeInt(int value) {
+  public void writeInt32(int value) {
     final int writerIdx = writerIndex;
     final int newIdx = writerIdx + 4;
     ensure(newIdx);
@@ -718,7 +718,7 @@ public final class MemoryBuffer {
     writerIndex = newIdx;
   }
 
-  public void writeLong(long value) {
+  public void writeInt64(long value) {
     final int writerIdx = writerIndex;
     final int newIdx = writerIdx + 8;
     ensure(newIdx);
@@ -731,7 +731,7 @@ public final class MemoryBuffer {
     writerIndex = newIdx;
   }
 
-  public void writeFloat(float value) {
+  public void writeFloat32(float value) {
     final int writerIdx = writerIndex;
     final int newIdx = writerIdx + 4;
     ensure(newIdx);
@@ -744,7 +744,7 @@ public final class MemoryBuffer {
     writerIndex = newIdx;
   }
 
-  public void writeDouble(double value) {
+  public void writeFloat64(double value) {
     final int writerIdx = writerIndex;
     final int newIdx = writerIdx + 8;
     ensure(newIdx);

--- a/java/fury-core/src/main/java/org/apache/fury/memory/MemoryBuffer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/memory/MemoryBuffer.java
@@ -1047,6 +1047,12 @@ public final class MemoryBuffer {
     return _unsafeWriteVarUint64(value);
   }
 
+  @CodegenInvoke
+  public int _unsafeWriteVarInt64(long value) {
+    value = (value << 1) ^ (value >> 63);
+    return _unsafeWriteVarUint64(value);
+  }
+
   public int writeVarUint64(long value) {
     // Var long encoding algorithm is based kryo UnsafeMemoryOutput.writeVarInt64.
     // var long are written using little endian byte order.

--- a/java/fury-core/src/main/java/org/apache/fury/memory/MemoryBuffer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/memory/MemoryBuffer.java
@@ -1359,7 +1359,7 @@ public final class MemoryBuffer {
     return Character.reverseBytes(UNSAFE.getChar(heapMemory, address + readerIdx));
   }
 
-  public short readShort() {
+  public short readInt16() {
     int readerIdx = readerIndex;
     // use subtract to avoid overflow
     int remaining = size - readerIdx;
@@ -1377,7 +1377,7 @@ public final class MemoryBuffer {
 
   // Reduce method body for better inline in the caller.
   @CodegenInvoke
-  public short readShortOnLE() {
+  public short readInt16OnLE() {
     int readerIdx = readerIndex;
     // use subtract to avoid overflow
     int remaining = size - readerIdx;
@@ -1390,7 +1390,7 @@ public final class MemoryBuffer {
 
   // Reduce method body for better inline in the caller.
   @CodegenInvoke
-  public short readShortOnBE() {
+  public short readInt16OnBE() {
     int readerIdx = readerIndex;
     // use subtract to avoid overflow
     int remaining = size - readerIdx;
@@ -1401,7 +1401,7 @@ public final class MemoryBuffer {
     return Short.reverseBytes(UNSAFE.getShort(heapMemory, address + readerIdx));
   }
 
-  public int readInt() {
+  public int readInt32() {
     int readerIdx = readerIndex;
     // use subtract to avoid overflow
     int remaining = size - readerIdx;
@@ -1419,7 +1419,7 @@ public final class MemoryBuffer {
 
   // Reduce method body for better inline in the caller.
   @CodegenInvoke
-  public int readIntOnLE() {
+  public int readInt32OnLE() {
     int readerIdx = readerIndex;
     // use subtract to avoid overflow
     int remaining = size - readerIdx;
@@ -1432,7 +1432,7 @@ public final class MemoryBuffer {
 
   // Reduce method body for better inline in the caller.
   @CodegenInvoke
-  public int readIntOnBE() {
+  public int readInt32OnBE() {
     int readerIdx = readerIndex;
     // use subtract to avoid overflow
     int remaining = size - readerIdx;
@@ -1443,7 +1443,7 @@ public final class MemoryBuffer {
     return Integer.reverseBytes(UNSAFE.getInt(heapMemory, address + readerIdx));
   }
 
-  public long readLong() {
+  public long readInt64() {
     int readerIdx = readerIndex;
     // use subtract to avoid overflow
     int remaining = size - readerIdx;
@@ -1461,7 +1461,7 @@ public final class MemoryBuffer {
 
   // Reduce method body for better inline in the caller.
   @CodegenInvoke
-  public long readLongOnLE() {
+  public long readInt64OnLE() {
     int readerIdx = readerIndex;
     // use subtract to avoid overflow
     int remaining = size - readerIdx;
@@ -1474,7 +1474,7 @@ public final class MemoryBuffer {
 
   // Reduce method body for better inline in the caller.
   @CodegenInvoke
-  public long readLongOnBE() {
+  public long readInt64OnBE() {
     int readerIdx = readerIndex;
     // use subtract to avoid overflow
     int remaining = size - readerIdx;
@@ -1486,16 +1486,16 @@ public final class MemoryBuffer {
   }
 
   /** Read fury SLI(Small Long as Int) encoded long. */
-  public long readSliLong() {
+  public long readSliInt64On() {
     if (LITTLE_ENDIAN) {
-      return readSliLongOnLE();
+      return readSliInt64OnLE();
     } else {
-      return readSliLongOnBE();
+      return readSliInt64OnBE();
     }
   }
 
   @CodegenInvoke
-  public long readSliLongOnLE() {
+  public long readSliInt64OnLE() {
     // Duplicate and manual inline for performance.
     // noinspection Duplicates
     final int readIdx = readerIndex;
@@ -1516,7 +1516,7 @@ public final class MemoryBuffer {
   }
 
   @CodegenInvoke
-  public long readSliLongOnBE() {
+  public long readSliInt64OnBE() {
     // noinspection Duplicates
     final int readIdx = readerIndex;
     int diff = size - readIdx;
@@ -1535,7 +1535,7 @@ public final class MemoryBuffer {
     return Long.reverseBytes(UNSAFE.getLong(heapMemory, address + readIdx + 1));
   }
 
-  public float readFloat() {
+  public float readFloat32() {
     int readerIdx = readerIndex;
     // use subtract to avoid overflow
     int remaining = size - readerIdx;
@@ -1553,7 +1553,7 @@ public final class MemoryBuffer {
 
   // Reduce method body for better inline in the caller.
   @CodegenInvoke
-  public float readFloatOnLE() {
+  public float readFloat32OnLE() {
     int readerIdx = readerIndex;
     // use subtract to avoid overflow
     int remaining = size - readerIdx;
@@ -1566,7 +1566,7 @@ public final class MemoryBuffer {
 
   // Reduce method body for better inline in the caller.
   @CodegenInvoke
-  public float readFloatOnBE() {
+  public float readFloat32OnBE() {
     int readerIdx = readerIndex;
     // use subtract to avoid overflow
     int remaining = size - readerIdx;
@@ -1578,7 +1578,7 @@ public final class MemoryBuffer {
         Integer.reverseBytes(UNSAFE.getInt(heapMemory, address + readerIdx)));
   }
 
-  public double readDouble() {
+  public double readFloat64() {
     int readerIdx = readerIndex;
     // use subtract to avoid overflow
     int remaining = size - readerIdx;
@@ -1596,7 +1596,7 @@ public final class MemoryBuffer {
 
   // Reduce method body for better inline in the caller.
   @CodegenInvoke
-  public double readDoubleOnLE() {
+  public double readFloat64OnLE() {
     int readerIdx = readerIndex;
     // use subtract to avoid overflow
     int remaining = size - readerIdx;
@@ -1609,7 +1609,7 @@ public final class MemoryBuffer {
 
   // Reduce method body for better inline in the caller.
   @CodegenInvoke
-  public double readDoubleOnBE() {
+  public double readFloat64OnBE() {
     int readerIdx = readerIndex;
     // use subtract to avoid overflow
     int remaining = size - readerIdx;

--- a/java/fury-core/src/main/java/org/apache/fury/memory/MemoryBuffer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/memory/MemoryBuffer.java
@@ -1048,7 +1048,9 @@ public final class MemoryBuffer {
   }
 
   @CodegenInvoke
+  // CHECKSTYLE.OFF:MethodName
   public int _unsafeWriteVarInt64(long value) {
+    // CHECKSTYLE.ON:MethodName
     value = (value << 1) ^ (value >> 63);
     return _unsafeWriteVarUint64(value);
   }
@@ -1438,7 +1440,9 @@ public final class MemoryBuffer {
 
   // Reduce method body for better inline in the caller.
   @CodegenInvoke
-  public long readInt64OnLE() {
+  // CHECKSTYLE.OFF:MethodName
+  public long _readInt64OnLE() {
+    // CHECKSTYLE.ON:MethodName
     int readerIdx = readerIndex;
     // use subtract to avoid overflow
     int remaining = size - readerIdx;
@@ -1451,7 +1455,9 @@ public final class MemoryBuffer {
 
   // Reduce method body for better inline in the caller.
   @CodegenInvoke
-  public long readInt64OnBE() {
+  // CHECKSTYLE.OFF:MethodName
+  public long _readInt64OnBE() {
+    // CHECKSTYLE.ON:MethodName
     int readerIdx = readerIndex;
     // use subtract to avoid overflow
     int remaining = size - readerIdx;
@@ -1472,7 +1478,9 @@ public final class MemoryBuffer {
   }
 
   @CodegenInvoke
+  // CHECKSTYLE.OFF:MethodName
   public long _readSliInt64OnLE() {
+    // CHECKSTYLE.ON:MethodName
     // Duplicate and manual inline for performance.
     // noinspection Duplicates
     final int readIdx = readerIndex;
@@ -1493,7 +1501,9 @@ public final class MemoryBuffer {
   }
 
   @CodegenInvoke
+  // CHECKSTYLE.OFF:MethodName
   public long _readSliInt64OnBE() {
+    // CHECKSTYLE.ON:MethodName
     // noinspection Duplicates
     final int readIdx = readerIndex;
     int diff = size - readIdx;
@@ -1530,7 +1540,9 @@ public final class MemoryBuffer {
 
   // Reduce method body for better inline in the caller.
   @CodegenInvoke
+  // CHECKSTYLE.OFF:MethodName
   public float _readFloat32OnLE() {
+    // CHECKSTYLE.ON:MethodName
     int readerIdx = readerIndex;
     // use subtract to avoid overflow
     int remaining = size - readerIdx;
@@ -1543,7 +1555,9 @@ public final class MemoryBuffer {
 
   // Reduce method body for better inline in the caller.
   @CodegenInvoke
+  // CHECKSTYLE.OFF:MethodName
   public float _readFloat32OnBE() {
+    // CHECKSTYLE.ON:MethodName
     int readerIdx = readerIndex;
     // use subtract to avoid overflow
     int remaining = size - readerIdx;
@@ -1573,7 +1587,9 @@ public final class MemoryBuffer {
 
   // Reduce method body for better inline in the caller.
   @CodegenInvoke
+  // CHECKSTYLE.OFF:MethodName
   public double _readFloat64OnLE() {
+    // CHECKSTYLE.ON:MethodName
     int readerIdx = readerIndex;
     // use subtract to avoid overflow
     int remaining = size - readerIdx;
@@ -1586,7 +1602,9 @@ public final class MemoryBuffer {
 
   // Reduce method body for better inline in the caller.
   @CodegenInvoke
+  // CHECKSTYLE.OFF:MethodName
   public double _readFloat64OnBE() {
+    // CHECKSTYLE.ON:MethodName
     int readerIdx = readerIndex;
     // use subtract to avoid overflow
     int remaining = size - readerIdx;
@@ -1610,7 +1628,9 @@ public final class MemoryBuffer {
 
   /** Reads the 1-5 byte as a varint on a little endian mache. */
   @CodegenInvoke
+  // CHECKSTYLE.OFF:MethodName
   public int _readVarInt32OnLE() {
+    // CHECKSTYLE.ON:MethodName
     // noinspection Duplicates
     int readIdx = readerIndex;
     int result;
@@ -1651,7 +1671,9 @@ public final class MemoryBuffer {
 
   /** Reads the 1-5 byte as a varint on a big endian mache. */
   @CodegenInvoke
+  // CHECKSTYLE.OFF:MethodName
   public int _readVarInt32OnBE() {
+    // CHECKSTYLE.ON:MethodName
     // noinspection Duplicates
     int readIdx = readerIndex;
     int result;
@@ -1852,7 +1874,9 @@ public final class MemoryBuffer {
   }
 
   @CodegenInvoke
+  // CHECKSTYLE.OFF:MethodName
   public long _readVarInt64OnLE() {
+    // CHECKSTYLE.ON:MethodName
     // Duplicate and manual inline for performance.
     // noinspection Duplicates
     int readIdx = readerIndex;
@@ -1882,7 +1906,9 @@ public final class MemoryBuffer {
   }
 
   @CodegenInvoke
+  // CHECKSTYLE.OFF:MethodName
   public long _readVarInt64OnBE() {
+    // CHECKSTYLE.ON:MethodName
     int readIdx = readerIndex;
     long result;
     if (size - readIdx < 9) {

--- a/java/fury-core/src/main/java/org/apache/fury/memory/MemoryBuffer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/memory/MemoryBuffer.java
@@ -1552,7 +1552,7 @@ public final class MemoryBuffer {
     }
     readerIndex = readerIdx + 4;
     return Float.intBitsToFloat(
-      Integer.reverseBytes(UNSAFE.getInt(heapMemory, address + readerIdx)));
+        Integer.reverseBytes(UNSAFE.getInt(heapMemory, address + readerIdx)));
   }
 
   public double readFloat64() {

--- a/java/fury-core/src/main/java/org/apache/fury/memory/MemoryBuffer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/memory/MemoryBuffer.java
@@ -1127,9 +1127,9 @@ public final class MemoryBuffer {
    * encode as 4 bytes int: | little-endian: ((int) value) << 1 |; Otherwise write as 9 bytes: | 0b1
    * | little-endian 8bytes long |
    */
-  public int writeSliLong(long value) {
+  public int writeSliInt64(long value) {
     ensure(writerIndex + 9);
-    return _unsafeWriteSliLong(value);
+    return _unsafeWriteSliInt64(value);
   }
 
   private static final long HALF_MAX_INT_VALUE = Integer.MAX_VALUE / 2;
@@ -1138,7 +1138,7 @@ public final class MemoryBuffer {
 
   /** Write long using fury SLI(Small Long as Int) encoding. */
   // CHECKSTYLE.OFF:MethodName
-  public int _unsafeWriteSliLong(long value) {
+  public int _unsafeWriteSliInt64(long value) {
     // CHECKSTYLE.ON:MethodName
     final int writerIndex = this.writerIndex;
     final long pos = address + writerIndex;
@@ -1493,7 +1493,7 @@ public final class MemoryBuffer {
   }
 
   /** Read fury SLI(Small Long as Int) encoded long. */
-  public long readSliInt64On() {
+  public long readSliInt64() {
     if (LITTLE_ENDIAN) {
       return readSliInt64OnLE();
     } else {

--- a/java/fury-core/src/main/java/org/apache/fury/memory/MemoryUtils.java
+++ b/java/fury-core/src/main/java/org/apache/fury/memory/MemoryUtils.java
@@ -67,11 +67,6 @@ public class MemoryUtils {
     }
   }
 
-  /** Get short in big endian order from provided buffer. */
-  public static short getShortB(byte[] b, int off) {
-    return (short) ((b[off + 1] & 0xFF) + (b[off] << 8));
-  }
-
   // Lazy load offset and also follow graalvm offset auto replace pattern.
   private static class Offset {
     private static final long BAS_BUF_BUF;
@@ -135,71 +130,4 @@ public class MemoryUtils {
     buffer.readerIndex(pos);
   }
 
-  public static int putVarUint36Small(byte[] arr, int index, long v) {
-    if (v >>> 7 == 0) {
-      arr[index] = (byte) v;
-      return 1;
-    }
-    if (v >>> 14 == 0) {
-      arr[index++] = (byte) ((v & 0x7F) | 0x80);
-      arr[index] = (byte) (v >>> 7);
-      return 2;
-    }
-    return bigWriteUint36(arr, index, v);
-  }
-
-  private static int bigWriteUint36(byte[] arr, int index, long v) {
-    if (v >>> 21 == 0) {
-      arr[index++] = (byte) ((v & 0x7F) | 0x80);
-      arr[index++] = (byte) (v >>> 7 | 0x80);
-      arr[index] = (byte) (v >>> 14);
-      return 3;
-    }
-    if (v >>> 28 == 0) {
-      arr[index++] = (byte) ((v & 0x7F) | 0x80);
-      arr[index++] = (byte) (v >>> 7 | 0x80);
-      arr[index++] = (byte) (v >>> 14 | 0x80);
-      arr[index] = (byte) (v >>> 21);
-      return 4;
-    }
-    arr[index++] = (byte) ((v & 0x7F) | 0x80);
-    arr[index++] = (byte) (v >>> 7 | 0x80);
-    arr[index++] = (byte) (v >>> 14 | 0x80);
-    arr[index++] = (byte) (v >>> 21 | 0x80);
-    arr[index] = (byte) (v >>> 28);
-    return 5;
-  }
-
-  public static void putInt(Object o, long pos, int value) {
-    if (!Platform.IS_LITTLE_ENDIAN) {
-      value = Integer.reverseBytes(value);
-    }
-    Platform.putInt(o, pos, value);
-  }
-
-  public static int getInt(Object o, long pos) {
-    int i = Platform.getInt(o, pos);
-    return Platform.IS_LITTLE_ENDIAN ? i : Integer.reverseBytes(i);
-  }
-
-  public static long getLong(Object o, long pos) {
-    long v = Platform.getLong(o, pos);
-    return Platform.IS_LITTLE_ENDIAN ? v : Long.reverseBytes(v);
-  }
-
-  public static void putFloat(Object o, long pos, float value) {
-    int v = Float.floatToRawIntBits(value);
-    if (!Platform.IS_LITTLE_ENDIAN) {
-      v = Integer.reverseBytes(v);
-    }
-    Platform.putInt(o, pos, v);
-  }
-
-  public static void putDouble(Object o, long pos, double value) {
-    long v = Double.doubleToRawLongBits(value);
-    if (!Platform.IS_LITTLE_ENDIAN) {
-      v = Long.reverseBytes(v);
-    }
-    Platform.putLong(o, pos, v);
-  }
 }

--- a/java/fury-core/src/main/java/org/apache/fury/memory/MemoryUtils.java
+++ b/java/fury-core/src/main/java/org/apache/fury/memory/MemoryUtils.java
@@ -129,5 +129,4 @@ public class MemoryUtils {
     buffer.pointTo(buf, 0, count);
     buffer.readerIndex(pos);
   }
-
 }

--- a/java/fury-core/src/main/java/org/apache/fury/memory/MemoryUtils.java
+++ b/java/fury-core/src/main/java/org/apache/fury/memory/MemoryUtils.java
@@ -190,7 +190,7 @@ public class MemoryUtils {
   public static void putFloat(Object o, long pos, float value) {
     int v = Float.floatToRawIntBits(value);
     if (!Platform.IS_LITTLE_ENDIAN) {
-      v =  Integer.reverseBytes(v);
+      v = Integer.reverseBytes(v);
     }
     Platform.putInt(o, pos, v);
   }

--- a/java/fury-core/src/main/java/org/apache/fury/memory/MemoryUtils.java
+++ b/java/fury-core/src/main/java/org/apache/fury/memory/MemoryUtils.java
@@ -67,6 +67,11 @@ public class MemoryUtils {
     }
   }
 
+  /** Get short in big endian order from provided buffer. */
+  public static short getShortB(byte[] b, int off) {
+    return (short) ((b[off + 1] & 0xFF) + (b[off] << 8));
+  }
+
   // Lazy load offset and also follow graalvm offset auto replace pattern.
   private static class Offset {
     private static final long BAS_BUF_BUF;
@@ -163,5 +168,38 @@ public class MemoryUtils {
     arr[index++] = (byte) (v >>> 21 | 0x80);
     arr[index] = (byte) (v >>> 28);
     return 5;
+  }
+
+  public static void putInt(Object o, long pos, int value) {
+    if (!Platform.IS_LITTLE_ENDIAN) {
+      value = Integer.reverseBytes(value);
+    }
+    Platform.putInt(o, pos, value);
+  }
+
+  public static int getInt(Object o, long pos) {
+    int i = Platform.getInt(o, pos);
+    return Platform.IS_LITTLE_ENDIAN ? i : Integer.reverseBytes(i);
+  }
+
+  public static long getLong(Object o, long pos) {
+    long v = Platform.getLong(o, pos);
+    return Platform.IS_LITTLE_ENDIAN ? v : Long.reverseBytes(v);
+  }
+
+  public static void putFloat(Object o, long pos, float value) {
+    int v = Float.floatToRawIntBits(value);
+    if (!Platform.IS_LITTLE_ENDIAN) {
+      v =  Integer.reverseBytes(v);
+    }
+    Platform.putInt(o, pos, v);
+  }
+
+  public static void putDouble(Object o, long pos, double value) {
+    long v = Double.doubleToRawLongBits(value);
+    if (!Platform.IS_LITTLE_ENDIAN) {
+      v = Long.reverseBytes(v);
+    }
+    Platform.putLong(o, pos, v);
   }
 }

--- a/java/fury-core/src/main/java/org/apache/fury/resolver/ClassResolver.java
+++ b/java/fury-core/src/main/java/org/apache/fury/resolver/ClassResolver.java
@@ -1457,7 +1457,7 @@ public class ClassResolver {
 
   // Note: Thread safe fot jit thread to call.
   public Expression writeClassExpr(Expression buffer, Expression classId) {
-    return new Invoke(buffer, "writeVarUint", new Expression.BitShift("<<", classId, 1));
+    return new Invoke(buffer, "writeVarUint32", new Expression.BitShift("<<", classId, 1));
   }
 
   // Invoked by Fury JIT.

--- a/java/fury-core/src/main/java/org/apache/fury/resolver/ClassResolver.java
+++ b/java/fury-core/src/main/java/org/apache/fury/resolver/ClassResolver.java
@@ -1205,9 +1205,9 @@ public class ClassResolver {
   public void writeClassAndUpdateCache(MemoryBuffer buffer, Class<?> cls) {
     // fast path for common type
     if (cls == Integer.class) {
-      buffer.writePositiveVarInt(INTEGER_CLASS_ID << 1);
+      buffer.writeVarUint32(INTEGER_CLASS_ID << 1);
     } else if (cls == Long.class) {
-      buffer.writePositiveVarInt(LONG_CLASS_ID << 1);
+      buffer.writeVarUint32(LONG_CLASS_ID << 1);
     } else {
       writeClass(buffer, getOrUpdateClassInfo(cls));
     }
@@ -1241,7 +1241,7 @@ public class ClassResolver {
       }
     } else {
       // use classId
-      buffer.writePositiveVarInt(classInfo.classId << 1);
+      buffer.writeVarUint32(classInfo.classId << 1);
     }
   }
 
@@ -1255,9 +1255,9 @@ public class ClassResolver {
     int newId = classMap.size;
     int id = classMap.putOrGet(classInfo.cls, newId);
     if (id >= 0) {
-      buffer.writePositiveVarInt(id);
+      buffer.writeVarUint32(id);
     } else {
-      buffer.writePositiveVarInt(newId);
+      buffer.writeVarUint32(newId);
       ClassDef classDef;
       Serializer<?> serializer = classInfo.serializer;
       Preconditions.checkArgument(serializer.getClass() != UnexistedClassSerializer.class);
@@ -1381,7 +1381,7 @@ public class ClassResolver {
    */
   public void writeClassDefs(MemoryBuffer buffer) {
     MetaContext metaContext = fury.getSerializationContext().getMetaContext();
-    buffer.writePositiveVarInt(metaContext.writingClassDefs.size());
+    buffer.writeVarUint32(metaContext.writingClassDefs.size());
     for (ClassDef classDef : metaContext.writingClassDefs) {
       classDef.writeClassDef(buffer);
     }
@@ -1457,7 +1457,7 @@ public class ClassResolver {
 
   // Note: Thread safe fot jit thread to call.
   public Expression writeClassExpr(Expression buffer, Expression classId) {
-    return new Invoke(buffer, "writePositiveVarInt", new Expression.BitShift("<<", classId, 1));
+    return new Invoke(buffer, "writeVarUint", new Expression.BitShift("<<", classId, 1));
   }
 
   // Invoked by Fury JIT.

--- a/java/fury-core/src/main/java/org/apache/fury/resolver/ClassResolver.java
+++ b/java/fury-core/src/main/java/org/apache/fury/resolver/ClassResolver.java
@@ -1395,7 +1395,7 @@ public class ClassResolver {
    */
   public void readClassDefs(MemoryBuffer buffer) {
     MetaContext metaContext = fury.getSerializationContext().getMetaContext();
-    int classDefOffset = buffer.readInt();
+    int classDefOffset = buffer.readInt32();
     int readerIndex = buffer.readerIndex();
     buffer.readerIndex(classDefOffset);
     int numClassDefs = buffer.readVarUintSmall();

--- a/java/fury-core/src/main/java/org/apache/fury/resolver/ClassResolver.java
+++ b/java/fury-core/src/main/java/org/apache/fury/resolver/ClassResolver.java
@@ -772,7 +772,6 @@ public class ClassResolver {
   }
 
   public Class<? extends Serializer> getSerializerClass(Class<?> cls) {
-
     boolean codegen =
         supportCodegenForJavaSerialization(cls) && fury.getConfig().isCodeGenEnabled();
     return getSerializerClass(cls, codegen);

--- a/java/fury-core/src/main/java/org/apache/fury/resolver/EnumStringResolver.java
+++ b/java/fury-core/src/main/java/org/apache/fury/resolver/EnumStringResolver.java
@@ -109,18 +109,18 @@ public final class EnumStringResolver {
 
   EnumStringBytes readEnumStringBytes(MemoryBuffer buffer) {
     if (buffer.readByte() == USE_STRING_VALUE) {
-      long hashCode = buffer.readLong();
+      long hashCode = buffer.readInt64();
       EnumStringBytes byteString = trySkipEnumStringBytes(buffer, hashCode);
       updateDynamicString(byteString);
       return byteString;
     } else {
-      return dynamicReadStringIds[buffer.readShort()];
+      return dynamicReadStringIds[buffer.readInt16()];
     }
   }
 
   EnumStringBytes readEnumStringBytes(MemoryBuffer buffer, EnumStringBytes cache) {
     if (buffer.readByte() == USE_STRING_VALUE) {
-      long hashCode = buffer.readLong();
+      long hashCode = buffer.readInt64();
       if (cache.hashCode == hashCode) {
         // skip byteString data
         buffer.increaseReaderIndex(2 + cache.bytes.length);
@@ -132,7 +132,7 @@ public final class EnumStringResolver {
         return byteString;
       }
     } else {
-      return dynamicReadStringIds[buffer.readShort()];
+      return dynamicReadStringIds[buffer.readInt16()];
     }
   }
 
@@ -140,7 +140,7 @@ public final class EnumStringResolver {
   private EnumStringBytes trySkipEnumStringBytes(MemoryBuffer buffer, long hashCode) {
     EnumStringBytes byteString = hash2EnumStringBytesMap.get(hashCode);
     if (byteString == null) {
-      int strBytesLength = buffer.readShort();
+      int strBytesLength = buffer.readInt16();
       byte[] strBytes = buffer.readBytes(strBytesLength);
       byteString = new EnumStringBytes(strBytes, hashCode);
       hash2EnumStringBytesMap.put(hashCode, byteString);

--- a/java/fury-core/src/main/java/org/apache/fury/resolver/EnumStringResolver.java
+++ b/java/fury-core/src/main/java/org/apache/fury/resolver/EnumStringResolver.java
@@ -94,16 +94,16 @@ public final class EnumStringResolver {
       dynamicWrittenEnumString[id] = byteString;
       int bytesLen = byteString.bytes.length;
       buffer.increaseWriterIndex(11 + bytesLen);
-      buffer.unsafePut(writerIndex, USE_STRING_VALUE);
+      buffer._unsafePut(writerIndex, USE_STRING_VALUE);
       // Since duplicate enum string writing are avoided by dynamic id,
       // use 8-byte hash won't increase too much space.
-      buffer.unsafePutLong(writerIndex + 1, byteString.hashCode);
-      buffer.unsafePutShort(writerIndex + 9, (short) bytesLen);
+      buffer._unsafePutLong(writerIndex + 1, byteString.hashCode);
+      buffer._unsafePutShort(writerIndex + 9, (short) bytesLen);
       buffer.put(writerIndex + 11, byteString.bytes, 0, bytesLen);
     } else {
       buffer.increaseWriterIndex(3);
-      buffer.unsafePut(writerIndex, USE_STRING_ID);
-      buffer.unsafePutShort(writerIndex + 1, id);
+      buffer._unsafePut(writerIndex, USE_STRING_ID);
+      buffer._unsafePutShort(writerIndex + 1, id);
     }
   }
 

--- a/java/fury-core/src/main/java/org/apache/fury/resolver/FieldResolver.java
+++ b/java/fury-core/src/main/java/org/apache/fury/resolver/FieldResolver.java
@@ -436,7 +436,7 @@ public class FieldResolver {
         fury.readRef(buffer, classInfo.getSerializer());
       }
     } else {
-      long encodedFieldInfo = buffer.readInt();
+      long encodedFieldInfo = buffer.readInt32();
       encodedFieldInfo = encodedFieldInfo << 32 | (partFieldInfo & 0x00000000ffffffffL);
       if ((encodedFieldInfo & 0b11) == SEPARATE_TYPES_HASH_FLAG) {
         // bit `0 0` + field name(62 bits MurmurHash3 hash) + field type + ref + n-bytes class
@@ -527,7 +527,7 @@ public class FieldResolver {
       if (skipDataBy8(buffer, partFieldInfo) != partFieldInfo) {
         return;
       }
-      partFieldInfo = buffer.readLong();
+      partFieldInfo = buffer.readInt64();
     }
     if (partFieldInfo != endTag) {
       throw new IllegalStateException(

--- a/java/fury-core/src/main/java/org/apache/fury/resolver/MapRefResolver.java
+++ b/java/fury-core/src/main/java/org/apache/fury/resolver/MapRefResolver.java
@@ -81,7 +81,7 @@ public final class MapRefResolver implements RefResolver {
       if (writtenRefId >= 0) {
         // The obj has been written previously.
         buffer.unsafeWriteByte(Fury.REF_FLAG);
-        buffer.unsafeWritePositiveVarInt(writtenRefId);
+        buffer.unsafeWriteVarUint32(writtenRefId);
         return true;
       } else {
         // The object is being written for the first time.
@@ -107,7 +107,7 @@ public final class MapRefResolver implements RefResolver {
     if (writtenRefId >= 0) {
       // The obj has been written previously.
       buffer.unsafeWriteByte(Fury.REF_FLAG);
-      buffer.unsafeWritePositiveVarInt(writtenRefId);
+      buffer.unsafeWriteVarUint32(writtenRefId);
       return false;
     } else {
       // The object is being written for the first time.

--- a/java/fury-core/src/main/java/org/apache/fury/resolver/MapRefResolver.java
+++ b/java/fury-core/src/main/java/org/apache/fury/resolver/MapRefResolver.java
@@ -66,7 +66,7 @@ public final class MapRefResolver implements RefResolver {
   public boolean writeRefOrNull(MemoryBuffer buffer, Object obj) {
     buffer.grow(10);
     if (obj == null) {
-      buffer.unsafeWriteByte(Fury.NULL_FLAG);
+      buffer._unsafeWriteByte(Fury.NULL_FLAG);
       return true;
     } else {
       // The id should be consistent with `#nextReadRefId`
@@ -80,12 +80,12 @@ public final class MapRefResolver implements RefResolver {
       }
       if (writtenRefId >= 0) {
         // The obj has been written previously.
-        buffer.unsafeWriteByte(Fury.REF_FLAG);
-        buffer.unsafeWriteVarUint32(writtenRefId);
+        buffer._unsafeWriteByte(Fury.REF_FLAG);
+        buffer._unsafeWriteVarUint32(writtenRefId);
         return true;
       } else {
         // The object is being written for the first time.
-        buffer.unsafeWriteByte(Fury.REF_VALUE_FLAG);
+        buffer._unsafeWriteByte(Fury.REF_VALUE_FLAG);
         return false;
       }
     }
@@ -106,12 +106,12 @@ public final class MapRefResolver implements RefResolver {
     }
     if (writtenRefId >= 0) {
       // The obj has been written previously.
-      buffer.unsafeWriteByte(Fury.REF_FLAG);
-      buffer.unsafeWriteVarUint32(writtenRefId);
+      buffer._unsafeWriteByte(Fury.REF_FLAG);
+      buffer._unsafeWriteVarUint32(writtenRefId);
       return false;
     } else {
       // The object is being written for the first time.
-      buffer.unsafeWriteByte(Fury.REF_VALUE_FLAG);
+      buffer._unsafeWriteByte(Fury.REF_VALUE_FLAG);
       return true;
     }
   }
@@ -119,7 +119,7 @@ public final class MapRefResolver implements RefResolver {
   @Override
   public boolean writeNullFlag(MemoryBuffer buffer, Object obj) {
     if (obj == null) {
-      buffer.unsafeWriteByte(Fury.NULL_FLAG);
+      buffer._unsafeWriteByte(Fury.NULL_FLAG);
       return true;
     }
     return false;

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/ArraySerializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/ArraySerializers.java
@@ -122,7 +122,7 @@ public class ArraySerializers {
     @Override
     public T[] read(MemoryBuffer buffer) {
       // Some jdk8 will crash if use varint, why?
-      int numElements = buffer.readInt();
+      int numElements = buffer.readInt32();
       Object[] value = newArray(numElements);
       RefResolver refResolver = fury.getRefResolver();
       refResolver.reference(value);

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/ArraySerializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/ArraySerializers.java
@@ -82,7 +82,7 @@ public class ArraySerializers {
     @Override
     public void write(MemoryBuffer buffer, T[] arr) {
       int len = arr.length;
-      buffer.writeInt(len);
+      buffer.writeInt32(len);
       RefResolver refResolver = fury.getRefResolver();
       Serializer componentSerializer = this.componentTypeSerializer;
       if (componentSerializer != null) {

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/ArraySerializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/ArraySerializers.java
@@ -112,7 +112,7 @@ public class ArraySerializers {
     @Override
     public void xwrite(MemoryBuffer buffer, T[] arr) {
       int len = arr.length;
-      buffer.writePositiveVarInt(len);
+      buffer.writeVarUint32(len);
       // TODO(chaokunyang) use generics by creating component serializers to multi-dimension array.
       for (T t : arr) {
         fury.xwriteRef(buffer, t);
@@ -160,7 +160,7 @@ public class ArraySerializers {
 
     @Override
     public T[] xread(MemoryBuffer buffer) {
-      int numElements = buffer.readPositiveVarInt();
+      int numElements = buffer.readVarUint32();
       Object[] value = newArray(numElements);
       for (int i = 0; i < numElements; i++) {
         value[i] = fury.xreadRef(buffer);
@@ -268,7 +268,7 @@ public class ArraySerializers {
         buf.copyToUnsafe(0, values, offset, size);
         return values;
       } else {
-        int size = buffer.readPositiveVarInt();
+        int size = buffer.readVarUint32();
         int numElements = size / elemSize;
         boolean[] values = new boolean[numElements];
         buffer.readToUnsafe(values, offset, size);
@@ -303,7 +303,7 @@ public class ArraySerializers {
         buf.copyToUnsafe(0, values, offset, size);
         return values;
       } else {
-        int size = buffer.readPositiveVarInt();
+        int size = buffer.readVarUint32();
         byte[] values = new byte[size];
         buffer.readToUnsafe(values, offset, size);
         return values;
@@ -338,7 +338,7 @@ public class ArraySerializers {
         buf.copyToUnsafe(0, values, offset, size);
         return values;
       } else {
-        int size = buffer.readPositiveVarInt();
+        int size = buffer.readVarUint32();
         int numElements = size / elemSize;
         char[] values = new char[numElements];
         buffer.readToUnsafe(values, offset, size);
@@ -389,7 +389,7 @@ public class ArraySerializers {
         buf.copyToUnsafe(0, values, offset, size);
         return values;
       } else {
-        int size = buffer.readPositiveVarInt();
+        int size = buffer.readVarUint32();
         int numElements = size / elemSize;
         short[] values = new short[numElements];
         buffer.readToUnsafe(values, offset, size);
@@ -425,7 +425,7 @@ public class ArraySerializers {
         buf.copyToUnsafe(0, values, offset, size);
         return values;
       } else {
-        int size = buffer.readPositiveVarInt();
+        int size = buffer.readVarUint32();
         int numElements = size / elemSize;
         int[] values = new int[numElements];
         buffer.readToUnsafe(values, offset, size);
@@ -461,7 +461,7 @@ public class ArraySerializers {
         buf.copyToUnsafe(0, values, offset, size);
         return values;
       } else {
-        int size = buffer.readPositiveVarInt();
+        int size = buffer.readVarUint32();
         int numElements = size / elemSize;
         long[] values = new long[numElements];
         buffer.readToUnsafe(values, offset, size);
@@ -497,7 +497,7 @@ public class ArraySerializers {
         buf.copyToUnsafe(0, values, offset, size);
         return values;
       } else {
-        int size = buffer.readPositiveVarInt();
+        int size = buffer.readVarUint32();
         int numElements = size / elemSize;
         float[] values = new float[numElements];
         buffer.readToUnsafe(values, offset, size);
@@ -533,7 +533,7 @@ public class ArraySerializers {
         buf.copyToUnsafe(0, values, offset, size);
         return values;
       } else {
-        int size = buffer.readPositiveVarInt();
+        int size = buffer.readVarUint32();
         int numElements = size / elemSize;
         double[] values = new double[numElements];
         buffer.readToUnsafe(values, offset, size);
@@ -563,7 +563,7 @@ public class ArraySerializers {
     @Override
     public void write(MemoryBuffer buffer, String[] value) {
       int len = value.length;
-      buffer.writePositiveVarInt(len);
+      buffer.writeVarUint32(len);
       if (len == 0) {
         return;
       }
@@ -615,7 +615,7 @@ public class ArraySerializers {
     @Override
     public void xwrite(MemoryBuffer buffer, String[] value) {
       int len = value.length;
-      buffer.writePositiveVarInt(len);
+      buffer.writeVarUint32(len);
       for (String elem : value) {
         if (elem != null) {
           buffer.writeByte(Fury.REF_VALUE_FLAG);
@@ -628,7 +628,7 @@ public class ArraySerializers {
 
     @Override
     public String[] xread(MemoryBuffer buffer) {
-      int numElements = buffer.readPositiveVarInt();
+      int numElements = buffer.readVarUint32();
       String[] value = new String[numElements];
       for (int i = 0; i < numElements; i++) {
         if (buffer.readByte() == Fury.REF_VALUE_FLAG) {
@@ -660,7 +660,7 @@ public class ArraySerializers {
   static void writePrimitiveArray(
       MemoryBuffer buffer, Object arr, int offset, int numElements, int elemSize) {
     int size = Math.multiplyExact(numElements, elemSize);
-    buffer.writePositiveVarInt(size);
+    buffer.writeVarUint32(size);
     int writerIndex = buffer.writerIndex();
     int end = writerIndex + size;
     buffer.ensure(end);

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/CompatibleSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/CompatibleSerializer.java
@@ -313,7 +313,7 @@ public final class CompatibleSerializer<T> extends CompatibleSerializerBase<T> {
     if (partFieldInfo == endTag) {
       return obj;
     }
-    long tmp = buffer.readInt();
+    long tmp = buffer.readInt32();
     partFieldInfo = tmp << 32 | (partFieldInfo & 0x00000000ffffffffL);
     partFieldInfo =
         readEmbedTypes9Fields(buffer, partFieldInfo, obj, null, INDEX_FOR_SKIP_FILL_VALUES);
@@ -337,7 +337,7 @@ public final class CompatibleSerializer<T> extends CompatibleSerializerBase<T> {
       return;
     }
     startIndex += fieldResolver.getEmbedTypes4Fields().length;
-    long tmp = buffer.readInt();
+    long tmp = buffer.readInt32();
     partFieldInfo = tmp << 32 | (partFieldInfo & 0x00000000ffffffffL);
     partFieldInfo = readEmbedTypes9Fields(buffer, partFieldInfo, null, vals, startIndex);
     if (partFieldInfo == endTag) {
@@ -354,7 +354,7 @@ public final class CompatibleSerializer<T> extends CompatibleSerializerBase<T> {
 
   private long readEmbedTypes4Fields(
       MemoryBuffer buffer, Object obj, Object[] vals, int startIndex) {
-    long partFieldInfo = buffer.readInt();
+    long partFieldInfo = buffer.readInt32();
     FieldResolver.FieldInfo[] embedTypes4Fields = fieldResolver.getEmbedTypes4Fields();
     if (embedTypes4Fields.length > 0) {
       long minFieldInfo = embedTypes4Fields[0].getEncodedFieldInfo();
@@ -364,7 +364,7 @@ public final class CompatibleSerializer<T> extends CompatibleSerializerBase<T> {
         if (part != partFieldInfo) {
           return part;
         }
-        partFieldInfo = buffer.readInt();
+        partFieldInfo = buffer.readInt32();
       }
       for (int i = 0; i < embedTypes4Fields.length; i++) {
         FieldResolver.FieldInfo fieldInfo = embedTypes4Fields[i];
@@ -375,7 +375,7 @@ public final class CompatibleSerializer<T> extends CompatibleSerializerBase<T> {
           } else {
             vals[startIndex + i] = readFieldValue(fieldInfo, buffer);
           }
-          partFieldInfo = buffer.readInt();
+          partFieldInfo = buffer.readInt32();
         } else {
           if ((partFieldInfo & 0b11) == FieldResolver.EMBED_TYPES_4_FLAG) {
             if (partFieldInfo < encodedFieldInfo) {
@@ -383,7 +383,7 @@ public final class CompatibleSerializer<T> extends CompatibleSerializerBase<T> {
               if (part != partFieldInfo) {
                 return part;
               }
-              partFieldInfo = buffer.readInt();
+              partFieldInfo = buffer.readInt32();
               i--;
             }
           } else {
@@ -397,7 +397,7 @@ public final class CompatibleSerializer<T> extends CompatibleSerializerBase<T> {
       if (part != partFieldInfo) {
         return part;
       }
-      partFieldInfo = buffer.readInt();
+      partFieldInfo = buffer.readInt32();
     }
     return partFieldInfo;
   }
@@ -413,7 +413,7 @@ public final class CompatibleSerializer<T> extends CompatibleSerializerBase<T> {
         if (part != partFieldInfo) {
           return part;
         }
-        partFieldInfo = buffer.readLong();
+        partFieldInfo = buffer.readInt64();
       }
 
       for (int i = 0; i < embedTypes9Fields.length; i++) {
@@ -425,7 +425,7 @@ public final class CompatibleSerializer<T> extends CompatibleSerializerBase<T> {
           } else {
             vals[startIndex + i] = readFieldValue(fieldInfo, buffer);
           }
-          partFieldInfo = buffer.readLong();
+          partFieldInfo = buffer.readInt64();
         } else {
           if ((partFieldInfo & 0b111) == FieldResolver.EMBED_TYPES_9_FLAG) {
             if (partFieldInfo < encodedFieldInfo) {
@@ -433,7 +433,7 @@ public final class CompatibleSerializer<T> extends CompatibleSerializerBase<T> {
               if (part != partFieldInfo) {
                 return part;
               }
-              partFieldInfo = buffer.readLong();
+              partFieldInfo = buffer.readInt64();
               i--;
             }
           } else {
@@ -447,7 +447,7 @@ public final class CompatibleSerializer<T> extends CompatibleSerializerBase<T> {
       if (part != partFieldInfo) {
         return part;
       }
-      partFieldInfo = buffer.readLong();
+      partFieldInfo = buffer.readInt64();
     }
     return partFieldInfo;
   }
@@ -463,7 +463,7 @@ public final class CompatibleSerializer<T> extends CompatibleSerializerBase<T> {
         if (part != partFieldInfo) {
           return part;
         }
-        partFieldInfo = buffer.readLong();
+        partFieldInfo = buffer.readInt64();
       }
 
       for (int i = 0; i < embedTypesHashFields.length; i++) {
@@ -475,7 +475,7 @@ public final class CompatibleSerializer<T> extends CompatibleSerializerBase<T> {
           } else {
             vals[startIndex + i] = readFieldValue(fieldInfo, buffer);
           }
-          partFieldInfo = buffer.readLong();
+          partFieldInfo = buffer.readInt64();
         } else {
           if ((partFieldInfo & 0b111) == FieldResolver.EMBED_TYPES_HASH_FLAG) {
             if (partFieldInfo < encodedFieldInfo) {
@@ -483,7 +483,7 @@ public final class CompatibleSerializer<T> extends CompatibleSerializerBase<T> {
               if (part != partFieldInfo) {
                 return part;
               }
-              partFieldInfo = buffer.readLong();
+              partFieldInfo = buffer.readInt64();
               i--;
             }
           } else {
@@ -497,7 +497,7 @@ public final class CompatibleSerializer<T> extends CompatibleSerializerBase<T> {
       if (part != partFieldInfo) {
         return part;
       }
-      partFieldInfo = buffer.readLong();
+      partFieldInfo = buffer.readInt64();
     }
     return partFieldInfo;
   }
@@ -513,7 +513,7 @@ public final class CompatibleSerializer<T> extends CompatibleSerializerBase<T> {
         if (part != partFieldInfo) {
           return;
         }
-        partFieldInfo = buffer.readLong();
+        partFieldInfo = buffer.readInt64();
       }
       for (int i = 0; i < separateTypesHashFields.length; i++) {
         FieldResolver.FieldInfo fieldInfo = separateTypesHashFields[i];
@@ -524,7 +524,7 @@ public final class CompatibleSerializer<T> extends CompatibleSerializerBase<T> {
           } else {
             vals[startIndex + i] = readFieldValue(fieldInfo, buffer);
           }
-          partFieldInfo = buffer.readLong();
+          partFieldInfo = buffer.readInt64();
         } else {
           if ((partFieldInfo & 0b11) == FieldResolver.SEPARATE_TYPES_HASH_FLAG) {
             if (partFieldInfo < encodedFieldInfo) {
@@ -532,7 +532,7 @@ public final class CompatibleSerializer<T> extends CompatibleSerializerBase<T> {
               if (part != partFieldInfo) {
                 return;
               }
-              partFieldInfo = buffer.readLong();
+              partFieldInfo = buffer.readInt64();
               i--;
             }
           } else {
@@ -575,19 +575,19 @@ public final class CompatibleSerializer<T> extends CompatibleSerializerBase<T> {
       case ClassResolver.PRIMITIVE_CHAR_CLASS_ID:
         return buffer.readChar();
       case ClassResolver.PRIMITIVE_SHORT_CLASS_ID:
-        return buffer.readShort();
+        return buffer.readInt16();
       case ClassResolver.PRIMITIVE_INT_CLASS_ID:
         if (fury.compressInt()) {
           return buffer.readVarInt32();
         } else {
-          return buffer.readInt();
+          return buffer.readInt32();
         }
       case ClassResolver.PRIMITIVE_FLOAT_CLASS_ID:
-        return buffer.readFloat();
+        return buffer.readFloat32();
       case ClassResolver.PRIMITIVE_LONG_CLASS_ID:
-        return fury.readLong(buffer);
+        return fury.readInt64(buffer);
       case ClassResolver.PRIMITIVE_DOUBLE_CLASS_ID:
-        return buffer.readDouble();
+        return buffer.readFloat64();
       case ClassResolver.STRING_CLASS_ID:
         return fury.readJavaStringRef(buffer);
       case ClassResolver.NO_CLASS_ID:

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/CompatibleSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/CompatibleSerializer.java
@@ -94,22 +94,22 @@ public final class CompatibleSerializer<T> extends CompatibleSerializerBase<T> {
   @Override
   public void write(MemoryBuffer buffer, T value) {
     for (FieldResolver.FieldInfo fieldInfo : fieldResolver.getEmbedTypes4Fields()) {
-      buffer.writeInt((int) fieldInfo.getEncodedFieldInfo());
+      buffer.writeInt32((int) fieldInfo.getEncodedFieldInfo());
       readAndWriteFieldValue(buffer, fieldInfo, value);
     }
     for (FieldResolver.FieldInfo fieldInfo : fieldResolver.getEmbedTypes9Fields()) {
-      buffer.writeLong(fieldInfo.getEncodedFieldInfo());
+      buffer.writeInt64(fieldInfo.getEncodedFieldInfo());
       readAndWriteFieldValue(buffer, fieldInfo, value);
     }
     for (FieldResolver.FieldInfo fieldInfo : fieldResolver.getEmbedTypesHashFields()) {
-      buffer.writeLong(fieldInfo.getEncodedFieldInfo());
+      buffer.writeInt64(fieldInfo.getEncodedFieldInfo());
       readAndWriteFieldValue(buffer, fieldInfo, value);
     }
     for (FieldResolver.FieldInfo fieldInfo : fieldResolver.getSeparateTypesHashFields()) {
-      buffer.writeLong(fieldInfo.getEncodedFieldInfo());
+      buffer.writeInt64(fieldInfo.getEncodedFieldInfo());
       readAndWriteFieldValue(buffer, fieldInfo, value);
     }
-    buffer.writeLong(fieldResolver.getEndTag());
+    buffer.writeInt64(fieldResolver.getEndTag());
   }
 
   public void writeFieldsValues(MemoryBuffer buffer, Object[] vals) {
@@ -117,19 +117,19 @@ public final class CompatibleSerializer<T> extends CompatibleSerializerBase<T> {
     Fury fury = this.fury;
     int index = 0;
     for (FieldResolver.FieldInfo fieldInfo : fieldResolver.getEmbedTypes4Fields()) {
-      buffer.writeInt((int) fieldInfo.getEncodedFieldInfo());
+      buffer.writeInt32((int) fieldInfo.getEncodedFieldInfo());
       writeFieldValue(fieldInfo, buffer, vals[index++]);
     }
     for (FieldResolver.FieldInfo fieldInfo : fieldResolver.getEmbedTypes9Fields()) {
-      buffer.writeLong(fieldInfo.getEncodedFieldInfo());
+      buffer.writeInt64(fieldInfo.getEncodedFieldInfo());
       writeFieldValue(fieldInfo, buffer, vals[index++]);
     }
     for (FieldResolver.FieldInfo fieldInfo : fieldResolver.getEmbedTypesHashFields()) {
-      buffer.writeLong(fieldInfo.getEncodedFieldInfo());
+      buffer.writeInt64(fieldInfo.getEncodedFieldInfo());
       writeFieldValue(fieldInfo, buffer, vals[index++]);
     }
     for (FieldResolver.FieldInfo fieldInfo : fieldResolver.getSeparateTypesHashFields()) {
-      buffer.writeLong(fieldInfo.getEncodedFieldInfo());
+      buffer.writeInt64(fieldInfo.getEncodedFieldInfo());
       Object value = vals[index++];
       if (!fury.getRefResolver().writeRefOrNull(buffer, value)) {
         byte fieldType = fieldInfo.getFieldType();
@@ -139,7 +139,7 @@ public final class CompatibleSerializer<T> extends CompatibleSerializerBase<T> {
         fury.writeNonRef(buffer, value, classInfo);
       }
     }
-    buffer.writeLong(fieldResolver.getEndTag());
+    buffer.writeInt64(fieldResolver.getEndTag());
   }
 
   private void readAndWriteFieldValue(
@@ -177,23 +177,23 @@ public final class CompatibleSerializer<T> extends CompatibleSerializerBase<T> {
         buffer.writeChar((Character) fieldValue);
         return;
       case ClassResolver.PRIMITIVE_SHORT_CLASS_ID:
-        buffer.writeShort((Short) fieldValue);
+        buffer.writeInt16((Short) fieldValue);
         return;
       case ClassResolver.PRIMITIVE_INT_CLASS_ID:
         if (fury.compressInt()) {
           buffer.writeVarInt32((Integer) fieldValue);
         } else {
-          buffer.writeInt((Integer) fieldValue);
+          buffer.writeInt32((Integer) fieldValue);
         }
         return;
       case ClassResolver.PRIMITIVE_FLOAT_CLASS_ID:
-        buffer.writeFloat((Float) fieldValue);
+        buffer.writeFloat32((Float) fieldValue);
         return;
       case ClassResolver.PRIMITIVE_LONG_CLASS_ID:
-        fury.writeLong(buffer, (Long) fieldValue);
+        fury.writeInt64(buffer, (Long) fieldValue);
         return;
       case ClassResolver.PRIMITIVE_DOUBLE_CLASS_ID:
-        buffer.writeDouble((Double) fieldValue);
+        buffer.writeFloat64((Double) fieldValue);
         return;
       case ClassResolver.STRING_CLASS_ID:
         fury.writeJavaStringRef(buffer, (String) fieldValue);

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/CompatibleSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/CompatibleSerializer.java
@@ -181,7 +181,7 @@ public final class CompatibleSerializer<T> extends CompatibleSerializerBase<T> {
         return;
       case ClassResolver.PRIMITIVE_INT_CLASS_ID:
         if (fury.compressInt()) {
-          buffer.writeVarInt((Integer) fieldValue);
+          buffer.writeVarInt32((Integer) fieldValue);
         } else {
           buffer.writeInt((Integer) fieldValue);
         }
@@ -578,7 +578,7 @@ public final class CompatibleSerializer<T> extends CompatibleSerializerBase<T> {
         return buffer.readShort();
       case ClassResolver.PRIMITIVE_INT_CLASS_ID:
         if (fury.compressInt()) {
-          return buffer.readVarInt();
+          return buffer.readVarInt32();
         } else {
           return buffer.readInt();
         }

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/JavaSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/JavaSerializer.java
@@ -35,6 +35,7 @@ import org.apache.fury.io.MemoryBufferObjectOutput;
 import org.apache.fury.logging.Logger;
 import org.apache.fury.logging.LoggerFactory;
 import org.apache.fury.memory.MemoryBuffer;
+import org.apache.fury.memory.MemoryUtils;
 import org.apache.fury.resolver.ClassResolver;
 import org.apache.fury.util.Platform;
 
@@ -246,7 +247,7 @@ public class JavaSerializer extends Serializer {
    */
   public static boolean serializedByJDK(byte[] data, int offset) {
     // JDK serialization use big endian byte order.
-    short magicNumber = MemoryBuffer.getShortB(data, offset);
+    short magicNumber = MemoryUtils.getShortB(data, offset);
     return magicNumber == ObjectStreamConstants.STREAM_MAGIC;
   }
 

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/JavaSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/JavaSerializer.java
@@ -34,8 +34,8 @@ import org.apache.fury.io.MemoryBufferObjectInput;
 import org.apache.fury.io.MemoryBufferObjectOutput;
 import org.apache.fury.logging.Logger;
 import org.apache.fury.logging.LoggerFactory;
+import org.apache.fury.memory.BigEndian;
 import org.apache.fury.memory.MemoryBuffer;
-import org.apache.fury.memory.MemoryUtils;
 import org.apache.fury.resolver.ClassResolver;
 import org.apache.fury.util.Platform;
 
@@ -247,7 +247,7 @@ public class JavaSerializer extends Serializer {
    */
   public static boolean serializedByJDK(byte[] data, int offset) {
     // JDK serialization use big endian byte order.
-    short magicNumber = MemoryUtils.getShortB(data, offset);
+    short magicNumber = BigEndian.getShortB(data, offset);
     return magicNumber == ObjectStreamConstants.STREAM_MAGIC;
   }
 

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/MetaSharedSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/MetaSharedSerializer.java
@@ -267,7 +267,7 @@ public class MetaSharedSerializer<T> extends Serializer<T> {
         return false;
       case ClassResolver.PRIMITIVE_INT_CLASS_ID:
         if (fury.compressInt()) {
-          buffer.readVarInt();
+          buffer.readVarInt32();
         } else {
           buffer.increaseReaderIndex(4);
         }

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/MetaSharedSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/MetaSharedSerializer.java
@@ -276,7 +276,7 @@ public class MetaSharedSerializer<T> extends Serializer<T> {
         buffer.increaseReaderIndex(4);
         return false;
       case ClassResolver.PRIMITIVE_LONG_CLASS_ID:
-        fury.readLong(buffer);
+        fury.readInt64(buffer);
         return false;
       case ClassResolver.PRIMITIVE_DOUBLE_CLASS_ID:
         buffer.increaseReaderIndex(8);

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/ObjectSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/ObjectSerializer.java
@@ -321,7 +321,7 @@ public final class ObjectSerializer<T> extends Serializer<T> {
     RefResolver refResolver = this.refResolver;
     ClassResolver classResolver = this.classResolver;
     if (fury.checkClassVersion()) {
-      int hash = buffer.readInt();
+      int hash = buffer.readInt32();
       checkClassVersion(fury, hash, classVersionHash);
     }
     Object[] fieldValues =
@@ -360,7 +360,7 @@ public final class ObjectSerializer<T> extends Serializer<T> {
     RefResolver refResolver = this.refResolver;
     ClassResolver classResolver = this.classResolver;
     if (fury.checkClassVersion()) {
-      int hash = buffer.readInt();
+      int hash = buffer.readInt32();
       checkClassVersion(fury, hash, classVersionHash);
     }
     // read order: primitive,boxed,final,other,collection,map
@@ -690,23 +690,23 @@ public final class ObjectSerializer<T> extends Serializer<T> {
         fieldAccessor.set(targetObject, buffer.readChar());
         return false;
       case ClassResolver.PRIMITIVE_SHORT_CLASS_ID:
-        fieldAccessor.set(targetObject, buffer.readShort());
+        fieldAccessor.set(targetObject, buffer.readInt16());
         return false;
       case ClassResolver.PRIMITIVE_INT_CLASS_ID:
         if (fury.compressInt()) {
           fieldAccessor.set(targetObject, buffer.readVarInt32());
         } else {
-          fieldAccessor.set(targetObject, buffer.readInt());
+          fieldAccessor.set(targetObject, buffer.readInt32());
         }
         return false;
       case ClassResolver.PRIMITIVE_FLOAT_CLASS_ID:
-        fieldAccessor.set(targetObject, buffer.readFloat());
+        fieldAccessor.set(targetObject, buffer.readFloat32());
         return false;
       case ClassResolver.PRIMITIVE_LONG_CLASS_ID:
-        fieldAccessor.set(targetObject, fury.readLong(buffer));
+        fieldAccessor.set(targetObject, fury.readInt64(buffer));
         return false;
       case ClassResolver.PRIMITIVE_DOUBLE_CLASS_ID:
-        fieldAccessor.set(targetObject, buffer.readDouble());
+        fieldAccessor.set(targetObject, buffer.readFloat64());
         return false;
       case ClassResolver.STRING_CLASS_ID:
         fieldAccessor.putObject(targetObject, fury.readJavaStringRef(buffer));
@@ -731,23 +731,23 @@ public final class ObjectSerializer<T> extends Serializer<T> {
         Platform.putChar(targetObject, fieldOffset, buffer.readChar());
         return false;
       case ClassResolver.PRIMITIVE_SHORT_CLASS_ID:
-        Platform.putShort(targetObject, fieldOffset, buffer.readShort());
+        Platform.putShort(targetObject, fieldOffset, buffer.readInt16());
         return false;
       case ClassResolver.PRIMITIVE_INT_CLASS_ID:
         if (fury.compressInt()) {
           Platform.putInt(targetObject, fieldOffset, buffer.readVarInt32());
         } else {
-          Platform.putInt(targetObject, fieldOffset, buffer.readInt());
+          Platform.putInt(targetObject, fieldOffset, buffer.readInt32());
         }
         return false;
       case ClassResolver.PRIMITIVE_FLOAT_CLASS_ID:
-        Platform.putFloat(targetObject, fieldOffset, buffer.readFloat());
+        Platform.putFloat(targetObject, fieldOffset, buffer.readFloat32());
         return false;
       case ClassResolver.PRIMITIVE_LONG_CLASS_ID:
-        Platform.putLong(targetObject, fieldOffset, fury.readLong(buffer));
+        Platform.putLong(targetObject, fieldOffset, fury.readInt64(buffer));
         return false;
       case ClassResolver.PRIMITIVE_DOUBLE_CLASS_ID:
-        Platform.putDouble(targetObject, fieldOffset, buffer.readDouble());
+        Platform.putDouble(targetObject, fieldOffset, buffer.readFloat64());
         return false;
       case ClassResolver.STRING_CLASS_ID:
         Platform.putObject(targetObject, fieldOffset, fury.readJavaStringRef(buffer));
@@ -805,7 +805,7 @@ public final class ObjectSerializer<T> extends Serializer<T> {
           if (buffer.readByte() == Fury.NULL_FLAG) {
             fieldAccessor.putObject(targetObject, null);
           } else {
-            fieldAccessor.putObject(targetObject, buffer.readShort());
+            fieldAccessor.putObject(targetObject, buffer.readInt16());
           }
           return false;
         }
@@ -817,7 +817,7 @@ public final class ObjectSerializer<T> extends Serializer<T> {
             if (fury.compressInt()) {
               fieldAccessor.putObject(targetObject, buffer.readVarInt32());
             } else {
-              fieldAccessor.putObject(targetObject, buffer.readInt());
+              fieldAccessor.putObject(targetObject, buffer.readInt32());
             }
           }
           return false;
@@ -827,7 +827,7 @@ public final class ObjectSerializer<T> extends Serializer<T> {
           if (buffer.readByte() == Fury.NULL_FLAG) {
             fieldAccessor.putObject(targetObject, null);
           } else {
-            fieldAccessor.putObject(targetObject, buffer.readFloat());
+            fieldAccessor.putObject(targetObject, buffer.readFloat32());
           }
           return false;
         }
@@ -836,7 +836,7 @@ public final class ObjectSerializer<T> extends Serializer<T> {
           if (buffer.readByte() == Fury.NULL_FLAG) {
             fieldAccessor.putObject(targetObject, null);
           } else {
-            fieldAccessor.putObject(targetObject, fury.readLong(buffer));
+            fieldAccessor.putObject(targetObject, fury.readInt64(buffer));
           }
           return false;
         }
@@ -845,7 +845,7 @@ public final class ObjectSerializer<T> extends Serializer<T> {
           if (buffer.readByte() == Fury.NULL_FLAG) {
             fieldAccessor.putObject(targetObject, null);
           } else {
-            fieldAccessor.putObject(targetObject, buffer.readDouble());
+            fieldAccessor.putObject(targetObject, buffer.readFloat64());
           }
           return false;
         }

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/ObjectSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/ObjectSerializer.java
@@ -200,7 +200,7 @@ public final class ObjectSerializer<T> extends Serializer<T> {
     RefResolver refResolver = this.refResolver;
     ClassResolver classResolver = this.classResolver;
     if (fury.checkClassVersion()) {
-      buffer.writeInt(classVersionHash);
+      buffer.writeInt32(classVersionHash);
     }
     // write order: primitive,boxed,final,other,collection,map
     writeFinalFields(buffer, value, fury, refResolver, classResolver);
@@ -488,7 +488,7 @@ public final class ObjectSerializer<T> extends Serializer<T> {
         buffer.writeChar((Character) fieldAccessor.get(targetObject));
         return false;
       case ClassResolver.PRIMITIVE_SHORT_CLASS_ID:
-        buffer.writeShort((Short) fieldAccessor.get(targetObject));
+        buffer.writeInt16((Short) fieldAccessor.get(targetObject));
         return false;
       case ClassResolver.PRIMITIVE_INT_CLASS_ID:
         {
@@ -496,21 +496,21 @@ public final class ObjectSerializer<T> extends Serializer<T> {
           if (fury.compressInt()) {
             buffer.writeVarInt32(fieldValue);
           } else {
-            buffer.writeInt(fieldValue);
+            buffer.writeInt32(fieldValue);
           }
           return false;
         }
       case ClassResolver.PRIMITIVE_FLOAT_CLASS_ID:
-        buffer.writeFloat((Float) fieldAccessor.get(targetObject));
+        buffer.writeFloat32((Float) fieldAccessor.get(targetObject));
         return false;
       case ClassResolver.PRIMITIVE_LONG_CLASS_ID:
         {
           long fieldValue = (long) fieldAccessor.get(targetObject);
-          fury.writeLong(buffer, fieldValue);
+          fury.writeInt64(buffer, fieldValue);
           return false;
         }
       case ClassResolver.PRIMITIVE_DOUBLE_CLASS_ID:
-        buffer.writeDouble((Double) fieldAccessor.get(targetObject));
+        buffer.writeFloat64((Double) fieldAccessor.get(targetObject));
         return false;
       default:
         return true;
@@ -530,7 +530,7 @@ public final class ObjectSerializer<T> extends Serializer<T> {
         buffer.writeChar(Platform.getChar(targetObject, fieldOffset));
         return false;
       case ClassResolver.PRIMITIVE_SHORT_CLASS_ID:
-        buffer.writeShort(Platform.getShort(targetObject, fieldOffset));
+        buffer.writeInt16(Platform.getShort(targetObject, fieldOffset));
         return false;
       case ClassResolver.PRIMITIVE_INT_CLASS_ID:
         {
@@ -538,21 +538,21 @@ public final class ObjectSerializer<T> extends Serializer<T> {
           if (fury.compressInt()) {
             buffer.writeVarInt32(fieldValue);
           } else {
-            buffer.writeInt(fieldValue);
+            buffer.writeInt32(fieldValue);
           }
           return false;
         }
       case ClassResolver.PRIMITIVE_FLOAT_CLASS_ID:
-        buffer.writeFloat(Platform.getFloat(targetObject, fieldOffset));
+        buffer.writeFloat32(Platform.getFloat(targetObject, fieldOffset));
         return false;
       case ClassResolver.PRIMITIVE_LONG_CLASS_ID:
         {
           long fieldValue = Platform.getLong(targetObject, fieldOffset);
-          fury.writeLong(buffer, fieldValue);
+          fury.writeInt64(buffer, fieldValue);
           return false;
         }
       case ClassResolver.PRIMITIVE_DOUBLE_CLASS_ID:
-        buffer.writeDouble(Platform.getDouble(targetObject, fieldOffset));
+        buffer.writeFloat64(Platform.getDouble(targetObject, fieldOffset));
         return false;
       default:
         return true;
@@ -610,7 +610,7 @@ public final class ObjectSerializer<T> extends Serializer<T> {
             buffer.writeByte(Fury.NULL_FLAG);
           } else {
             buffer.writeByte(Fury.NOT_NULL_VALUE_FLAG);
-            buffer.writeShort((Short) (fieldValue));
+            buffer.writeInt16((Short) (fieldValue));
           }
           return false;
         }
@@ -623,7 +623,7 @@ public final class ObjectSerializer<T> extends Serializer<T> {
             if (fury.compressInt()) {
               buffer.writeVarInt32((Integer) (fieldValue));
             } else {
-              buffer.writeInt((Integer) (fieldValue));
+              buffer.writeInt32((Integer) (fieldValue));
             }
           }
           return false;
@@ -634,7 +634,7 @@ public final class ObjectSerializer<T> extends Serializer<T> {
             buffer.writeByte(Fury.NULL_FLAG);
           } else {
             buffer.writeByte(Fury.NOT_NULL_VALUE_FLAG);
-            buffer.writeFloat((Float) (fieldValue));
+            buffer.writeFloat32((Float) (fieldValue));
           }
           return false;
         }
@@ -644,7 +644,7 @@ public final class ObjectSerializer<T> extends Serializer<T> {
             buffer.writeByte(Fury.NULL_FLAG);
           } else {
             buffer.writeByte(Fury.NOT_NULL_VALUE_FLAG);
-            fury.writeLong(buffer, (Long) fieldValue);
+            fury.writeInt64(buffer, (Long) fieldValue);
           }
           return false;
         }
@@ -654,7 +654,7 @@ public final class ObjectSerializer<T> extends Serializer<T> {
             buffer.writeByte(Fury.NULL_FLAG);
           } else {
             buffer.writeByte(Fury.NOT_NULL_VALUE_FLAG);
-            buffer.writeDouble((Double) (fieldValue));
+            buffer.writeFloat64((Double) (fieldValue));
           }
           return false;
         }

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/ObjectSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/ObjectSerializer.java
@@ -494,7 +494,7 @@ public final class ObjectSerializer<T> extends Serializer<T> {
         {
           int fieldValue = (Integer) fieldAccessor.get(targetObject);
           if (fury.compressInt()) {
-            buffer.writeVarInt(fieldValue);
+            buffer.writeVarInt32(fieldValue);
           } else {
             buffer.writeInt(fieldValue);
           }
@@ -536,7 +536,7 @@ public final class ObjectSerializer<T> extends Serializer<T> {
         {
           int fieldValue = Platform.getInt(targetObject, fieldOffset);
           if (fury.compressInt()) {
-            buffer.writeVarInt(fieldValue);
+            buffer.writeVarInt32(fieldValue);
           } else {
             buffer.writeInt(fieldValue);
           }
@@ -621,7 +621,7 @@ public final class ObjectSerializer<T> extends Serializer<T> {
           } else {
             buffer.writeByte(Fury.NOT_NULL_VALUE_FLAG);
             if (fury.compressInt()) {
-              buffer.writeVarInt((Integer) (fieldValue));
+              buffer.writeVarInt32((Integer) (fieldValue));
             } else {
               buffer.writeInt((Integer) (fieldValue));
             }
@@ -694,7 +694,7 @@ public final class ObjectSerializer<T> extends Serializer<T> {
         return false;
       case ClassResolver.PRIMITIVE_INT_CLASS_ID:
         if (fury.compressInt()) {
-          fieldAccessor.set(targetObject, buffer.readVarInt());
+          fieldAccessor.set(targetObject, buffer.readVarInt32());
         } else {
           fieldAccessor.set(targetObject, buffer.readInt());
         }
@@ -735,7 +735,7 @@ public final class ObjectSerializer<T> extends Serializer<T> {
         return false;
       case ClassResolver.PRIMITIVE_INT_CLASS_ID:
         if (fury.compressInt()) {
-          Platform.putInt(targetObject, fieldOffset, buffer.readVarInt());
+          Platform.putInt(targetObject, fieldOffset, buffer.readVarInt32());
         } else {
           Platform.putInt(targetObject, fieldOffset, buffer.readInt());
         }
@@ -815,7 +815,7 @@ public final class ObjectSerializer<T> extends Serializer<T> {
             fieldAccessor.putObject(targetObject, null);
           } else {
             if (fury.compressInt()) {
-              fieldAccessor.putObject(targetObject, buffer.readVarInt());
+              fieldAccessor.putObject(targetObject, buffer.readVarInt32());
             } else {
               fieldAccessor.putObject(targetObject, buffer.readInt());
             }

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/ObjectStreamSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/ObjectStreamSerializer.java
@@ -125,7 +125,7 @@ public class ObjectStreamSerializer extends Serializer {
 
   @Override
   public void write(MemoryBuffer buffer, Object value) {
-    buffer.writeShort((short) slotsInfos.length);
+    buffer.writeInt16((short) slotsInfos.length);
     try {
       for (SlotsInfo slotsInfo : slotsInfos) {
         // create a classinfo to avoid null class bytes when class id is a
@@ -607,7 +607,7 @@ public class ObjectStreamSerializer extends Serializer {
 
     @Override
     public void writeShort(int v) throws IOException {
-      buffer.writeShort((short) v);
+      buffer.writeInt16((short) v);
     }
 
     @Override
@@ -617,22 +617,22 @@ public class ObjectStreamSerializer extends Serializer {
 
     @Override
     public void writeInt(int v) throws IOException {
-      buffer.writeInt(v);
+      buffer.writeInt32(v);
     }
 
     @Override
     public void writeLong(long v) throws IOException {
-      buffer.writeLong(v);
+      buffer.writeInt64(v);
     }
 
     @Override
     public void writeFloat(float v) throws IOException {
-      buffer.writeFloat(v);
+      buffer.writeFloat32(v);
     }
 
     @Override
     public void writeDouble(double v) throws IOException {
-      buffer.writeDouble(v);
+      buffer.writeFloat64(v);
     }
 
     @Override

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/ObjectStreamSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/ObjectStreamSerializer.java
@@ -177,7 +177,7 @@ public class ObjectStreamSerializer extends Serializer {
       obj = Platform.newInstance(type);
     }
     fury.getRefResolver().reference(obj);
-    int numClasses = buffer.readShort();
+    int numClasses = buffer.readInt16();
     int slotIndex = 0;
     try {
       TreeMap<Integer, ObjectInputValidation> callbacks = new TreeMap<>(Collections.reverseOrder());
@@ -890,12 +890,12 @@ public class ObjectStreamSerializer extends Serializer {
       return b & 0xff;
     }
 
-    public short readShort() throws IOException {
-      return buffer.readShort();
+    public short readInt16() throws IOException {
+      return buffer.readInt16();
     }
 
     public int readUnsignedShort() throws IOException {
-      int b = buffer.readShort();
+      int b = buffer.readInt16();
       return b & 0xffff;
     }
 
@@ -903,20 +903,20 @@ public class ObjectStreamSerializer extends Serializer {
       return buffer.readChar();
     }
 
-    public int readInt() throws IOException {
-      return buffer.readInt();
+    public int readInt32() throws IOException {
+      return buffer.readInt32();
     }
 
-    public long readLong() throws IOException {
-      return buffer.readLong();
+    public long readInt64() throws IOException {
+      return buffer.readInt64();
     }
 
-    public float readFloat() throws IOException {
-      return buffer.readFloat();
+    public float readFloat32() throws IOException {
+      return buffer.readFloat32();
     }
 
-    public double readDouble() throws IOException {
-      return buffer.readDouble();
+    public double readFloat64() throws IOException {
+      return buffer.readFloat64();
     }
 
     public void readFully(byte[] data) throws IOException {

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/ObjectStreamSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/ObjectStreamSerializer.java
@@ -425,10 +425,12 @@ public class ObjectStreamSerializer extends Serializer {
       this.fury = slotsInfo.slotsSerializer.fury;
     }
 
+    @Override
     protected final void writeObjectOverride(Object obj) throws IOException {
       fury.writeRef(buffer, obj);
     }
 
+    @Override
     public void writeUnshared(Object obj) throws IOException {
       fury.writeNonRef(buffer, obj);
     }
@@ -516,6 +518,7 @@ public class ObjectStreamSerializer extends Serializer {
     private final ObjectArray putFieldsCache = new ObjectArray();
     private PutFieldImpl curPut;
 
+    @Override
     public PutField putFields() throws IOException {
       if (curPut == null) {
         Object o = putFieldsCache.popOrNull();
@@ -527,6 +530,7 @@ public class ObjectStreamSerializer extends Serializer {
       return curPut;
     }
 
+    @Override
     public void writeFields() throws IOException {
       if (fieldsWritten) {
         throw new NotActiveException("not in writeObject invocation or fields already written");
@@ -542,6 +546,7 @@ public class ObjectStreamSerializer extends Serializer {
       fieldsWritten = true;
     }
 
+    @Override
     public void defaultWriteObject() throws IOException, NotActiveException {
       if (fieldsWritten) {
         throw new NotActiveException("not in writeObject invocation or fields already written");
@@ -550,32 +555,39 @@ public class ObjectStreamSerializer extends Serializer {
       fieldsWritten = true;
     }
 
+    @Override
     public void reset() throws IOException {
       Class cls = slotsInfo.slotsSerializer.getType();
       // Fury won't invoke this method, throw exception if the user invokes it.
       throwUnsupportedEncodingException(cls);
     }
 
+    @Override
     protected void annotateClass(Class<?> cl) throws IOException {
       throw new IllegalStateException();
     }
 
+    @Override
     protected void annotateProxyClass(Class<?> cl) throws IOException {
       throw new IllegalStateException();
     }
 
+    @Override
     protected void writeClassDescriptor(ObjectStreamClass desc) throws IOException {
       throw new UnsupportedEncodingException();
     }
 
+    @Override
     protected Object replaceObject(Object obj) throws IOException {
       throw new UnsupportedEncodingException();
     }
 
+    @Override
     protected boolean enableReplaceObject(boolean enable) throws SecurityException {
       throw new IllegalStateException();
     }
 
+    @Override
     protected void writeStreamHeader() throws IOException {
       throw new IllegalStateException();
     }
@@ -656,15 +668,19 @@ public class ObjectStreamSerializer extends Serializer {
       fury.writeJavaString(buffer, s);
     }
 
+    @Override
     public void useProtocolVersion(int version) throws IOException {
       Class cls = slotsInfo.cls;
       throwUnsupportedEncodingException(cls);
     }
 
+    @Override
     public void flush() throws IOException {}
 
+    @Override
     protected void drain() throws IOException {}
 
+    @Override
     public void close() throws IOException {}
   }
 
@@ -689,10 +705,12 @@ public class ObjectStreamSerializer extends Serializer {
       this.slotsInfo = slotsInfo;
     }
 
+    @Override
     protected Object readObjectOverride() {
       return fury.readRef(buffer);
     }
 
+    @Override
     public Object readUnshared() {
       return fury.readNonRef(buffer);
     }
@@ -819,6 +837,7 @@ public class ObjectStreamSerializer extends Serializer {
 
     // `readFields`/`writeFields` can handle fields which doesn't exist in current class.
     // `defaultReadObject` will skip those fields.
+    @Override
     public GetField readFields() throws IOException {
       if (fieldsRead) {
         throw new NotActiveException("not in readObject invocation or fields already read");
@@ -828,6 +847,7 @@ public class ObjectStreamSerializer extends Serializer {
       return getField;
     }
 
+    @Override
     public void defaultReadObject() throws IOException, ClassNotFoundException {
       if (fieldsRead) {
         throw new NotActiveException("not in readObject invocation or fields already read");
@@ -840,6 +860,7 @@ public class ObjectStreamSerializer extends Serializer {
     // restore it user may need access to other state which is created by the subclass and
     // at this point will be null. Users thus use `registerValidation`.
     // see `javax.swing.text.AbstractDocument.readObject` as an example.
+    @Override
     public void registerValidation(ObjectInputValidation obj, int prio)
         throws NotActiveException, InvalidObjectException {
       // Since this method is only visible to fury, it won't be invoked by users outside
@@ -851,10 +872,12 @@ public class ObjectStreamSerializer extends Serializer {
       callbacks.put(prio, obj);
     }
 
+    @Override
     public int read() throws IOException {
-      return buffer.readByte();
+      return buffer.readByte() & 0xFF;
     }
 
+    @Override
     public int read(byte[] buf, int offset, int length) throws IOException {
       if (buf == null) {
         throw new NullPointerException();
@@ -873,24 +896,29 @@ public class ObjectStreamSerializer extends Serializer {
       }
     }
 
+    @Override
     public int available() throws IOException {
       return buffer.remaining();
     }
 
+    @Override
     public boolean readBoolean() throws IOException {
       return buffer.readBoolean();
     }
 
+    @Override
     public byte readByte() throws IOException {
       return buffer.readByte();
     }
 
+    @Override
     public int readUnsignedByte() throws IOException {
       int b = buffer.readByte();
       return b & 0xff;
     }
 
-    public short readInt16() throws IOException {
+    @Override
+    public short readShort() throws IOException {
       return buffer.readInt16();
     }
 
@@ -899,47 +927,58 @@ public class ObjectStreamSerializer extends Serializer {
       return b & 0xffff;
     }
 
+    @Override
     public char readChar() throws IOException {
       return buffer.readChar();
     }
 
-    public int readInt32() throws IOException {
+    @Override
+    public int readInt() throws IOException {
       return buffer.readInt32();
     }
 
-    public long readInt64() throws IOException {
+    @Override
+    public long readLong() throws IOException {
       return buffer.readInt64();
     }
 
-    public float readFloat32() throws IOException {
+    @Override
+    public float readFloat() throws IOException {
       return buffer.readFloat32();
     }
 
-    public double readFloat64() throws IOException {
+    @Override
+    public double readDouble() throws IOException {
       return buffer.readFloat64();
     }
 
+    @Override
     public void readFully(byte[] data) throws IOException {
       buffer.readBytes(data);
     }
 
+    @Override
     public void readFully(byte[] data, int offset, int size) throws IOException {
       buffer.readBytes(data, offset, size);
     }
 
+    @Override
     public int skipBytes(int len) throws IOException {
       buffer.increaseReaderIndex(len);
       return len;
     }
 
+    @Override
     public String readLine() throws IOException {
       throw new UnsupportedOperationException();
     }
 
+    @Override
     public String readUTF() throws IOException {
       return fury.readJavaString(buffer);
     }
 
+    @Override
     public void close() throws IOException {}
   }
 }

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/OptionalSerializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/OptionalSerializers.java
@@ -59,7 +59,7 @@ public final class OptionalSerializers {
       boolean present = value.isPresent();
       buffer.writeBoolean(present);
       if (present) {
-        buffer.writeInt(value.getAsInt());
+        buffer.writeInt32(value.getAsInt());
       }
     }
 
@@ -83,7 +83,7 @@ public final class OptionalSerializers {
       boolean present = value.isPresent();
       buffer.writeBoolean(present);
       if (present) {
-        buffer.writeLong(value.getAsLong());
+        buffer.writeInt64(value.getAsLong());
       }
     }
 
@@ -107,7 +107,7 @@ public final class OptionalSerializers {
       boolean present = value.isPresent();
       buffer.writeBoolean(present);
       if (present) {
-        buffer.writeDouble(value.getAsDouble());
+        buffer.writeFloat64(value.getAsDouble());
       }
     }
 

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/OptionalSerializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/OptionalSerializers.java
@@ -66,7 +66,7 @@ public final class OptionalSerializers {
     @Override
     public OptionalInt read(MemoryBuffer buffer) {
       if (buffer.readBoolean()) {
-        return OptionalInt.of(buffer.readInt());
+        return OptionalInt.of(buffer.readInt32());
       } else {
         return OptionalInt.empty();
       }
@@ -90,7 +90,7 @@ public final class OptionalSerializers {
     @Override
     public OptionalLong read(MemoryBuffer buffer) {
       if (buffer.readBoolean()) {
-        return OptionalLong.of(buffer.readLong());
+        return OptionalLong.of(buffer.readInt64());
       } else {
         return OptionalLong.empty();
       }
@@ -114,7 +114,7 @@ public final class OptionalSerializers {
     @Override
     public OptionalDouble read(MemoryBuffer buffer) {
       if (buffer.readBoolean()) {
-        return OptionalDouble.of(buffer.readDouble());
+        return OptionalDouble.of(buffer.readFloat64());
       } else {
         return OptionalDouble.empty();
       }

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/PrimitiveSerializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/PrimitiveSerializers.java
@@ -174,7 +174,7 @@ public class PrimitiveSerializers {
     @Override
     public void write(MemoryBuffer buffer, Integer value) {
       if (compressNumber) {
-        buffer.writeVarInt(value);
+        buffer.writeVarInt32(value);
       } else {
         buffer.writeInt(value);
       }
@@ -183,7 +183,7 @@ public class PrimitiveSerializers {
     @Override
     public Integer read(MemoryBuffer buffer) {
       if (compressNumber) {
-        return buffer.readVarInt();
+        return buffer.readVarInt32();
       } else {
         return buffer.readInt();
       }
@@ -227,11 +227,11 @@ public class PrimitiveSerializers {
     public static String writeLongFunc(LongEncoding longEncoding, boolean ensureBounds) {
       switch (longEncoding) {
         case LE_RAW_BYTES:
-          return ensureBounds ? "writeLong" : "unsafeWriteVarLong";
+          return ensureBounds ? "writeLong" : "unsafeWriteVarInt64";
         case SLI:
           return ensureBounds ? "writeSliLong" : "unsafeWriteSliLong";
         case PVL:
-          return ensureBounds ? "writeVarLong" : "unsafeWriteVarLong";
+          return ensureBounds ? "writeVarInt64" : "unsafeWriteVarInt64";
         default:
           throw new UnsupportedOperationException("Unsupported long encoding " + longEncoding);
       }
@@ -248,7 +248,7 @@ public class PrimitiveSerializers {
       } else if (longEncoding == LongEncoding.LE_RAW_BYTES) {
         buffer.writeLong(value);
       } else {
-        buffer.writeVarLong(value);
+        buffer.writeVarInt64(value);
       }
     }
 
@@ -258,7 +258,7 @@ public class PrimitiveSerializers {
       } else if (longEncoding == LongEncoding.LE_RAW_BYTES) {
         return buffer.readLong();
       } else {
-        return buffer.readVarLong();
+        return buffer.readVarInt64();
       }
     }
 
@@ -273,7 +273,7 @@ public class PrimitiveSerializers {
         case SLI:
           return Platform.IS_LITTLE_ENDIAN ? "readSliLongOnLE" : "readSliLongOnBE";
         case PVL:
-          return Platform.IS_LITTLE_ENDIAN ? "readVarLongOnLE" : "readVarLongOnBE";
+          return Platform.IS_LITTLE_ENDIAN ? "readVarInt64OnLE" : "readVarInt64OnBE";
         default:
           throw new UnsupportedOperationException("Unsupported long encoding " + longEncoding);
       }

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/PrimitiveSerializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/PrimitiveSerializers.java
@@ -265,7 +265,7 @@ public class PrimitiveSerializers {
     public static String readLongFunc(LongEncoding longEncoding) {
       switch (longEncoding) {
         case LE_RAW_BYTES:
-          return Platform.IS_LITTLE_ENDIAN ? "readInt64OnLE" : "readInt64OnBE";
+          return Platform.IS_LITTLE_ENDIAN ? "_readInt64OnLE" : "_readInt64OnBE";
         case SLI:
           return Platform.IS_LITTLE_ENDIAN ? "_readSliInt64OnLE" : "_readSliInt64OnBE";
         case PVL:

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/PrimitiveSerializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/PrimitiveSerializers.java
@@ -154,7 +154,7 @@ public class PrimitiveSerializers {
 
     @Override
     public Short read(MemoryBuffer buffer) {
-      return buffer.readShort();
+      return buffer.readInt16();
     }
   }
 
@@ -185,7 +185,7 @@ public class PrimitiveSerializers {
       if (compressNumber) {
         return buffer.readVarInt32();
       } else {
-        return buffer.readInt();
+        return buffer.readInt32();
       }
     }
 
@@ -197,7 +197,7 @@ public class PrimitiveSerializers {
 
     @Override
     public Integer xread(MemoryBuffer buffer) {
-      return buffer.readInt();
+      return buffer.readInt32();
     }
   }
 
@@ -221,7 +221,7 @@ public class PrimitiveSerializers {
 
     @Override
     public Long read(MemoryBuffer buffer) {
-      return readLong(buffer, longEncoding);
+      return readInt64(buffer, longEncoding);
     }
 
     public static Expression writeLong(
@@ -248,26 +248,26 @@ public class PrimitiveSerializers {
       }
     }
 
-    public static long readLong(MemoryBuffer buffer, LongEncoding longEncoding) {
+    public static long readInt64(MemoryBuffer buffer, LongEncoding longEncoding) {
       if (longEncoding == LongEncoding.SLI) {
-        return buffer.readSliLong();
+        return buffer.readSliInt64On();
       } else if (longEncoding == LongEncoding.LE_RAW_BYTES) {
-        return buffer.readLong();
+        return buffer.readInt64();
       } else {
         return buffer.readVarInt64();
       }
     }
 
-    public static Expression readLong(Expression buffer, LongEncoding longEncoding) {
+    public static Expression readInt64(Expression buffer, LongEncoding longEncoding) {
       return new Invoke(buffer, readLongFunc(longEncoding), PRIMITIVE_LONG_TYPE);
     }
 
     public static String readLongFunc(LongEncoding longEncoding) {
       switch (longEncoding) {
         case LE_RAW_BYTES:
-          return Platform.IS_LITTLE_ENDIAN ? "readLongOnLE" : "readLongOnBE";
+          return Platform.IS_LITTLE_ENDIAN ? "readInt64OnLE" : "readInt64OnBE";
         case SLI:
-          return Platform.IS_LITTLE_ENDIAN ? "readSliLongOnLE" : "readSliLongOnBE";
+          return Platform.IS_LITTLE_ENDIAN ? "readSliInt64OnLE" : "readSliInt64OnBE";
         case PVL:
           return Platform.IS_LITTLE_ENDIAN ? "readVarInt64OnLE" : "readVarInt64OnBE";
         default:
@@ -283,7 +283,7 @@ public class PrimitiveSerializers {
 
     @Override
     public Long xread(MemoryBuffer buffer) {
-      return buffer.readLong();
+      return buffer.readInt64();
     }
   }
 
@@ -304,7 +304,7 @@ public class PrimitiveSerializers {
 
     @Override
     public Float read(MemoryBuffer buffer) {
-      return buffer.readFloat();
+      return buffer.readFloat32();
     }
   }
 
@@ -325,7 +325,7 @@ public class PrimitiveSerializers {
 
     @Override
     public Double read(MemoryBuffer buffer) {
-      return buffer.readDouble();
+      return buffer.readFloat64();
     }
   }
 

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/PrimitiveSerializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/PrimitiveSerializers.java
@@ -230,7 +230,7 @@ public class PrimitiveSerializers {
         case LE_RAW_BYTES:
           return new Invoke(buffer, "writeInt64", v);
         case SLI:
-          return new Invoke(buffer, ensureBounds ? "writeSliLong" : "_unsafeWriteSliLong", v);
+          return new Invoke(buffer, ensureBounds ? "writeSliInt64" : "_unsafeWriteSliInt64", v);
         case PVL:
           return new Invoke(buffer, ensureBounds ? "writeVarInt64" : "_unsafeWriteVarInt64", v);
         default:
@@ -240,7 +240,7 @@ public class PrimitiveSerializers {
 
     public static void writeInt64(MemoryBuffer buffer, long value, LongEncoding longEncoding) {
       if (longEncoding == LongEncoding.SLI) {
-        buffer.writeSliLong(value);
+        buffer.writeSliInt64(value);
       } else if (longEncoding == LongEncoding.LE_RAW_BYTES) {
         buffer.writeInt64(value);
       } else {
@@ -250,7 +250,7 @@ public class PrimitiveSerializers {
 
     public static long readInt64(MemoryBuffer buffer, LongEncoding longEncoding) {
       if (longEncoding == LongEncoding.SLI) {
-        return buffer.readSliInt64On();
+        return buffer.readSliInt64();
       } else if (longEncoding == LongEncoding.LE_RAW_BYTES) {
         return buffer.readInt64();
       } else {

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/PrimitiveSerializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/PrimitiveSerializers.java
@@ -267,9 +267,9 @@ public class PrimitiveSerializers {
         case LE_RAW_BYTES:
           return Platform.IS_LITTLE_ENDIAN ? "readInt64OnLE" : "readInt64OnBE";
         case SLI:
-          return Platform.IS_LITTLE_ENDIAN ? "readSliInt64OnLE" : "readSliInt64OnBE";
+          return Platform.IS_LITTLE_ENDIAN ? "_readSliInt64OnLE" : "_readSliInt64OnBE";
         case PVL:
-          return Platform.IS_LITTLE_ENDIAN ? "readVarInt64OnLE" : "readVarInt64OnBE";
+          return Platform.IS_LITTLE_ENDIAN ? "_readVarInt64OnLE" : "_readVarInt64OnBE";
         default:
           throw new UnsupportedOperationException("Unsupported long encoding " + longEncoding);
       }

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/PrimitiveSerializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/PrimitiveSerializers.java
@@ -149,7 +149,7 @@ public class PrimitiveSerializers {
 
     @Override
     public void write(MemoryBuffer buffer, Short value) {
-      buffer.writeShort(value);
+      buffer.writeInt16(value);
     }
 
     @Override
@@ -176,7 +176,7 @@ public class PrimitiveSerializers {
       if (compressNumber) {
         buffer.writeVarInt32(value);
       } else {
-        buffer.writeInt(value);
+        buffer.writeInt32(value);
       }
     }
 
@@ -192,7 +192,7 @@ public class PrimitiveSerializers {
     @Override
     public void xwrite(MemoryBuffer buffer, Integer value) {
       // TODO support varint in cross-language serialization
-      buffer.writeInt(value);
+      buffer.writeInt32(value);
     }
 
     @Override
@@ -216,7 +216,7 @@ public class PrimitiveSerializers {
 
     @Override
     public void write(MemoryBuffer buffer, Long value) {
-      writeLong(buffer, value, longEncoding);
+      writeInt64(buffer, value, longEncoding);
     }
 
     @Override
@@ -224,11 +224,11 @@ public class PrimitiveSerializers {
       return readInt64(buffer, longEncoding);
     }
 
-    public static Expression writeLong(
+    public static Expression writeInt64(
         Expression buffer, Expression v, LongEncoding longEncoding, boolean ensureBounds) {
       switch (longEncoding) {
         case LE_RAW_BYTES:
-          return new Invoke(buffer, "writeLong", v);
+          return new Invoke(buffer, "writeInt64", v);
         case SLI:
           return new Invoke(buffer, ensureBounds ? "writeSliLong" : "_unsafeWriteSliLong", v);
         case PVL:
@@ -238,11 +238,11 @@ public class PrimitiveSerializers {
       }
     }
 
-    public static void writeLong(MemoryBuffer buffer, long value, LongEncoding longEncoding) {
+    public static void writeInt64(MemoryBuffer buffer, long value, LongEncoding longEncoding) {
       if (longEncoding == LongEncoding.SLI) {
         buffer.writeSliLong(value);
       } else if (longEncoding == LongEncoding.LE_RAW_BYTES) {
-        buffer.writeLong(value);
+        buffer.writeInt64(value);
       } else {
         buffer.writeVarInt64(value);
       }
@@ -278,7 +278,7 @@ public class PrimitiveSerializers {
     @Override
     public void xwrite(MemoryBuffer buffer, Long value) {
       // TODO support var long in cross-language serialization
-      buffer.writeLong(value);
+      buffer.writeInt64(value);
     }
 
     @Override
@@ -299,7 +299,7 @@ public class PrimitiveSerializers {
 
     @Override
     public void write(MemoryBuffer buffer, Float value) {
-      buffer.writeFloat(value);
+      buffer.writeFloat32(value);
     }
 
     @Override
@@ -320,7 +320,7 @@ public class PrimitiveSerializers {
 
     @Override
     public void write(MemoryBuffer buffer, Double value) {
-      buffer.writeDouble(value);
+      buffer.writeFloat64(value);
     }
 
     @Override

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/PrimitiveSerializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/PrimitiveSerializers.java
@@ -230,9 +230,9 @@ public class PrimitiveSerializers {
         case LE_RAW_BYTES:
           return new Invoke(buffer, "writeLong", v);
         case SLI:
-          return new Invoke(buffer, ensureBounds ? "writeSliLong" : "unsafeWriteSliLong", v);
+          return new Invoke(buffer, ensureBounds ? "writeSliLong" : "_unsafeWriteSliLong", v);
         case PVL:
-          return new Invoke(buffer, ensureBounds ? "writeVarInt64" : "unsafeWriteVarInt64", v);
+          return new Invoke(buffer, ensureBounds ? "writeVarInt64" : "_unsafeWriteVarInt64", v);
         default:
           throw new UnsupportedOperationException("Unsupported long encoding " + longEncoding);
       }

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/PrimitiveSerializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/PrimitiveSerializers.java
@@ -224,22 +224,18 @@ public class PrimitiveSerializers {
       return readLong(buffer, longEncoding);
     }
 
-    public static String writeLongFunc(LongEncoding longEncoding, boolean ensureBounds) {
+    public static Expression writeLong(
+        Expression buffer, Expression v, LongEncoding longEncoding, boolean ensureBounds) {
       switch (longEncoding) {
         case LE_RAW_BYTES:
-          return ensureBounds ? "writeLong" : "unsafeWriteVarInt64";
+          return new Invoke(buffer, "writeLong", v);
         case SLI:
-          return ensureBounds ? "writeSliLong" : "unsafeWriteSliLong";
+          return new Invoke(buffer, ensureBounds ? "writeSliLong" : "unsafeWriteSliLong", v);
         case PVL:
-          return ensureBounds ? "writeVarInt64" : "unsafeWriteVarInt64";
+          return new Invoke(buffer, ensureBounds ? "writeVarInt64" : "unsafeWriteVarInt64", v);
         default:
           throw new UnsupportedOperationException("Unsupported long encoding " + longEncoding);
       }
-    }
-
-    public static Expression writeLong(
-        Expression buffer, Expression v, LongEncoding longEncoding, boolean ensureBounds) {
-      return new Invoke(buffer, writeLongFunc(longEncoding, ensureBounds), v);
     }
 
     public static void writeLong(MemoryBuffer buffer, long value, LongEncoding longEncoding) {

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/Serializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/Serializers.java
@@ -401,7 +401,7 @@ public class Serializers {
 
     @Override
     public void write(MemoryBuffer buffer, AtomicInteger value) {
-      buffer.writeInt(value.get());
+      buffer.writeInt32(value.get());
     }
 
     @Override
@@ -418,7 +418,7 @@ public class Serializers {
 
     @Override
     public void write(MemoryBuffer buffer, AtomicLong value) {
-      buffer.writeLong(value.get());
+      buffer.writeInt64(value.get());
     }
 
     @Override
@@ -501,7 +501,7 @@ public class Serializers {
     @Override
     public void write(MemoryBuffer buffer, Pattern pattern) {
       fury.writeJavaString(buffer, pattern.pattern());
-      buffer.writeInt(pattern.flags());
+      buffer.writeInt32(pattern.flags());
     }
 
     @Override
@@ -520,8 +520,8 @@ public class Serializers {
 
     @Override
     public void write(MemoryBuffer buffer, final UUID uuid) {
-      buffer.writeLong(uuid.getMostSignificantBits());
-      buffer.writeLong(uuid.getLeastSignificantBits());
+      buffer.writeInt64(uuid.getMostSignificantBits());
+      buffer.writeInt64(uuid.getLeastSignificantBits());
     }
 
     @Override

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/Serializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/Serializers.java
@@ -157,19 +157,19 @@ public class Serializers {
       case ClassResolver.PRIMITIVE_CHAR_CLASS_ID:
         return buffer.readChar();
       case ClassResolver.PRIMITIVE_SHORT_CLASS_ID:
-        return buffer.readShort();
+        return buffer.readInt16();
       case ClassResolver.PRIMITIVE_INT_CLASS_ID:
         if (fury.compressInt()) {
           return buffer.readVarInt32();
         } else {
-          return buffer.readInt();
+          return buffer.readInt32();
         }
       case ClassResolver.PRIMITIVE_FLOAT_CLASS_ID:
-        return buffer.readFloat();
+        return buffer.readFloat32();
       case ClassResolver.PRIMITIVE_LONG_CLASS_ID:
-        return fury.readLong(buffer);
+        return fury.readInt64(buffer);
       case ClassResolver.PRIMITIVE_DOUBLE_CLASS_ID:
-        return buffer.readDouble();
+        return buffer.readFloat64();
       default:
         {
           throw new IllegalStateException("unreachable");
@@ -406,7 +406,7 @@ public class Serializers {
 
     @Override
     public AtomicInteger read(MemoryBuffer buffer) {
-      return new AtomicInteger(buffer.readInt());
+      return new AtomicInteger(buffer.readInt32());
     }
   }
 
@@ -423,7 +423,7 @@ public class Serializers {
 
     @Override
     public AtomicLong read(MemoryBuffer buffer) {
-      return new AtomicLong(buffer.readLong());
+      return new AtomicLong(buffer.readInt64());
     }
   }
 
@@ -507,7 +507,7 @@ public class Serializers {
     @Override
     public Pattern read(MemoryBuffer buffer) {
       String regex = fury.readJavaString(buffer);
-      int flags = buffer.readInt();
+      int flags = buffer.readInt32();
       return Pattern.compile(regex, flags);
     }
   }
@@ -526,7 +526,7 @@ public class Serializers {
 
     @Override
     public UUID read(MemoryBuffer buffer) {
-      return new UUID(buffer.readLong(), buffer.readLong());
+      return new UUID(buffer.readInt64(), buffer.readInt64());
     }
   }
 

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/Serializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/Serializers.java
@@ -160,7 +160,7 @@ public class Serializers {
         return buffer.readShort();
       case ClassResolver.PRIMITIVE_INT_CLASS_ID:
         if (fury.compressInt()) {
-          return buffer.readVarInt();
+          return buffer.readVarInt32();
         } else {
           return buffer.readInt();
         }
@@ -254,7 +254,7 @@ public class Serializers {
           bytesLen <<= 1;
         }
         long header = ((long) bytesLen << 2) | coder;
-        buffer.writePositiveVarLong(header);
+        buffer.writeVarUint64(header);
         buffer.writeBytes(v, 0, bytesLen);
       } else {
         char[] v = (char[]) GET_VALUE.apply(value);
@@ -322,7 +322,7 @@ public class Serializers {
 
     @Override
     public void write(MemoryBuffer buffer, Enum value) {
-      buffer.writePositiveVarInt(value.ordinal());
+      buffer.writeVarUint32(value.ordinal());
     }
 
     @Override
@@ -339,17 +339,17 @@ public class Serializers {
     @Override
     public void write(MemoryBuffer buffer, BigDecimal value) {
       final byte[] bytes = value.unscaledValue().toByteArray();
-      buffer.writePositiveVarInt(value.scale());
-      buffer.writePositiveVarInt(value.precision());
-      buffer.writePositiveVarInt(bytes.length);
+      buffer.writeVarUint32(value.scale());
+      buffer.writeVarUint32(value.precision());
+      buffer.writeVarUint32(bytes.length);
       buffer.writeBytes(bytes);
     }
 
     @Override
     public BigDecimal read(MemoryBuffer buffer) {
-      int scale = buffer.readPositiveVarInt();
-      int precision = buffer.readPositiveVarInt();
-      int len = buffer.readPositiveVarInt();
+      int scale = buffer.readVarUint32();
+      int precision = buffer.readVarUint32();
+      int len = buffer.readVarUint32();
       byte[] bytes = buffer.readBytes(len);
       final BigInteger bigInteger = new BigInteger(bytes);
       return new BigDecimal(bigInteger, scale, new MathContext(precision));
@@ -364,13 +364,13 @@ public class Serializers {
     @Override
     public void write(MemoryBuffer buffer, BigInteger value) {
       final byte[] bytes = value.toByteArray();
-      buffer.writePositiveVarInt(bytes.length);
+      buffer.writeVarUint32(bytes.length);
       buffer.writeBytes(bytes);
     }
 
     @Override
     public BigInteger read(MemoryBuffer buffer) {
-      int len = buffer.readPositiveVarInt();
+      int len = buffer.readVarUint32();
       byte[] bytes = buffer.readBytes(len);
       return new BigInteger(bytes);
     }

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/StringSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/StringSerializer.java
@@ -359,7 +359,7 @@ public final class StringSerializer extends Serializer<String> {
       writerIndex += arrIndex - targetIndex;
       System.arraycopy(bytes, 0, targetArray, arrIndex, bytesLen);
     } else {
-      writerIndex += buffer.unsafePutVarUint36Small(writerIndex, header);
+      writerIndex += buffer._unsafePutVarUint36Small(writerIndex, header);
       long offHeapAddress = buffer.getUnsafeAddress();
       Platform.copyMemory(
           bytes, Platform.BYTE_ARRAY_OFFSET, null, offHeapAddress + writerIndex, bytesLen);
@@ -385,7 +385,7 @@ public final class StringSerializer extends Serializer<String> {
       }
       buffer.unsafeWriterIndex(writerIndex);
     } else {
-      writerIndex += buffer.unsafePutVarUint36Small(writerIndex, header);
+      writerIndex += buffer._unsafePutVarUint36Small(writerIndex, header);
       final byte[] tmpArray = getByteArray(strLen);
       // Write to heap memory then copy is 60% faster than unsafe write to direct memory.
       for (int i = 0; i < strLen; i++) {
@@ -440,7 +440,7 @@ public final class StringSerializer extends Serializer<String> {
 
   private int offHeapWriteCharsUTF16(
       MemoryBuffer buffer, char[] chars, int writerIndex, long header, int numBytes) {
-    writerIndex += buffer.unsafePutVarUint36Small(writerIndex, header);
+    writerIndex += buffer._unsafePutVarUint36Small(writerIndex, header);
     byte[] tmpArray = getByteArray(numBytes);
     int charIndex = 0;
     for (int i = 0; i < numBytes; i += 2) {

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/StringSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/StringSerializer.java
@@ -36,8 +36,8 @@ import org.apache.fury.annotation.CodegenInvoke;
 import org.apache.fury.codegen.Expression;
 import org.apache.fury.codegen.Expression.Invoke;
 import org.apache.fury.codegen.Expression.StaticInvoke;
+import org.apache.fury.memory.LittleEndian;
 import org.apache.fury.memory.MemoryBuffer;
-import org.apache.fury.memory.MemoryUtils;
 import org.apache.fury.type.Type;
 import org.apache.fury.util.MathUtils;
 import org.apache.fury.util.Platform;
@@ -355,7 +355,7 @@ public final class StringSerializer extends Serializer<String> {
       // jvm doesn't eliminate well in some jdk.
       final int targetIndex = buffer.unsafeHeapWriterIndex();
       int arrIndex = targetIndex;
-      arrIndex += MemoryUtils.putVarUint36Small(targetArray, arrIndex, header);
+      arrIndex += LittleEndian.putVarUint36Small(targetArray, arrIndex, header);
       writerIndex += arrIndex - targetIndex;
       System.arraycopy(bytes, 0, targetArray, arrIndex, bytesLen);
     } else {
@@ -377,7 +377,7 @@ public final class StringSerializer extends Serializer<String> {
     final byte[] targetArray = buffer.getHeapMemory();
     if (targetArray != null) {
       int arrIndex = buffer.unsafeHeapWriterIndex();
-      int written = MemoryUtils.putVarUint36Small(targetArray, arrIndex, header);
+      int written = LittleEndian.putVarUint36Small(targetArray, arrIndex, header);
       arrIndex += written;
       writerIndex += written + strLen;
       for (int i = 0; i < strLen; i++) {
@@ -407,7 +407,7 @@ public final class StringSerializer extends Serializer<String> {
     byte[] targetArray = buffer.getHeapMemory();
     if (targetArray != null) {
       int arrIndex = buffer.unsafeHeapWriterIndex();
-      int written = MemoryUtils.putVarUint36Small(targetArray, arrIndex, header);
+      int written = LittleEndian.putVarUint36Small(targetArray, arrIndex, header);
       arrIndex += written;
       writerIndex += written + numBytes;
       if (Platform.IS_LITTLE_ENDIAN) {

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/StringSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/StringSerializer.java
@@ -641,7 +641,7 @@ public final class StringSerializer extends Serializer<String> {
 
   public void writeUTF8String(MemoryBuffer buffer, String value) {
     byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
-    buffer.writePositiveVarInt(bytes.length);
+    buffer.writeVarUint32(bytes.length);
     buffer.writeBytes(bytes);
   }
 

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/StructSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/StructSerializer.java
@@ -167,7 +167,7 @@ public class StructSerializer<T> extends Serializer<T> {
       typeHash = computeStructHash();
       this.typeHash = typeHash;
     }
-    int newHash = buffer.readInt();
+    int newHash = buffer.readInt32();
     if (newHash != typeHash) {
       throw new ClassNotCompatibleException(
           String.format(

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/StructSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/StructSerializer.java
@@ -122,7 +122,7 @@ public class StructSerializer<T> extends Serializer<T> {
       typeHash = computeStructHash();
       this.typeHash = typeHash;
     }
-    buffer.writeInt(typeHash);
+    buffer.writeInt32(typeHash);
     Generics generics = fury.getGenerics();
     GenericType[] fieldGenerics = getGenericTypes(generics);
     for (int i = 0; i < fieldAccessors.length; i++) {

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/TimeSerializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/TimeSerializers.java
@@ -73,7 +73,7 @@ public class TimeSerializers {
 
     @Override
     public T read(MemoryBuffer buffer) {
-      return newInstance(buffer.readLong());
+      return newInstance(buffer.readInt64());
     }
 
     protected abstract T newInstance(long time);
@@ -146,7 +146,7 @@ public class TimeSerializers {
 
     @Override
     public Timestamp xread(MemoryBuffer buffer) {
-      return DateTimeUtils.toJavaTimestamp(buffer.readLong());
+      return DateTimeUtils.toJavaTimestamp(buffer.readInt64());
     }
 
     @Override
@@ -163,8 +163,8 @@ public class TimeSerializers {
 
     @Override
     public Timestamp read(MemoryBuffer buffer) {
-      Timestamp t = new Timestamp(buffer.readLong());
-      t.setNanos(buffer.readInt());
+      Timestamp t = new Timestamp(buffer.readInt64());
+      t.setNanos(buffer.readInt32());
       return t;
     }
   }
@@ -191,7 +191,7 @@ public class TimeSerializers {
 
     @Override
     public LocalDate xread(MemoryBuffer buffer) {
-      return DateTimeUtils.daysToLocalDate(buffer.readInt());
+      return DateTimeUtils.daysToLocalDate(buffer.readInt32());
     }
 
     @Override
@@ -211,7 +211,7 @@ public class TimeSerializers {
     }
 
     public static LocalDate readLocalDate(MemoryBuffer buffer) {
-      int year = buffer.readInt();
+      int year = buffer.readInt32();
       int month = buffer.readByte();
       int dayOfMonth = buffer.readByte();
       return LocalDate.of(year, month, dayOfMonth);
@@ -240,7 +240,7 @@ public class TimeSerializers {
 
     @Override
     public Instant xread(MemoryBuffer buffer) {
-      return DateTimeUtils.microsToInstant(buffer.readLong());
+      return DateTimeUtils.microsToInstant(buffer.readInt64());
     }
 
     @Override
@@ -251,8 +251,8 @@ public class TimeSerializers {
 
     @Override
     public Instant read(MemoryBuffer buffer) {
-      long seconds = buffer.readLong();
-      int nanos = buffer.readInt();
+      long seconds = buffer.readInt64();
+      int nanos = buffer.readInt32();
       return Instant.ofEpochSecond(seconds, nanos);
     }
   }
@@ -274,8 +274,8 @@ public class TimeSerializers {
 
     @Override
     public Duration read(MemoryBuffer buffer) {
-      long seconds = buffer.readLong();
-      int nanos = buffer.readInt();
+      long seconds = buffer.readInt64();
+      int nanos = buffer.readInt32();
       return Duration.ofSeconds(seconds, nanos);
     }
   }
@@ -360,7 +360,7 @@ public class TimeSerializers {
           if (second < 0) {
             second = ~second;
           } else {
-            nano = buffer.readInt();
+            nano = buffer.readInt32();
           }
         }
       }
@@ -415,11 +415,11 @@ public class TimeSerializers {
 
     public Calendar read(MemoryBuffer buffer) {
       Calendar result = Calendar.getInstance(timeZoneSerializer.read(buffer));
-      result.setTimeInMillis(buffer.readLong());
+      result.setTimeInMillis(buffer.readInt64());
       result.setLenient(buffer.readBoolean());
       result.setFirstDayOfWeek(buffer.readByte());
       result.setMinimalDaysInFirstWeek(buffer.readByte());
-      long gregorianChange = buffer.readLong();
+      long gregorianChange = buffer.readInt64();
       if (gregorianChange != DEFAULT_GREGORIAN_CUTOVER) {
         if (result instanceof GregorianCalendar) {
           ((GregorianCalendar) result).setGregorianChange(new Date(gregorianChange));
@@ -478,7 +478,7 @@ public class TimeSerializers {
     public static ZoneOffset readZoneOffset(MemoryBuffer buffer) {
       int offsetByte = buffer.readByte();
       return (offsetByte == 127
-          ? ZoneOffset.ofTotalSeconds(buffer.readInt())
+          ? ZoneOffset.ofTotalSeconds(buffer.readInt32())
           : ZoneOffset.ofTotalSeconds(offsetByte * 900));
     }
   }
@@ -523,7 +523,7 @@ public class TimeSerializers {
 
     @Override
     public Year read(MemoryBuffer buffer) {
-      return Year.of(buffer.readInt());
+      return Year.of(buffer.readInt32());
     }
   }
 
@@ -544,7 +544,7 @@ public class TimeSerializers {
 
     @Override
     public YearMonth read(MemoryBuffer buffer) {
-      int year = buffer.readInt();
+      int year = buffer.readInt32();
       byte month = buffer.readByte();
       return YearMonth.of(year, month);
     }
@@ -587,9 +587,9 @@ public class TimeSerializers {
     }
 
     public Period read(MemoryBuffer buffer) {
-      int years = buffer.readInt();
-      int months = buffer.readInt();
-      int days = buffer.readInt();
+      int years = buffer.readInt32();
+      int months = buffer.readInt32();
+      int days = buffer.readInt32();
       return Period.of(years, months, days);
     }
   }

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/TimeSerializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/TimeSerializers.java
@@ -68,7 +68,7 @@ public class TimeSerializers {
 
     @Override
     public void write(MemoryBuffer buffer, T value) {
-      buffer.writeLong(value.getTime());
+      buffer.writeInt64(value.getTime());
     }
 
     @Override
@@ -141,7 +141,7 @@ public class TimeSerializers {
 
     @Override
     public void xwrite(MemoryBuffer buffer, Timestamp value) {
-      buffer.writeLong(DateTimeUtils.fromJavaTimestamp(value));
+      buffer.writeInt64(DateTimeUtils.fromJavaTimestamp(value));
     }
 
     @Override
@@ -157,8 +157,8 @@ public class TimeSerializers {
     @Override
     public void write(MemoryBuffer buffer, Timestamp value) {
       long time = value.getTime() - (value.getNanos() / 1_000_000);
-      buffer.writeLong(time);
-      buffer.writeInt(value.getNanos());
+      buffer.writeInt64(time);
+      buffer.writeInt32(value.getNanos());
     }
 
     @Override
@@ -186,7 +186,7 @@ public class TimeSerializers {
     @Override
     public void xwrite(MemoryBuffer buffer, LocalDate value) {
       // TODO use java encoding to support larger range.
-      buffer.writeInt(DateTimeUtils.localDateToDays(value));
+      buffer.writeInt32(DateTimeUtils.localDateToDays(value));
     }
 
     @Override
@@ -200,7 +200,7 @@ public class TimeSerializers {
     }
 
     public static void writeLocalDate(MemoryBuffer buffer, LocalDate value) {
-      buffer.writeInt(value.getYear());
+      buffer.writeInt32(value.getYear());
       buffer.writeByte(value.getMonthValue());
       buffer.writeByte(value.getDayOfMonth());
     }
@@ -235,7 +235,7 @@ public class TimeSerializers {
     @Override
     public void xwrite(MemoryBuffer buffer, Instant value) {
       // FIXME JDK17 may have higher precision than millisecond
-      buffer.writeLong(DateTimeUtils.instantToMicros(value));
+      buffer.writeInt64(DateTimeUtils.instantToMicros(value));
     }
 
     @Override
@@ -245,8 +245,8 @@ public class TimeSerializers {
 
     @Override
     public void write(MemoryBuffer buffer, Instant value) {
-      buffer.writeLong(value.getEpochSecond());
-      buffer.writeInt(value.getNano());
+      buffer.writeInt64(value.getEpochSecond());
+      buffer.writeInt32(value.getNano());
     }
 
     @Override
@@ -268,8 +268,8 @@ public class TimeSerializers {
 
     @Override
     public void write(MemoryBuffer buffer, Duration value) {
-      buffer.writeLong(value.getSeconds());
-      buffer.writeInt(value.getNano());
+      buffer.writeInt64(value.getSeconds());
+      buffer.writeInt32(value.getNano());
     }
 
     @Override
@@ -335,7 +335,7 @@ public class TimeSerializers {
         buffer.writeByte(time.getHour());
         buffer.writeByte(time.getMinute());
         buffer.writeByte(time.getSecond());
-        buffer.writeInt(time.getNano());
+        buffer.writeInt32(time.getNano());
       }
     }
 
@@ -402,14 +402,14 @@ public class TimeSerializers {
 
     public void write(MemoryBuffer buffer, Calendar object) {
       timeZoneSerializer.write(buffer, object.getTimeZone()); // can't be null
-      buffer.writeLong(object.getTimeInMillis());
+      buffer.writeInt64(object.getTimeInMillis());
       buffer.writeBoolean(object.isLenient());
       buffer.writeByte(object.getFirstDayOfWeek());
       buffer.writeByte(object.getMinimalDaysInFirstWeek());
       if (object instanceof GregorianCalendar) {
-        buffer.writeLong(((GregorianCalendar) object).getGregorianChange().getTime());
+        buffer.writeInt64(((GregorianCalendar) object).getGregorianChange().getTime());
       } else {
-        buffer.writeLong(DEFAULT_GREGORIAN_CUTOVER);
+        buffer.writeInt64(DEFAULT_GREGORIAN_CUTOVER);
       }
     }
 
@@ -467,7 +467,7 @@ public class TimeSerializers {
       int offsetByte = offsetSecs % 900 == 0 ? offsetSecs / 900 : 127; // compress to -72 to +72
       buffer.writeByte(offsetByte);
       if (offsetByte == 127) {
-        buffer.writeInt(offsetSecs);
+        buffer.writeInt32(offsetSecs);
       }
     }
 
@@ -518,7 +518,7 @@ public class TimeSerializers {
 
     @Override
     public void write(MemoryBuffer buffer, Year obj) {
-      buffer.writeInt(obj.getValue());
+      buffer.writeInt32(obj.getValue());
     }
 
     @Override
@@ -538,7 +538,7 @@ public class TimeSerializers {
 
     @Override
     public void write(MemoryBuffer buffer, YearMonth obj) {
-      buffer.writeInt(obj.getYear());
+      buffer.writeInt32(obj.getYear());
       buffer.writeByte(obj.getMonthValue());
     }
 
@@ -581,9 +581,9 @@ public class TimeSerializers {
     }
 
     public void write(MemoryBuffer buffer, Period obj) {
-      buffer.writeInt(obj.getYears());
-      buffer.writeInt(obj.getMonths());
-      buffer.writeInt(obj.getDays());
+      buffer.writeInt32(obj.getYears());
+      buffer.writeInt32(obj.getMonths());
+      buffer.writeInt32(obj.getDays());
     }
 
     public Period read(MemoryBuffer buffer) {

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/UnexistedClassSerializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/UnexistedClassSerializers.java
@@ -115,9 +115,9 @@ public final class UnexistedClassSerializers {
       // class not exist, use class def id for identity.
       int id = classMap.putOrGet(value.classDef.getId(), newId);
       if (id >= 0) {
-        buffer.writePositiveVarInt(id);
+        buffer.writeVarUint32(id);
       } else {
-        buffer.writePositiveVarInt(newId);
+        buffer.writeVarUint32(newId);
         metaContext.writingClassDefs.add(value.classDef);
       }
     }

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/UnexistedClassSerializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/UnexistedClassSerializers.java
@@ -132,7 +132,7 @@ public final class UnexistedClassSerializers {
       RefResolver refResolver = fury.getRefResolver();
       ClassResolver classResolver = fury.getClassResolver();
       if (fury.checkClassVersion()) {
-        buffer.writeInt(fieldsInfo.classVersionHash);
+        buffer.writeInt32(fieldsInfo.classVersionHash);
       }
       // write order: primitive,boxed,final,other,collection,map
       ObjectSerializer.FinalTypeField[] finalFields = fieldsInfo.finalFields;

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/collection/AbstractCollectionSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/collection/AbstractCollectionSerializer.java
@@ -439,7 +439,7 @@ public abstract class AbstractCollectionSerializer<T> extends Serializer<T> {
   public void xwrite(MemoryBuffer buffer, T value) {
     Collection collection = (Collection) value;
     int len = collection.size();
-    buffer.writePositiveVarInt(len);
+    buffer.writeVarUint32(len);
     xwriteElements(fury, buffer, collection);
   }
 

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/collection/AbstractMapSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/collection/AbstractMapSerializer.java
@@ -704,7 +704,7 @@ public abstract class AbstractMapSerializer<T> extends Serializer<T> {
    * will raise NPE.
    */
   public Map newMap(MemoryBuffer buffer) {
-    numElements = buffer.readPositiveVarInt();
+    numElements = buffer.readVarUint32();
     if (constructor == null) {
       constructor = ReflectionUtils.getCtrHandle(type, true);
     }

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/collection/ChildContainerSerializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/collection/ChildContainerSerializers.java
@@ -136,7 +136,7 @@ public class ChildContainerSerializers {
 
     @Override
     public Collection onCollectionWrite(MemoryBuffer buffer, T value) {
-      buffer.writePositiveVarInt(value.size());
+      buffer.writeVarUint32(value.size());
       for (Serializer slotsSerializer : slotsSerializers) {
         slotsSerializer.write(buffer, value);
       }
@@ -185,7 +185,7 @@ public class ChildContainerSerializers {
 
     @Override
     public Map onMapWrite(MemoryBuffer buffer, T value) {
-      buffer.writePositiveVarInt(value.size());
+      buffer.writeVarUint32(value.size());
       for (Serializer slotsSerializer : slotsSerializers) {
         slotsSerializer.write(buffer, value);
       }

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/collection/CollectionSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/collection/CollectionSerializer.java
@@ -36,7 +36,7 @@ public class CollectionSerializer<T extends Collection> extends AbstractCollecti
 
   @Override
   public Collection onCollectionWrite(MemoryBuffer buffer, T value) {
-    buffer.writePositiveVarInt(value.size());
+    buffer.writeVarUint32(value.size());
     return value;
   }
 

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/collection/CollectionSerializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/collection/CollectionSerializers.java
@@ -126,7 +126,7 @@ public class CollectionSerializers {
 
     @Override
     public List<?> xread(MemoryBuffer buffer) {
-      int numElements = buffer.readPositiveVarInt();
+      int numElements = buffer.readVarUint32();
       Object[] arr = new Object[numElements];
       for (int i = 0; i < numElements; i++) {
         Object elem = fury.xreadRef(buffer);
@@ -148,7 +148,7 @@ public class CollectionSerializers {
 
     @Override
     public HashSet newCollection(MemoryBuffer buffer) {
-      int numElements = buffer.readPositiveVarInt();
+      int numElements = buffer.readVarUint32();
       setNumElements(numElements);
       HashSet hashSet = new HashSet(numElements);
       fury.getRefResolver().reference(hashSet);
@@ -168,7 +168,7 @@ public class CollectionSerializers {
 
     @Override
     public LinkedHashSet newCollection(MemoryBuffer buffer) {
-      int numElements = buffer.readPositiveVarInt();
+      int numElements = buffer.readVarUint32();
       setNumElements(numElements);
       LinkedHashSet hashSet = new LinkedHashSet(numElements);
       fury.getRefResolver().reference(hashSet);
@@ -192,7 +192,7 @@ public class CollectionSerializers {
 
     @Override
     public Collection onCollectionWrite(MemoryBuffer buffer, T value) {
-      buffer.writePositiveVarInt(value.size());
+      buffer.writeVarUint32(value.size());
       fury.writeRef(buffer, value.comparator());
       return value;
     }
@@ -200,7 +200,7 @@ public class CollectionSerializers {
     @SuppressWarnings("unchecked")
     @Override
     public T newCollection(MemoryBuffer buffer) {
-      int numElements = buffer.readPositiveVarInt();
+      int numElements = buffer.readVarUint32();
       setNumElements(numElements);
       T collection;
       Comparator comparator = (Comparator) fury.readRef(buffer);
@@ -240,7 +240,7 @@ public class CollectionSerializers {
     @Override
     public void xwrite(MemoryBuffer buffer, List<?> value) {
       // write length
-      buffer.writePositiveVarInt(0);
+      buffer.writeVarUint32(0);
     }
 
     @Override
@@ -250,7 +250,7 @@ public class CollectionSerializers {
 
     @Override
     public List<?> xread(MemoryBuffer buffer) {
-      buffer.readPositiveVarInt();
+      buffer.readVarUint32();
       return Collections.EMPTY_LIST;
     }
   }
@@ -272,7 +272,7 @@ public class CollectionSerializers {
     @Override
     public void xwrite(MemoryBuffer buffer, Set<?> value) {
       // write length
-      buffer.writePositiveVarInt(0);
+      buffer.writeVarUint32(0);
     }
 
     @Override
@@ -282,7 +282,7 @@ public class CollectionSerializers {
 
     @Override
     public Set<?> xread(MemoryBuffer buffer) {
-      buffer.readPositiveVarInt();
+      buffer.readVarUint32();
       return Collections.EMPTY_SET;
     }
   }
@@ -321,7 +321,7 @@ public class CollectionSerializers {
 
     @Override
     public void xwrite(MemoryBuffer buffer, List<?> value) {
-      buffer.writePositiveVarInt(1);
+      buffer.writeVarUint32(1);
       fury.xwriteRef(buffer, value.get(0));
     }
 
@@ -332,7 +332,7 @@ public class CollectionSerializers {
 
     @Override
     public List<?> xread(MemoryBuffer buffer) {
-      buffer.readPositiveVarInt();
+      buffer.readVarUint32();
       return Collections.singletonList(fury.xreadRef(buffer));
     }
   }
@@ -355,7 +355,7 @@ public class CollectionSerializers {
 
     @Override
     public void xwrite(MemoryBuffer buffer, Set<?> value) {
-      buffer.writePositiveVarInt(1);
+      buffer.writeVarUint32(1);
       fury.xwriteRef(buffer, value.iterator().next());
     }
 
@@ -366,7 +366,7 @@ public class CollectionSerializers {
 
     @Override
     public Set<?> xread(MemoryBuffer buffer) {
-      buffer.readPositiveVarInt();
+      buffer.readVarUint32();
       return Collections.singleton(fury.xreadRef(buffer));
     }
   }
@@ -380,7 +380,7 @@ public class CollectionSerializers {
 
     @Override
     public ConcurrentSkipListSet newCollection(MemoryBuffer buffer) {
-      int numElements = buffer.readPositiveVarInt();
+      int numElements = buffer.readVarUint32();
       setNumElements(numElements);
       Comparator comparator = (Comparator) fury.readRef(buffer);
       ConcurrentSkipListSet skipListSet = new ConcurrentSkipListSet(comparator);
@@ -397,7 +397,7 @@ public class CollectionSerializers {
 
     @Override
     public Vector newCollection(MemoryBuffer buffer) {
-      int numElements = buffer.readPositiveVarInt();
+      int numElements = buffer.readVarUint32();
       setNumElements(numElements);
       Vector<Object> vector = new Vector<>(numElements);
       fury.getRefResolver().reference(vector);
@@ -413,7 +413,7 @@ public class CollectionSerializers {
 
     @Override
     public ArrayDeque newCollection(MemoryBuffer buffer) {
-      int numElements = buffer.readPositiveVarInt();
+      int numElements = buffer.readVarUint32();
       setNumElements(numElements);
       ArrayDeque deque = new ArrayDeque(numElements);
       fury.getRefResolver().reference(deque);
@@ -442,7 +442,7 @@ public class CollectionSerializers {
       }
       fury.getClassResolver().writeClassAndUpdateCache(buffer, elemClass);
       Serializer serializer = fury.getClassResolver().getSerializer(elemClass);
-      buffer.writePositiveVarInt(object.size());
+      buffer.writeVarUint32(object.size());
       for (Object element : object) {
         serializer.write(buffer, element);
       }
@@ -453,7 +453,7 @@ public class CollectionSerializers {
       Class elemClass = fury.getClassResolver().readClassInfo(buffer).getCls();
       EnumSet object = EnumSet.noneOf(elemClass);
       Serializer elemSerializer = fury.getClassResolver().getSerializer(elemClass);
-      int length = buffer.readPositiveVarInt();
+      int length = buffer.readVarUint32();
       for (int i = 0; i < length; i++) {
         object.add(elemSerializer.read(buffer));
       }
@@ -475,7 +475,7 @@ public class CollectionSerializers {
 
     @Override
     public BitSet read(MemoryBuffer buffer) {
-      long[] values = buffer.readLongs(buffer.readPositiveVarInt());
+      long[] values = buffer.readLongs(buffer.readVarUint32());
       return BitSet.valueOf(values);
     }
   }
@@ -486,14 +486,14 @@ public class CollectionSerializers {
     }
 
     public Collection onCollectionWrite(MemoryBuffer buffer, PriorityQueue value) {
-      buffer.writePositiveVarInt(value.size());
+      buffer.writeVarUint32(value.size());
       fury.writeRef(buffer, value.comparator());
       return value;
     }
 
     @Override
     public PriorityQueue newCollection(MemoryBuffer buffer) {
-      int numElements = buffer.readPositiveVarInt();
+      int numElements = buffer.readVarUint32();
       setNumElements(numElements);
       Comparator comparator = (Comparator) fury.readRef(buffer);
       PriorityQueue queue = new PriorityQueue(comparator);

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/collection/FuryArrayAsListSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/collection/FuryArrayAsListSerializer.java
@@ -39,7 +39,7 @@ public final class FuryArrayAsListSerializer extends CollectionSerializer<ArrayA
   }
 
   public Collection newCollection(MemoryBuffer buffer) {
-    int numElements = buffer.readPositiveVarInt();
+    int numElements = buffer.readVarUint32();
     setNumElements(numElements);
     return new ArrayAsList(numElements);
   }

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/collection/GuavaCollectionSerializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/collection/GuavaCollectionSerializers.java
@@ -53,7 +53,7 @@ public class GuavaCollectionSerializers {
 
     @Override
     public T xread(MemoryBuffer buffer) {
-      int size = buffer.readPositiveVarInt();
+      int size = buffer.readVarUint32();
       List list = new ArrayList<>();
       xreadElements(fury, buffer, list, size);
       return xnewInstance(list);
@@ -71,7 +71,7 @@ public class GuavaCollectionSerializers {
 
     @Override
     public Collection newCollection(MemoryBuffer buffer) {
-      int numElements = buffer.readPositiveVarInt();
+      int numElements = buffer.readVarUint32();
       setNumElements(numElements);
       return new CollectionContainer<>(numElements);
     }
@@ -122,7 +122,7 @@ public class GuavaCollectionSerializers {
 
     @Override
     public Collection newCollection(MemoryBuffer buffer) {
-      int numElements = buffer.readPositiveVarInt();
+      int numElements = buffer.readVarUint32();
       setNumElements(numElements);
       return new CollectionContainer(numElements);
     }
@@ -153,7 +153,7 @@ public class GuavaCollectionSerializers {
 
     @Override
     public Collection newCollection(MemoryBuffer buffer) {
-      int numElements = buffer.readPositiveVarInt();
+      int numElements = buffer.readVarUint32();
       setNumElements(numElements);
       return new CollectionContainer<>(numElements);
     }
@@ -184,14 +184,14 @@ public class GuavaCollectionSerializers {
 
     @Override
     public Collection onCollectionWrite(MemoryBuffer buffer, T value) {
-      buffer.writePositiveVarInt(value.size());
+      buffer.writeVarUint32(value.size());
       fury.writeRef(buffer, value.comparator());
       return value;
     }
 
     @Override
     public Collection newCollection(MemoryBuffer buffer) {
-      int numElements = buffer.readPositiveVarInt();
+      int numElements = buffer.readVarUint32();
       setNumElements(numElements);
       Comparator comparator = (Comparator) fury.readRef(buffer);
       return new SortedCollectionContainer(comparator, numElements);
@@ -216,7 +216,7 @@ public class GuavaCollectionSerializers {
 
     @Override
     public Map newMap(MemoryBuffer buffer) {
-      int numElements = buffer.readPositiveVarInt();
+      int numElements = buffer.readVarUint32();
       setNumElements(numElements);
       return new MapContainer(numElements);
     }
@@ -241,7 +241,7 @@ public class GuavaCollectionSerializers {
 
     @Override
     public T xread(MemoryBuffer buffer) {
-      int size = buffer.readPositiveVarInt();
+      int size = buffer.readVarUint32();
       Map map = new HashMap();
       xreadElements(fury, buffer, map, size);
       return xnewInstance(map);
@@ -319,14 +319,14 @@ public class GuavaCollectionSerializers {
 
     @Override
     public Map onMapWrite(MemoryBuffer buffer, T value) {
-      buffer.writePositiveVarInt(value.size());
+      buffer.writeVarUint32(value.size());
       fury.writeRef(buffer, value.comparator());
       return value;
     }
 
     @Override
     public Map newMap(MemoryBuffer buffer) {
-      int numElements = buffer.readPositiveVarInt();
+      int numElements = buffer.readVarUint32();
       setNumElements(numElements);
       Comparator comparator = (Comparator) fury.readRef(buffer);
       return new SortedMapContainer<>(comparator, numElements);

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/collection/ImmutableCollectionSerializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/collection/ImmutableCollectionSerializers.java
@@ -109,7 +109,7 @@ public class ImmutableCollectionSerializers {
 
     @Override
     public Collection newCollection(MemoryBuffer buffer) {
-      int numElements = buffer.readPositiveVarInt();
+      int numElements = buffer.readVarUint32();
       setNumElements(numElements);
       if (Platform.JAVA_VERSION > 8) {
         return new CollectionContainer<>(numElements);
@@ -141,7 +141,7 @@ public class ImmutableCollectionSerializers {
 
     @Override
     public Collection newCollection(MemoryBuffer buffer) {
-      int numElements = buffer.readPositiveVarInt();
+      int numElements = buffer.readVarUint32();
       setNumElements(numElements);
       if (Platform.JAVA_VERSION > 8) {
         return new CollectionContainer<>(numElements);
@@ -173,7 +173,7 @@ public class ImmutableCollectionSerializers {
 
     @Override
     public Map newMap(MemoryBuffer buffer) {
-      int numElements = buffer.readPositiveVarInt();
+      int numElements = buffer.readVarUint32();
       setNumElements(numElements);
       if (Platform.JAVA_VERSION > 8) {
         return new JDKImmutableMapContainer(numElements);

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/collection/MapSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/collection/MapSerializer.java
@@ -36,7 +36,7 @@ public class MapSerializer<T extends Map> extends AbstractMapSerializer<T> {
 
   @Override
   public Map onMapWrite(MemoryBuffer buffer, T value) {
-    buffer.writePositiveVarInt(value.size());
+    buffer.writeVarUint32(value.size());
     return value;
   }
 

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/collection/MapSerializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/collection/MapSerializers.java
@@ -63,7 +63,7 @@ public class MapSerializers {
 
     @Override
     public HashMap newMap(MemoryBuffer buffer) {
-      int numElements = buffer.readPositiveVarInt();
+      int numElements = buffer.readVarUint32();
       setNumElements(numElements);
       HashMap hashMap = new HashMap(numElements);
       fury.getRefResolver().reference(hashMap);
@@ -83,7 +83,7 @@ public class MapSerializers {
 
     @Override
     public LinkedHashMap newMap(MemoryBuffer buffer) {
-      int numElements = buffer.readPositiveVarInt();
+      int numElements = buffer.readVarUint32();
       setNumElements(numElements);
       LinkedHashMap hashMap = new LinkedHashMap(numElements);
       fury.getRefResolver().reference(hashMap);
@@ -103,7 +103,7 @@ public class MapSerializers {
 
     @Override
     public LazyMap newMap(MemoryBuffer buffer) {
-      int numElements = buffer.readPositiveVarInt();
+      int numElements = buffer.readVarUint32();
       setNumElements(numElements);
       LazyMap map = new LazyMap(numElements);
       fury.getRefResolver().reference(map);
@@ -122,7 +122,7 @@ public class MapSerializers {
 
     @Override
     public Map onMapWrite(MemoryBuffer buffer, T value) {
-      buffer.writePositiveVarInt(value.size());
+      buffer.writeVarUint32(value.size());
       fury.writeRef(buffer, value.comparator());
       return value;
     }
@@ -130,7 +130,7 @@ public class MapSerializers {
     @SuppressWarnings("unchecked")
     @Override
     public Map newMap(MemoryBuffer buffer) {
-      setNumElements(buffer.readPositiveVarInt());
+      setNumElements(buffer.readVarUint32());
       T map;
       Comparator comparator = (Comparator) fury.readRef(buffer);
       if (type == TreeMap.class) {
@@ -164,7 +164,7 @@ public class MapSerializers {
     @Override
     public void xwrite(MemoryBuffer buffer, Map<?, ?> value) {
       // write length
-      buffer.writePositiveVarInt(0);
+      buffer.writeVarUint32(0);
     }
 
     @Override
@@ -174,7 +174,7 @@ public class MapSerializers {
 
     @Override
     public Map<?, ?> xread(MemoryBuffer buffer) {
-      buffer.readPositiveVarInt();
+      buffer.readVarUint32();
       return Collections.EMPTY_MAP;
     }
   }
@@ -213,7 +213,7 @@ public class MapSerializers {
 
     @Override
     public void xwrite(MemoryBuffer buffer, Map<?, ?> value) {
-      buffer.writePositiveVarInt(1);
+      buffer.writeVarUint32(1);
       Map.Entry entry = value.entrySet().iterator().next();
       fury.xwriteRef(buffer, entry.getKey());
       fury.xwriteRef(buffer, entry.getValue());
@@ -228,7 +228,7 @@ public class MapSerializers {
 
     @Override
     public Map<?, ?> xread(MemoryBuffer buffer) {
-      buffer.readPositiveVarInt();
+      buffer.readVarUint32();
       Object key = fury.xreadRef(buffer);
       Object value = fury.xreadRef(buffer);
       return Collections.singletonMap(key, value);
@@ -243,7 +243,7 @@ public class MapSerializers {
 
     @Override
     public ConcurrentHashMap newMap(MemoryBuffer buffer) {
-      int numElements = buffer.readPositiveVarInt();
+      int numElements = buffer.readVarUint32();
       setNumElements(numElements);
       ConcurrentHashMap map = new ConcurrentHashMap(numElements);
       fury.getRefResolver().reference(map);
@@ -265,7 +265,7 @@ public class MapSerializers {
 
     @Override
     public ConcurrentSkipListMap newMap(MemoryBuffer buffer) {
-      int numElements = buffer.readPositiveVarInt();
+      int numElements = buffer.readVarUint32();
       setNumElements(numElements);
       Comparator comparator = (Comparator) fury.readRef(buffer);
       ConcurrentSkipListMap map = new ConcurrentSkipListMap(comparator);
@@ -299,7 +299,7 @@ public class MapSerializers {
 
     @Override
     public Map onMapWrite(MemoryBuffer buffer, EnumMap value) {
-      buffer.writePositiveVarInt(value.size());
+      buffer.writeVarUint32(value.size());
       Class keyType = (Class) Platform.getObject(value, keyTypeFieldOffset);
       fury.getClassResolver().writeClassAndUpdateCache(buffer, keyType);
       return value;
@@ -307,7 +307,7 @@ public class MapSerializers {
 
     @Override
     public EnumMap newMap(MemoryBuffer buffer) {
-      setNumElements(buffer.readPositiveVarInt());
+      setNumElements(buffer.readVarUint32());
       Class<?> keyType = fury.getClassResolver().readClassInfo(buffer).getCls();
       return new EnumMap(keyType);
     }
@@ -322,7 +322,7 @@ public class MapSerializers {
 
     @Override
     public void write(MemoryBuffer buffer, Map<String, T> value) {
-      buffer.writePositiveVarInt(value.size());
+      buffer.writeVarUint32(value.size());
       for (Map.Entry<String, T> e : value.entrySet()) {
         fury.writeJavaStringRef(buffer, e.getKey());
         // If value is a collection, the `newCollection` method will record itself to

--- a/java/fury-core/src/main/java/org/apache/fury/type/ClassDef.java
+++ b/java/fury-core/src/main/java/org/apache/fury/type/ClassDef.java
@@ -189,7 +189,7 @@ public class ClassDef implements Serializable {
       id = Math.abs(id);
     }
     buffer.writeBytes(serialized);
-    buffer.writeLong(id);
+    buffer.writeInt64(id);
   }
 
   private static void writeSharedString(
@@ -405,7 +405,7 @@ public class ClassDef implements Serializable {
       buffer.writeBoolean(isMonomorphic);
       if (this instanceof RegisteredFieldType) {
         buffer.writeByte(0);
-        buffer.writeShort(((RegisteredFieldType) this).getClassId());
+        buffer.writeInt16(((RegisteredFieldType) this).getClassId());
       } else if (this instanceof CollectionFieldType) {
         buffer.writeByte(1);
         ((CollectionFieldType) this).elementType.write(buffer);

--- a/java/fury-core/src/main/java/org/apache/fury/type/ClassDef.java
+++ b/java/fury-core/src/main/java/org/apache/fury/type/ClassDef.java
@@ -167,14 +167,14 @@ public class ClassDef implements Serializable {
       MemoryBuffer buf = MemoryUtils.buffer(32);
       IdentityObjectIntMap<String> map = new IdentityObjectIntMap<>(8, 0.5f);
       writeSharedString(buf, map, className);
-      buf.writePositiveVarInt(fieldsInfo.size());
+      buf.writeVarUint32(fieldsInfo.size());
       for (FieldInfo fieldInfo : fieldsInfo) {
         writeSharedString(buf, map, fieldInfo.definedClass);
         byte[] bytes = fieldInfo.fieldName.getBytes(StandardCharsets.UTF_8);
         buf.writePrimitiveArrayWithSize(bytes, Platform.BYTE_ARRAY_OFFSET, bytes.length);
         fieldInfo.fieldType.write(buf);
       }
-      buf.writePositiveVarInt(extMeta.size());
+      buf.writeVarUint32(extMeta.size());
       extMeta.forEach(
           (k, v) -> {
             byte[] keyBytes = k.getBytes(StandardCharsets.UTF_8);
@@ -199,7 +199,7 @@ public class ClassDef implements Serializable {
     if (id >= 0) {
       // TODO use flagged varint.
       buffer.writeBoolean(true);
-      buffer.writePositiveVarInt(id);
+      buffer.writeVarUint32(id);
     } else {
       buffer.writeBoolean(false);
       byte[] bytes = str.getBytes(StandardCharsets.UTF_8);
@@ -212,13 +212,13 @@ public class ClassDef implements Serializable {
     List<String> strings = new ArrayList<>();
     String className = readSharedString(buffer, strings);
     List<FieldInfo> fieldInfos = new ArrayList<>();
-    int numFields = buffer.readPositiveVarInt();
+    int numFields = buffer.readVarUint32();
     for (int i = 0; i < numFields; i++) {
       String definedClass = readSharedString(buffer, strings);
       String fieldName = new String(buffer.readBytesAndSize(), StandardCharsets.UTF_8);
       fieldInfos.add(new FieldInfo(definedClass, fieldName, FieldType.read(buffer)));
     }
-    int extMetaSize = buffer.readPositiveVarInt();
+    int extMetaSize = buffer.readVarUint32();
     Map<String, String> extMeta = new HashMap<>();
     for (int i = 0; i < extMetaSize; i++) {
       extMeta.put(

--- a/java/fury-core/src/main/java/org/apache/fury/type/ClassDef.java
+++ b/java/fury-core/src/main/java/org/apache/fury/type/ClassDef.java
@@ -225,7 +225,7 @@ public class ClassDef implements Serializable {
           new String(buffer.readBytesAndSize(), StandardCharsets.UTF_8),
           new String(buffer.readBytesAndSize(), StandardCharsets.UTF_8));
     }
-    long id = buffer.readLong();
+    long id = buffer.readInt64();
     ClassDef classDef = new ClassDef(className, fieldInfos, extMeta);
     classDef.id = id;
     return classDef;
@@ -425,7 +425,7 @@ public class ClassDef implements Serializable {
       byte typecode = buffer.readByte();
       switch (typecode) {
         case 0:
-          return new RegisteredFieldType(isFinal, buffer.readShort());
+          return new RegisteredFieldType(isFinal, buffer.readInt16());
         case 1:
           return new CollectionFieldType(isFinal, read(buffer));
         case 2:

--- a/java/fury-core/src/main/resources/META-INF/NOTICE
+++ b/java/fury-core/src/main/resources/META-INF/NOTICE
@@ -27,10 +27,6 @@ The text of each license is the standard Apache 2.0 license.
       java/fury-core/src/main/java/org/apache/fury/codegen/Code.java
       java/fury-core/src/main/java/org/apache/fury/util/Platform.java
 
-* flink (https://github.com/apache/flink)
-    Files:
-      java/fury-core/src/main/java/org/apache/fury/memory/MemoryBuffer.java
-
 * commons-io (https://github.com/apache/commons-io)
     Files:
       java/fury-core/src/main/java/org/apache/fury/io/ClassLoaderObjectInputStream.java

--- a/java/fury-core/src/test/java/org/apache/fury/CrossLanguageTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/CrossLanguageTest.java
@@ -139,13 +139,13 @@ public class CrossLanguageTest {
     buffer = MemoryUtils.wrap(Files.readAllBytes(dataFile));
     Assert.assertTrue(buffer.readBoolean());
     Assert.assertEquals(buffer.readByte(), Byte.MAX_VALUE);
-    Assert.assertEquals(buffer.readShort(), Short.MAX_VALUE);
-    Assert.assertEquals(buffer.readInt(), Integer.MAX_VALUE);
-    Assert.assertEquals(buffer.readLong(), Long.MAX_VALUE);
-    Assert.assertEquals(buffer.readFloat(), -1.1f, 0.0001);
-    Assert.assertEquals(buffer.readDouble(), -1.1, 0.0001);
+    Assert.assertEquals(buffer.readInt16(), Short.MAX_VALUE);
+    Assert.assertEquals(buffer.readInt32(), Integer.MAX_VALUE);
+    Assert.assertEquals(buffer.readInt64(), Long.MAX_VALUE);
+    Assert.assertEquals(buffer.readFloat32(), -1.1f, 0.0001);
+    Assert.assertEquals(buffer.readFloat64(), -1.1, 0.0001);
     Assert.assertEquals(buffer.readVarUint32(), 100);
-    Assert.assertTrue(Arrays.equals(buffer.readBytes(buffer.readInt()), bytes));
+    Assert.assertTrue(Arrays.equals(buffer.readBytes(buffer.readInt32()), bytes));
   }
 
   @Test
@@ -699,10 +699,10 @@ public class CrossLanguageTest {
 
     MemoryBuffer inBandBuffer = MemoryUtils.wrap(Files.readAllBytes(intBandDataFile));
     outOfBandBuffer = MemoryUtils.wrap(Files.readAllBytes(outOfBandDataFile));
-    int numBuffers = outOfBandBuffer.readInt();
+    int numBuffers = outOfBandBuffer.readInt32();
     buffers = new ArrayList<>();
     for (int i = 0; i < numBuffers; i++) {
-      int len = outOfBandBuffer.readInt();
+      int len = outOfBandBuffer.readInt32();
       int readerIndex = outOfBandBuffer.readerIndex();
       buffers.add(outOfBandBuffer.slice(readerIndex, len));
       outOfBandBuffer.readerIndex(readerIndex + len);

--- a/java/fury-core/src/test/java/org/apache/fury/CrossLanguageTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/CrossLanguageTest.java
@@ -117,14 +117,14 @@ public class CrossLanguageTest {
     MemoryBuffer buffer = MemoryUtils.buffer(32);
     buffer.writeBoolean(true);
     buffer.writeByte(Byte.MAX_VALUE);
-    buffer.writeShort(Short.MAX_VALUE);
-    buffer.writeInt(Integer.MAX_VALUE);
-    buffer.writeLong(Long.MAX_VALUE);
-    buffer.writeFloat(-1.1f);
-    buffer.writeDouble(-1.1);
+    buffer.writeInt16(Short.MAX_VALUE);
+    buffer.writeInt32(Integer.MAX_VALUE);
+    buffer.writeInt64(Long.MAX_VALUE);
+    buffer.writeFloat32(-1.1f);
+    buffer.writeFloat64(-1.1);
     buffer.writeVarUint32(100);
     byte[] bytes = {'a', 'b'};
-    buffer.writeInt(bytes.length);
+    buffer.writeInt32(bytes.length);
     buffer.writeBytes(bytes);
     Path dataFile = Files.createTempFile("test_buffer", "data");
     Files.write(dataFile, buffer.getBytes(0, buffer.writerIndex()));
@@ -170,8 +170,8 @@ public class CrossLanguageTest {
     Assert.assertTrue(executeCommand(command, 30));
     long[] longs = MurmurHash3.murmurhash3_x64_128(new byte[] {1, 2, 8}, 0, 3, 47);
     buffer.writerIndex(0);
-    buffer.writeLong(longs[0]);
-    buffer.writeLong(longs[1]);
+    buffer.writeInt64(longs[0]);
+    buffer.writeInt64(longs[1]);
     Files.write(
         dataFile, buffer.getBytes(0, buffer.writerIndex()), StandardOpenOption.TRUNCATE_EXISTING);
     Assert.assertTrue(executeCommand(command, 30));
@@ -681,9 +681,9 @@ public class CrossLanguageTest {
     Files.deleteIfExists(outOfBandDataFile);
     Files.createFile(outOfBandDataFile);
     MemoryBuffer outOfBandBuffer = MemoryBuffer.newHeapBuffer(32);
-    outOfBandBuffer.writeInt(buffers.size());
+    outOfBandBuffer.writeInt32(buffers.size());
     for (int i = 0; i < buffers.size(); i++) {
-      outOfBandBuffer.writeInt(bufferObjects.get(i).totalBytes());
+      outOfBandBuffer.writeInt32(bufferObjects.get(i).totalBytes());
       bufferObjects.get(i).writeTo(outOfBandBuffer);
     }
     Files.write(outOfBandDataFile, outOfBandBuffer.getBytes(0, outOfBandBuffer.writerIndex()));

--- a/java/fury-core/src/test/java/org/apache/fury/CrossLanguageTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/CrossLanguageTest.java
@@ -122,7 +122,7 @@ public class CrossLanguageTest {
     buffer.writeLong(Long.MAX_VALUE);
     buffer.writeFloat(-1.1f);
     buffer.writeDouble(-1.1);
-    buffer.writePositiveVarInt(100);
+    buffer.writeVarUint32(100);
     byte[] bytes = {'a', 'b'};
     buffer.writeInt(bytes.length);
     buffer.writeBytes(bytes);
@@ -144,7 +144,7 @@ public class CrossLanguageTest {
     Assert.assertEquals(buffer.readLong(), Long.MAX_VALUE);
     Assert.assertEquals(buffer.readFloat(), -1.1f, 0.0001);
     Assert.assertEquals(buffer.readDouble(), -1.1, 0.0001);
-    Assert.assertEquals(buffer.readPositiveVarInt(), 100);
+    Assert.assertEquals(buffer.readVarUint32(), 100);
     Assert.assertTrue(Arrays.equals(buffer.readBytes(buffer.readInt()), bytes));
   }
 

--- a/java/fury-core/src/test/java/org/apache/fury/FuryTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/FuryTest.java
@@ -178,8 +178,8 @@ public class FuryTest extends FuryTestBase {
     MemoryBuffer buffer0 = MemoryUtils.buffer(64);
     buffer0.writeLong(-1);
     buffer0.writeLong(-1);
-    buffer0.readLong();
-    buffer0.readLong();
+    buffer0.readInt64();
+    buffer0.readInt64();
     MemoryBuffer buffer = buffer0.slice(8);
     assertSerializationToBuffer(fury1, fury2, buffer);
   }
@@ -492,7 +492,7 @@ public class FuryTest extends FuryTestBase {
 
     @Override
     public UUID read(MemoryBuffer buffer) {
-      return new UUID(buffer.readLong(), buffer.readLong());
+      return new UUID(buffer.readInt64(), buffer.readInt64());
     }
 
     @Override

--- a/java/fury-core/src/test/java/org/apache/fury/FuryTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/FuryTest.java
@@ -176,8 +176,8 @@ public class FuryTest extends FuryTestBase {
     Fury fury1 = Fury.builder().withLanguage(language).requireClassRegistration(false).build();
     Fury fury2 = Fury.builder().withLanguage(language).requireClassRegistration(false).build();
     MemoryBuffer buffer0 = MemoryUtils.buffer(64);
-    buffer0.writeLong(-1);
-    buffer0.writeLong(-1);
+    buffer0.writeInt64(-1);
+    buffer0.writeInt64(-1);
     buffer0.readInt64();
     buffer0.readInt64();
     MemoryBuffer buffer = buffer0.slice(8);
@@ -497,8 +497,8 @@ public class FuryTest extends FuryTestBase {
 
     @Override
     public void write(MemoryBuffer buffer, UUID value) {
-      buffer.writeLong(value.getMostSignificantBits());
-      buffer.writeLong(value.getLeastSignificantBits());
+      buffer.writeInt64(value.getMostSignificantBits());
+      buffer.writeInt64(value.getLeastSignificantBits());
     }
   }
 

--- a/java/fury-core/src/test/java/org/apache/fury/io/MemoryBufferObjectInputTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/io/MemoryBufferObjectInputTest.java
@@ -35,11 +35,11 @@ public class MemoryBufferObjectInputTest {
     Fury fury = Fury.builder().build();
     MemoryBuffer buffer = MemoryUtils.buffer(32);
     buffer.writeByte(1);
-    buffer.writeInt(2);
-    buffer.writeLong(3);
+    buffer.writeInt32(2);
+    buffer.writeInt64(3);
     buffer.writeBoolean(true);
-    buffer.writeFloat(4.1f);
-    buffer.writeDouble(4.2);
+    buffer.writeFloat32(4.1f);
+    buffer.writeFloat64(4.2);
     fury.writeJavaString(buffer, "abc");
     try (MemoryBufferObjectInput input = new MemoryBufferObjectInput(fury, buffer)) {
       assertEquals(input.readByte(), 1);

--- a/java/fury-core/src/test/java/org/apache/fury/io/MemoryBufferObjectInputTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/io/MemoryBufferObjectInputTest.java
@@ -43,11 +43,11 @@ public class MemoryBufferObjectInputTest {
     fury.writeJavaString(buffer, "abc");
     try (MemoryBufferObjectInput input = new MemoryBufferObjectInput(fury, buffer)) {
       assertEquals(input.readByte(), 1);
-      assertEquals(input.readInt32(), 2);
-      assertEquals(input.readInt64(), 3);
+      assertEquals(input.readInt(), 2);
+      assertEquals(input.readLong(), 3);
       assertTrue(input.readBoolean());
-      assertEquals(input.readFloat32(), 4.1f);
-      assertEquals(input.readFloat64(), 4.2);
+      assertEquals(input.readFloat(), 4.1f);
+      assertEquals(input.readDouble(), 4.2);
       assertEquals(input.readUTF(), "abc");
     }
   }

--- a/java/fury-core/src/test/java/org/apache/fury/io/MemoryBufferObjectInputTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/io/MemoryBufferObjectInputTest.java
@@ -43,11 +43,11 @@ public class MemoryBufferObjectInputTest {
     fury.writeJavaString(buffer, "abc");
     try (MemoryBufferObjectInput input = new MemoryBufferObjectInput(fury, buffer)) {
       assertEquals(input.readByte(), 1);
-      assertEquals(input.readInt(), 2);
-      assertEquals(input.readLong(), 3);
+      assertEquals(input.readInt32(), 2);
+      assertEquals(input.readInt64(), 3);
       assertTrue(input.readBoolean());
-      assertEquals(input.readFloat(), 4.1f);
-      assertEquals(input.readDouble(), 4.2);
+      assertEquals(input.readFloat32(), 4.1f);
+      assertEquals(input.readFloat64(), 4.2);
       assertEquals(input.readUTF(), "abc");
     }
   }

--- a/java/fury-core/src/test/java/org/apache/fury/io/MemoryBufferObjectOutputTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/io/MemoryBufferObjectOutputTest.java
@@ -36,11 +36,11 @@ public class MemoryBufferObjectOutputTest {
     MemoryBuffer buffer = MemoryUtils.buffer(32);
     try (MemoryBufferObjectOutput output = new MemoryBufferObjectOutput(fury, buffer)) {
       output.writeByte(1);
-      output.writeInt(2);
-      output.writeLong(3);
+      output.writeInt32(2);
+      output.writeInt64(3);
       output.writeBoolean(true);
-      output.writeFloat(4.1f);
-      output.writeDouble(4.2);
+      output.writeFloat32(4.1f);
+      output.writeFloat64(4.2);
       output.writeChars("abc");
       output.writeUTF("abc");
     }

--- a/java/fury-core/src/test/java/org/apache/fury/io/MemoryBufferObjectOutputTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/io/MemoryBufferObjectOutputTest.java
@@ -36,21 +36,21 @@ public class MemoryBufferObjectOutputTest {
     MemoryBuffer buffer = MemoryUtils.buffer(32);
     try (MemoryBufferObjectOutput output = new MemoryBufferObjectOutput(fury, buffer)) {
       output.writeByte(1);
-      output.writeInt32(2);
-      output.writeInt64(3);
+      output.writeInt(2);
+      output.writeLong(3);
       output.writeBoolean(true);
-      output.writeFloat32(4.1f);
-      output.writeFloat64(4.2);
+      output.writeFloat(4.1f);
+      output.writeDouble(4.2);
       output.writeChars("abc");
       output.writeUTF("abc");
     }
     try (MemoryBufferObjectInput input = new MemoryBufferObjectInput(fury, buffer)) {
       assertEquals(input.readByte(), 1);
-      assertEquals(input.readInt32(), 2);
-      assertEquals(input.readInt64(), 3);
+      assertEquals(input.readInt(), 2);
+      assertEquals(input.readLong(), 3);
       assertTrue(input.readBoolean());
-      assertEquals(input.readFloat32(), 4.1f);
-      assertEquals(input.readFloat64(), 4.2);
+      assertEquals(input.readFloat(), 4.1f);
+      assertEquals(input.readDouble(), 4.2);
       assertEquals(input.readUTF(), "abc");
       assertEquals(input.readUTF(), "abc");
     }

--- a/java/fury-core/src/test/java/org/apache/fury/io/MemoryBufferObjectOutputTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/io/MemoryBufferObjectOutputTest.java
@@ -46,11 +46,11 @@ public class MemoryBufferObjectOutputTest {
     }
     try (MemoryBufferObjectInput input = new MemoryBufferObjectInput(fury, buffer)) {
       assertEquals(input.readByte(), 1);
-      assertEquals(input.readInt(), 2);
-      assertEquals(input.readLong(), 3);
+      assertEquals(input.readInt32(), 2);
+      assertEquals(input.readInt64(), 3);
       assertTrue(input.readBoolean());
-      assertEquals(input.readFloat(), 4.1f);
-      assertEquals(input.readDouble(), 4.2);
+      assertEquals(input.readFloat32(), 4.1f);
+      assertEquals(input.readFloat64(), 4.2);
       assertEquals(input.readUTF(), "abc");
       assertEquals(input.readUTF(), "abc");
     }

--- a/java/fury-core/src/test/java/org/apache/fury/memory/MemoryBufferTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/memory/MemoryBufferTest.java
@@ -31,6 +31,25 @@ import org.testng.annotations.Test;
 public class MemoryBufferTest {
 
   @Test
+  public void testBufferPut() {
+    MemoryBuffer buffer = MemoryUtils.buffer(16);
+    buffer.put(0, (byte) 10);
+    assertEquals(buffer.get(0), (byte) 10);
+    buffer.putChar(0, 'a');
+    assertEquals(buffer.getChar(0), 'a');
+    buffer.putShort(0, (short) 10);
+    assertEquals(buffer.getShort(0), (short) 10);
+    buffer.putInt(0, Integer.MAX_VALUE);
+    assertEquals(buffer.getInt(0), Integer.MAX_VALUE);
+    buffer.putLong(0, Long.MAX_VALUE);
+    assertEquals(buffer.getLong(0), Long.MAX_VALUE);
+    buffer.putFloat(0, Float.MAX_VALUE);
+    assertEquals(buffer.getFloat(0), Float.MAX_VALUE);
+    buffer.putDouble(0, Double.MAX_VALUE);
+    assertEquals(buffer.getDouble(0), Double.MAX_VALUE);
+  }
+
+  @Test
   public void testBufferWrite() {
     MemoryBuffer buffer = MemoryUtils.buffer(8);
     buffer.writeBoolean(true);
@@ -64,24 +83,24 @@ public class MemoryBufferTest {
       long pos = buffer.getUnsafeAddress();
       assertEquals(buffer.getUnsafeWriterAddress(), pos);
       assertEquals(buffer.getUnsafeReaderAddress(), pos);
-      MemoryBuffer.unsafePut(heapMemory, pos, Byte.MIN_VALUE);
+      Platform.putByte(heapMemory, pos, Byte.MIN_VALUE);
       pos += 1;
-      MemoryBuffer.unsafePutShort(heapMemory, pos, Short.MAX_VALUE);
+      Platform.putShort(heapMemory, pos, Short.MAX_VALUE);
       pos += 2;
-      MemoryBuffer.unsafePutInt(heapMemory, pos, Integer.MIN_VALUE);
+      MemoryUtils.putInt(heapMemory, pos, Integer.MIN_VALUE);
       pos += 4;
-      MemoryBuffer.unsafePutLong(heapMemory, pos, Long.MAX_VALUE);
+      Platform.putLong(heapMemory, pos, Long.MAX_VALUE);
       pos += 8;
-      MemoryBuffer.unsafePutDouble(heapMemory, pos, -1);
+      MemoryUtils.putDouble(heapMemory, pos, -1);
       pos += 8;
-      MemoryBuffer.unsafePutFloat(heapMemory, pos, -1);
-      assertEquals(buffer.unsafeGetFloat((int) (pos - Platform.BYTE_ARRAY_OFFSET)), -1);
+      MemoryUtils.putFloat(heapMemory, pos, -1);
+      assertEquals(buffer.getFloat((int) (pos - Platform.BYTE_ARRAY_OFFSET)), -1);
       pos -= 8;
-      assertEquals(buffer.unsafeGetDouble((int) (pos - Platform.BYTE_ARRAY_OFFSET)), -1);
+      assertEquals(buffer.getDouble((int) (pos - Platform.BYTE_ARRAY_OFFSET)), -1);
       pos -= 8;
-      assertEquals(MemoryBuffer.unsafeGetLong(heapMemory, pos), Long.MAX_VALUE);
+      assertEquals(MemoryUtils.getLong(heapMemory, pos), Long.MAX_VALUE);
       pos -= 4;
-      assertEquals(MemoryBuffer.unsafeGetInt(heapMemory, pos), Integer.MIN_VALUE);
+      assertEquals(MemoryUtils.getInt(heapMemory, pos), Integer.MIN_VALUE);
       pos -= 2;
       assertEquals(buffer.getShort((int) (pos - Platform.BYTE_ARRAY_OFFSET)), Short.MAX_VALUE);
       pos -= 1;
@@ -94,22 +113,22 @@ public class MemoryBufferTest {
       index += 1;
       buffer.unsafePutShort(index, Short.MAX_VALUE);
       index += 2;
-      buffer.unsafePutInt(index, Integer.MIN_VALUE);
+      buffer.putInt(index, Integer.MIN_VALUE);
       index += 4;
       buffer.unsafePutLong(index, Long.MAX_VALUE);
       index += 8;
-      buffer.unsafePutDouble(index, -1);
+      buffer.putDouble(index, -1);
       index += 8;
-      buffer.unsafePutFloat(index, -1);
-      assertEquals(buffer.unsafeGetFloat(index), -1);
+      buffer.putFloat(index, -1);
+      assertEquals(buffer.getFloat(index), -1);
       index -= 8;
-      assertEquals(buffer.unsafeGetDouble(index), -1);
+      assertEquals(buffer.getDouble(index), -1);
       index -= 8;
       assertEquals(buffer.unsafeGetLong(index), Long.MAX_VALUE);
       index -= 4;
-      assertEquals(buffer.unsafeGetInt(index), Integer.MIN_VALUE);
+      assertEquals(buffer.getInt(index), Integer.MIN_VALUE);
       index -= 2;
-      assertEquals(buffer.unsafeGetShort(index), Short.MAX_VALUE);
+      assertEquals(buffer.getShort(index), Short.MAX_VALUE);
       index -= 1;
       assertEquals(buffer.unsafeGet(index), Byte.MIN_VALUE);
     }
@@ -179,8 +198,8 @@ public class MemoryBufferTest {
   public void testCompare() {
     MemoryBuffer buf1 = MemoryUtils.buffer(16);
     MemoryBuffer buf2 = MemoryUtils.buffer(16);
-    buf1.putLongB(0, 10);
-    buf2.putLongB(0, 10);
+    buf1.putLongBE(0, 10);
+    buf2.putLongBE(0, 10);
     buf1.put(9, (byte) 1);
     buf2.put(9, (byte) 2);
     Assert.assertTrue(buf1.compare(buf2, 0, 0, buf1.size()) < 0);
@@ -192,8 +211,8 @@ public class MemoryBufferTest {
   public void testEqualTo() {
     MemoryBuffer buf1 = MemoryUtils.buffer(16);
     MemoryBuffer buf2 = MemoryUtils.buffer(16);
-    buf1.putLongB(0, 10);
-    buf2.putLongB(0, 10);
+    buf1.putLongBE(0, 10);
+    buf2.putLongBE(0, 10);
     buf1.put(9, (byte) 1);
     buf2.put(9, (byte) 1);
     Assert.assertTrue(buf1.equalTo(buf2, 0, 0, buf1.size()));
@@ -533,8 +552,8 @@ public class MemoryBufferTest {
     byte[] data = new byte[4];
     data[0] = (byte) 0xac;
     data[1] = (byte) 0xed;
-    assertEquals(MemoryBuffer.getShortB(data, 0), (short) 0xaced);
-    assertEquals(MemoryBuffer.fromByteArray(data).getShortB(0), (short) 0xaced);
+    assertEquals(MemoryUtils.getShortB(data, 0), (short) 0xaced);
+    assertEquals(MemoryBuffer.fromByteArray(data).getShortBE(0), (short) 0xaced);
   }
 
   @Test

--- a/java/fury-core/src/test/java/org/apache/fury/memory/MemoryBufferTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/memory/MemoryBufferTest.java
@@ -130,7 +130,7 @@ public class MemoryBufferTest {
       index -= 2;
       assertEquals(buffer.getShort(index), Short.MAX_VALUE);
       index -= 1;
-      assertEquals(buffer.unsafeGet(index), Byte.MIN_VALUE);
+      assertEquals(buffer.get(index), Byte.MIN_VALUE);
     }
   }
 
@@ -195,24 +195,11 @@ public class MemoryBufferTest {
   }
 
   @Test
-  public void testCompare() {
-    MemoryBuffer buf1 = MemoryUtils.buffer(16);
-    MemoryBuffer buf2 = MemoryUtils.buffer(16);
-    buf1.putLongBE(0, 10);
-    buf2.putLongBE(0, 10);
-    buf1.put(9, (byte) 1);
-    buf2.put(9, (byte) 2);
-    Assert.assertTrue(buf1.compare(buf2, 0, 0, buf1.size()) < 0);
-    buf1.put(9, (byte) 3);
-    Assert.assertFalse(buf1.compare(buf2, 0, 0, buf1.size()) < 0);
-  }
-
-  @Test
   public void testEqualTo() {
     MemoryBuffer buf1 = MemoryUtils.buffer(16);
     MemoryBuffer buf2 = MemoryUtils.buffer(16);
-    buf1.putLongBE(0, 10);
-    buf2.putLongBE(0, 10);
+    buf1.putLong(0, 10);
+    buf2.putLong(0, 10);
     buf1.put(9, (byte) 1);
     buf2.put(9, (byte) 1);
     Assert.assertTrue(buf1.equalTo(buf2, 0, 0, buf1.size()));
@@ -494,27 +481,27 @@ public class MemoryBufferTest {
   public void testWriteVarUint32Aligned() {
     MemoryBuffer buf = MemoryUtils.buffer(16);
     assertEquals(buf.writeVarUint32Aligned(1), 4);
-    assertEquals(buf.readPositiveAlignedVarInt(), 1);
+    assertEquals(buf.readAlignedVarUint(), 1);
     assertEquals(buf.writeVarUint32Aligned(1 << 5), 4);
-    assertEquals(buf.readPositiveAlignedVarInt(), 1 << 5);
+    assertEquals(buf.readAlignedVarUint(), 1 << 5);
     assertEquals(buf.writeVarUint32Aligned(1 << 10), 4);
-    assertEquals(buf.readPositiveAlignedVarInt(), 1 << 10);
+    assertEquals(buf.readAlignedVarUint(), 1 << 10);
     assertEquals(buf.writeVarUint32Aligned(1 << 15), 4);
-    assertEquals(buf.readPositiveAlignedVarInt(), 1 << 15);
+    assertEquals(buf.readAlignedVarUint(), 1 << 15);
     assertEquals(buf.writeVarUint32Aligned(1 << 20), 4);
-    assertEquals(buf.readPositiveAlignedVarInt(), 1 << 20);
+    assertEquals(buf.readAlignedVarUint(), 1 << 20);
     assertEquals(buf.writeVarUint32Aligned(1 << 25), 8);
-    assertEquals(buf.readPositiveAlignedVarInt(), 1 << 25);
+    assertEquals(buf.readAlignedVarUint(), 1 << 25);
     assertEquals(buf.writeVarUint32Aligned(1 << 30), 8);
-    assertEquals(buf.readPositiveAlignedVarInt(), 1 << 30);
+    assertEquals(buf.readAlignedVarUint(), 1 << 30);
     assertEquals(buf.writeVarUint32Aligned(Integer.MAX_VALUE), 8);
-    assertEquals(buf.readPositiveAlignedVarInt(), Integer.MAX_VALUE);
+    assertEquals(buf.readAlignedVarUint(), Integer.MAX_VALUE);
     buf.writeByte((byte) 1); // make address unaligned.
     buf.writeShort((short) 1); // make address unaligned.
     assertEquals(buf.writeVarUint32Aligned(Integer.MAX_VALUE), 9);
     buf.readByte();
     buf.readShort();
-    assertEquals(buf.readPositiveAlignedVarInt(), Integer.MAX_VALUE);
+    assertEquals(buf.readAlignedVarUint(), Integer.MAX_VALUE);
     for (int i = 0; i < 32; i++) {
       MemoryBuffer buf1 = MemoryUtils.buffer(16);
       assertAligned(i, buf1);
@@ -531,20 +518,20 @@ public class MemoryBufferTest {
       buffer.writeVarUint32Aligned(1 << j);
       assertEquals(buffer.writerIndex() % 4, 0);
       buffer.readByte();
-      assertEquals(buffer.readPositiveAlignedVarInt(), 1 << j);
+      assertEquals(buffer.readAlignedVarUint(), 1 << j);
       for (int k = 0; k < i % 4; k++) {
         buffer.writeByte((byte) i); // make address unaligned.
         buffer.writeVarUint32Aligned(1 << j);
         assertEquals(buffer.writerIndex() % 4, 0);
         buffer.readByte();
-        assertEquals(buffer.readPositiveAlignedVarInt(), 1 << j);
+        assertEquals(buffer.readAlignedVarUint(), 1 << j);
       }
     }
     buffer.writeByte((byte) i); // make address unaligned.
     buffer.writeVarUint32Aligned(Integer.MAX_VALUE);
     assertEquals(buffer.writerIndex() % 4, 0);
     buffer.readByte();
-    assertEquals(buffer.readPositiveAlignedVarInt(), Integer.MAX_VALUE);
+    assertEquals(buffer.readAlignedVarUint(), Integer.MAX_VALUE);
   }
 
   @Test
@@ -553,7 +540,6 @@ public class MemoryBufferTest {
     data[0] = (byte) 0xac;
     data[1] = (byte) 0xed;
     assertEquals(MemoryUtils.getShortB(data, 0), (short) 0xaced);
-    assertEquals(MemoryBuffer.fromByteArray(data).getShortBE(0), (short) 0xaced);
   }
 
   @Test

--- a/java/fury-core/src/test/java/org/apache/fury/memory/MemoryBufferTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/memory/MemoryBufferTest.java
@@ -66,11 +66,11 @@ public class MemoryBufferTest {
     assertTrue(buffer.readBoolean());
     assertEquals(buffer.readByte(), Byte.MIN_VALUE);
     assertEquals(buffer.readChar(), 'a');
-    assertEquals(buffer.readShort(), Short.MAX_VALUE);
-    assertEquals(buffer.readInt(), Integer.MAX_VALUE);
-    assertEquals(buffer.readLong(), Long.MAX_VALUE);
-    assertEquals(buffer.readFloat(), Float.MAX_VALUE, 0.1);
-    assertEquals(buffer.readDouble(), Double.MAX_VALUE, 0.1);
+    assertEquals(buffer.readInt16(), Short.MAX_VALUE);
+    assertEquals(buffer.readInt32(), Integer.MAX_VALUE);
+    assertEquals(buffer.readInt64(), Long.MAX_VALUE);
+    assertEquals(buffer.readFloat32(), Float.MAX_VALUE, 0.1);
+    assertEquals(buffer.readFloat64(), Double.MAX_VALUE, 0.1);
     assertEquals(buffer.readBytes(bytes.length), bytes);
     assertEquals(buffer.readerIndex(), buffer.writerIndex());
   }
@@ -87,20 +87,20 @@ public class MemoryBufferTest {
       pos += 1;
       Platform.putShort(heapMemory, pos, Short.MAX_VALUE);
       pos += 2;
-      LittleEndian.putInt(heapMemory, pos, Integer.MIN_VALUE);
+      LittleEndian.putInt32(heapMemory, pos, Integer.MIN_VALUE);
       pos += 4;
       Platform.putLong(heapMemory, pos, Long.MAX_VALUE);
       pos += 8;
-      LittleEndian.putDouble(heapMemory, pos, -1);
+      LittleEndian.putFloat64(heapMemory, pos, -1);
       pos += 8;
-      LittleEndian.putFloat(heapMemory, pos, -1);
+      LittleEndian.putFloat32(heapMemory, pos, -1);
       assertEquals(buffer.getFloat((int) (pos - Platform.BYTE_ARRAY_OFFSET)), -1);
       pos -= 8;
       assertEquals(buffer.getDouble((int) (pos - Platform.BYTE_ARRAY_OFFSET)), -1);
       pos -= 8;
-      assertEquals(LittleEndian.getLong(heapMemory, pos), Long.MAX_VALUE);
+      assertEquals(LittleEndian.getInt64(heapMemory, pos), Long.MAX_VALUE);
       pos -= 4;
-      assertEquals(LittleEndian.getInt(heapMemory, pos), Integer.MIN_VALUE);
+      assertEquals(LittleEndian.getInt32(heapMemory, pos), Integer.MIN_VALUE);
       pos -= 2;
       assertEquals(buffer.getShort((int) (pos - Platform.BYTE_ARRAY_OFFSET)), Short.MAX_VALUE);
       pos -= 1;
@@ -500,7 +500,7 @@ public class MemoryBufferTest {
     buf.writeShort((short) 1); // make address unaligned.
     assertEquals(buf.writeVarUint32Aligned(Integer.MAX_VALUE), 9);
     buf.readByte();
-    buf.readShort();
+    buf.readInt16();
     assertEquals(buf.readAlignedVarUint(), Integer.MAX_VALUE);
     for (int i = 0; i < 32; i++) {
       MemoryBuffer buf1 = MemoryUtils.buffer(16);
@@ -576,10 +576,10 @@ public class MemoryBufferTest {
     assertEquals(buf.writerIndex(), readerIndex);
     int actualBytesWritten = buf.writeSliLong(value);
     assertEquals(actualBytesWritten, bytesWritten);
-    long varLong = buf.readSliLong();
+    long varLong = buf.readSliInt64On();
     assertEquals(buf.writerIndex(), buf.readerIndex());
     assertEquals(value, varLong);
-    assertEquals(buf.slice(readerIndex, buf.readerIndex() - readerIndex).readSliLong(), value);
+    assertEquals(buf.slice(readerIndex, buf.readerIndex() - readerIndex).readSliInt64On(), value);
   }
 
   @Test

--- a/java/fury-core/src/test/java/org/apache/fury/memory/MemoryBufferTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/memory/MemoryBufferTest.java
@@ -109,13 +109,13 @@ public class MemoryBufferTest {
     {
       MemoryBuffer buffer = MemoryUtils.buffer(1024);
       int index = 0;
-      buffer.unsafePut(index, Byte.MIN_VALUE);
+      buffer._unsafePut(index, Byte.MIN_VALUE);
       index += 1;
-      buffer.unsafePutShort(index, Short.MAX_VALUE);
+      buffer._unsafePutShort(index, Short.MAX_VALUE);
       index += 2;
       buffer.putInt(index, Integer.MIN_VALUE);
       index += 4;
-      buffer.unsafePutLong(index, Long.MAX_VALUE);
+      buffer._unsafePutLong(index, Long.MAX_VALUE);
       index += 8;
       buffer.putDouble(index, -1);
       index += 8;
@@ -124,7 +124,7 @@ public class MemoryBufferTest {
       index -= 8;
       assertEquals(buffer.getDouble(index), -1);
       index -= 8;
-      assertEquals(buffer.unsafeGetLong(index), Long.MAX_VALUE);
+      assertEquals(buffer._unsafeGetLong(index), Long.MAX_VALUE);
       index -= 4;
       assertEquals(buffer.getInt(index), Integer.MIN_VALUE);
       index -= 2;
@@ -590,21 +590,21 @@ public class MemoryBufferTest {
       int diff = MemoryUtils.putVarUint36Small(buf.getHeapMemory(), index, 10);
       assertEquals(buf.readVarUint36Small(), 10);
       buf.increaseReaderIndex(-diff);
-      index += buf.unsafePutVarUint36Small(index, 10);
+      index += buf._unsafePutVarUint36Small(index, 10);
       assertEquals(buf.readVarUint36Small(), 10);
     }
     {
       int diff = MemoryUtils.putVarUint36Small(buf.getHeapMemory(), index, Short.MAX_VALUE);
       assertEquals(buf.readVarUint36Small(), Short.MAX_VALUE);
       buf.increaseReaderIndex(-diff);
-      index += buf.unsafePutVarUint36Small(index, Short.MAX_VALUE);
+      index += buf._unsafePutVarUint36Small(index, Short.MAX_VALUE);
       assertEquals(buf.readVarUint36Small(), Short.MAX_VALUE);
     }
     {
       int diff = MemoryUtils.putVarUint36Small(buf.getHeapMemory(), index, Integer.MAX_VALUE);
       assertEquals(buf.readVarUint36Small(), Integer.MAX_VALUE);
       buf.increaseReaderIndex(-diff);
-      index += buf.unsafePutVarUint36Small(index, Integer.MAX_VALUE);
+      index += buf._unsafePutVarUint36Small(index, Integer.MAX_VALUE);
       assertEquals(buf.readVarUint36Small(), Integer.MAX_VALUE);
     }
     {
@@ -613,7 +613,7 @@ public class MemoryBufferTest {
               buf.getHeapMemory(), index, 0b111111111111111111111111111111111111L);
       assertEquals(buf.readVarUint36Small(), 0b111111111111111111111111111111111111L);
       buf.increaseReaderIndex(-diff);
-      buf.unsafePutVarUint36Small(index, 0b1000000000000000000000000000000000000L);
+      buf._unsafePutVarUint36Small(index, 0b1000000000000000000000000000000000000L);
       assertEquals(buf.readVarUint36Small(), 0); // overflow
     }
   }

--- a/java/fury-core/src/test/java/org/apache/fury/memory/MemoryBufferTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/memory/MemoryBufferTest.java
@@ -543,43 +543,43 @@ public class MemoryBufferTest {
   }
 
   @Test
-  public void testWriteSliLong() {
+  public void testWriteSliInt64() {
     MemoryBuffer buf = MemoryUtils.buffer(8);
-    checkSliLong(buf, -1, 4);
+    checkSliInt64(buf, -1, 4);
     for (int i = 0; i < 10; i++) {
       for (int j = 0; j < i; j++) {
-        checkSliLong(buf(i), -1, 4);
-        checkSliLong(buf(i), 1, 4);
-        checkSliLong(buf(i), 1L << 6, 4);
-        checkSliLong(buf(i), 1L << 7, 4);
-        checkSliLong(buf(i), -(2 << 5), 4);
-        checkSliLong(buf(i), -(2 << 6), 4);
-        checkSliLong(buf(i), 1L << 28, 4);
-        checkSliLong(buf(i), Integer.MAX_VALUE / 2, 4);
-        checkSliLong(buf(i), Integer.MIN_VALUE / 2, 4);
-        checkSliLong(buf(i), -1L << 30, 4);
-        checkSliLong(buf(i), 1L << 30, 9);
-        checkSliLong(buf(i), Integer.MAX_VALUE, 9);
-        checkSliLong(buf(i), Integer.MIN_VALUE, 9);
-        checkSliLong(buf(i), -1L << 31, 9);
-        checkSliLong(buf(i), 1L << 31, 9);
-        checkSliLong(buf(i), -1L << 32, 9);
-        checkSliLong(buf(i), 1L << 32, 9);
-        checkSliLong(buf(i), Long.MAX_VALUE, 9);
-        checkSliLong(buf(i), Long.MIN_VALUE, 9);
+        checkSliInt64(buf(i), -1, 4);
+        checkSliInt64(buf(i), 1, 4);
+        checkSliInt64(buf(i), 1L << 6, 4);
+        checkSliInt64(buf(i), 1L << 7, 4);
+        checkSliInt64(buf(i), -(2 << 5), 4);
+        checkSliInt64(buf(i), -(2 << 6), 4);
+        checkSliInt64(buf(i), 1L << 28, 4);
+        checkSliInt64(buf(i), Integer.MAX_VALUE / 2, 4);
+        checkSliInt64(buf(i), Integer.MIN_VALUE / 2, 4);
+        checkSliInt64(buf(i), -1L << 30, 4);
+        checkSliInt64(buf(i), 1L << 30, 9);
+        checkSliInt64(buf(i), Integer.MAX_VALUE, 9);
+        checkSliInt64(buf(i), Integer.MIN_VALUE, 9);
+        checkSliInt64(buf(i), -1L << 31, 9);
+        checkSliInt64(buf(i), 1L << 31, 9);
+        checkSliInt64(buf(i), -1L << 32, 9);
+        checkSliInt64(buf(i), 1L << 32, 9);
+        checkSliInt64(buf(i), Long.MAX_VALUE, 9);
+        checkSliInt64(buf(i), Long.MIN_VALUE, 9);
       }
     }
   }
 
-  private void checkSliLong(MemoryBuffer buf, long value, int bytesWritten) {
+  private void checkSliInt64(MemoryBuffer buf, long value, int bytesWritten) {
     int readerIndex = buf.readerIndex();
     assertEquals(buf.writerIndex(), readerIndex);
-    int actualBytesWritten = buf.writeSliLong(value);
+    int actualBytesWritten = buf.writeSliInt64(value);
     assertEquals(actualBytesWritten, bytesWritten);
-    long varLong = buf.readSliInt64On();
+    long varLong = buf.readSliInt64();
     assertEquals(buf.writerIndex(), buf.readerIndex());
     assertEquals(value, varLong);
-    assertEquals(buf.slice(readerIndex, buf.readerIndex() - readerIndex).readSliInt64On(), value);
+    assertEquals(buf.slice(readerIndex, buf.readerIndex() - readerIndex).readSliInt64(), value);
   }
 
   @Test

--- a/java/fury-core/src/test/java/org/apache/fury/memory/MemoryBufferTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/memory/MemoryBufferTest.java
@@ -55,11 +55,11 @@ public class MemoryBufferTest {
     buffer.writeBoolean(true);
     buffer.writeByte(Byte.MIN_VALUE);
     buffer.writeChar('a');
-    buffer.writeShort(Short.MAX_VALUE);
-    buffer.writeInt(Integer.MAX_VALUE);
-    buffer.writeLong(Long.MAX_VALUE);
-    buffer.writeFloat(Float.MAX_VALUE);
-    buffer.writeDouble(Double.MAX_VALUE);
+    buffer.writeInt16(Short.MAX_VALUE);
+    buffer.writeInt32(Integer.MAX_VALUE);
+    buffer.writeInt64(Long.MAX_VALUE);
+    buffer.writeFloat32(Float.MAX_VALUE);
+    buffer.writeFloat64(Double.MAX_VALUE);
     byte[] bytes = new byte[] {1, 2, 3, 4};
     buffer.writeBytes(bytes);
 
@@ -497,7 +497,7 @@ public class MemoryBufferTest {
     assertEquals(buf.writeVarUint32Aligned(Integer.MAX_VALUE), 8);
     assertEquals(buf.readAlignedVarUint(), Integer.MAX_VALUE);
     buf.writeByte((byte) 1); // make address unaligned.
-    buf.writeShort((short) 1); // make address unaligned.
+    buf.writeInt16((short) 1); // make address unaligned.
     assertEquals(buf.writeVarUint32Aligned(Integer.MAX_VALUE), 9);
     buf.readByte();
     buf.readInt16();

--- a/java/fury-core/src/test/java/org/apache/fury/memory/MemoryBufferTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/memory/MemoryBufferTest.java
@@ -214,7 +214,7 @@ public class MemoryBufferTest {
     buf.writePrimitiveArrayWithSize(bytes, Platform.BYTE_ARRAY_OFFSET, bytes.length);
     buf.writePrimitiveArrayWithSize(chars, Platform.CHAR_ARRAY_OFFSET, chars.length * 2);
     assertEquals(bytes, buf.readBytesAndSize());
-    assertEquals(chars, buf.readChars(buf.readPositiveVarInt()));
+    assertEquals(chars, buf.readChars(buf.readVarUint32()));
     buf.writePrimitiveArrayAlignedSize(bytes, Platform.BYTE_ARRAY_OFFSET, bytes.length);
     buf.writePrimitiveArrayAlignedSize(chars, Platform.CHAR_ARRAY_OFFSET, chars.length * 2);
     assertEquals(bytes, buf.readBytesWithAlignedSize());
@@ -222,58 +222,57 @@ public class MemoryBufferTest {
   }
 
   @Test
-  public void testWritePositiveVarInt() {
+  public void testWriteVarUint32() {
     for (int i = 0; i < 32; i++) {
       MemoryBuffer buf = MemoryUtils.buffer(8);
       for (int j = 0; j < i; j++) {
         buf.writeByte((byte) 1); // make address unaligned.
         buf.readByte();
       }
-      checkPositiveVarInt(buf, 1, 1);
-      checkPositiveVarInt(buf, 1 << 6, 1);
-      checkPositiveVarInt(buf, 1 << 7, 2);
-      checkPositiveVarInt(buf, 1 << 13, 2);
-      checkPositiveVarInt(buf, 1 << 14, 3);
-      checkPositiveVarInt(buf, 1 << 20, 3);
-      checkPositiveVarInt(buf, 1 << 21, 4);
-      checkPositiveVarInt(buf, 1 << 27, 4);
-      checkPositiveVarInt(buf, 1 << 28, 5);
-      checkPositiveVarInt(buf, Integer.MAX_VALUE, 5);
+      checkVarUint32(buf, 1, 1);
+      checkVarUint32(buf, 1 << 6, 1);
+      checkVarUint32(buf, 1 << 7, 2);
+      checkVarUint32(buf, 1 << 13, 2);
+      checkVarUint32(buf, 1 << 14, 3);
+      checkVarUint32(buf, 1 << 20, 3);
+      checkVarUint32(buf, 1 << 21, 4);
+      checkVarUint32(buf, 1 << 27, 4);
+      checkVarUint32(buf, 1 << 28, 5);
+      checkVarUint32(buf, Integer.MAX_VALUE, 5);
 
-      checkPositiveVarInt(buf, -1);
-      checkPositiveVarInt(buf, -1 << 6);
-      checkPositiveVarInt(buf, -1 << 7);
-      checkPositiveVarInt(buf, -1 << 13);
-      checkPositiveVarInt(buf, -1 << 14);
-      checkPositiveVarInt(buf, -1 << 20);
-      checkPositiveVarInt(buf, -1 << 21);
-      checkPositiveVarInt(buf, -1 << 27);
-      checkPositiveVarInt(buf, -1 << 28);
-      checkPositiveVarInt(buf, Byte.MIN_VALUE);
-      checkPositiveVarInt(buf, Short.MIN_VALUE);
-      checkPositiveVarInt(buf, Integer.MIN_VALUE);
+      checkVarUint32(buf, -1);
+      checkVarUint32(buf, -1 << 6);
+      checkVarUint32(buf, -1 << 7);
+      checkVarUint32(buf, -1 << 13);
+      checkVarUint32(buf, -1 << 14);
+      checkVarUint32(buf, -1 << 20);
+      checkVarUint32(buf, -1 << 21);
+      checkVarUint32(buf, -1 << 27);
+      checkVarUint32(buf, -1 << 28);
+      checkVarUint32(buf, Byte.MIN_VALUE);
+      checkVarUint32(buf, Short.MIN_VALUE);
+      checkVarUint32(buf, Integer.MIN_VALUE);
     }
   }
 
-  private void checkPositiveVarInt(MemoryBuffer buf, int value, int bytesWritten) {
+  private void checkVarUint32(MemoryBuffer buf, int value, int bytesWritten) {
     assertEquals(buf.writerIndex(), buf.readerIndex());
-    int actualBytesWritten = buf.writePositiveVarInt(value);
+    int actualBytesWritten = buf.writeVarUint32(value);
     assertEquals(actualBytesWritten, bytesWritten);
-    int varInt = buf.readPositiveVarInt();
+    int varInt = buf.readVarUint32();
     assertEquals(buf.writerIndex(), buf.readerIndex());
     assertEquals(value, varInt);
   }
 
-  private void checkPositiveVarInt(MemoryBuffer buf, int value) {
+  private void checkVarUint32(MemoryBuffer buf, int value) {
     int readerIndex = buf.readerIndex();
     assertEquals(buf.writerIndex(), readerIndex);
-    buf.writePositiveVarInt(value);
-    int varInt = buf.readPositiveVarInt();
+    buf.writeVarUint32(value);
+    int varInt = buf.readVarUint32();
     assertEquals(buf.writerIndex(), buf.readerIndex());
     assertEquals(value, varInt);
-    // test slow read branch in `readPositiveVarInt`
-    assertEquals(
-        buf.slice(readerIndex, buf.readerIndex() - readerIndex).readPositiveVarInt(), value);
+    // test slow read branch in `readVarUint`
+    assertEquals(buf.slice(readerIndex, buf.readerIndex() - readerIndex).readVarUint32(), value);
   }
 
   @Test
@@ -323,178 +322,177 @@ public class MemoryBufferTest {
   private void checkVarInt(MemoryBuffer buf, int value, int bytesWritten) {
     int readerIndex = buf.readerIndex();
     assertEquals(buf.writerIndex(), readerIndex);
-    int actualBytesWritten = buf.writeVarInt(value);
+    int actualBytesWritten = buf.writeVarInt32(value);
     assertEquals(actualBytesWritten, bytesWritten);
-    int varInt = buf.readVarInt();
+    int varInt = buf.readVarInt32();
     assertEquals(buf.writerIndex(), buf.readerIndex());
     assertEquals(value, varInt);
-    // test slow read branch in `readVarInt`
-    assertEquals(buf.slice(readerIndex, buf.readerIndex() - readerIndex).readVarInt(), value);
+    // test slow read branch in `readVarInt32`
+    assertEquals(buf.slice(readerIndex, buf.readerIndex() - readerIndex).readVarInt32(), value);
   }
 
   @Test
-  public void testWriteVarLong() {
+  public void testWriteVarInt64() {
     MemoryBuffer buf = MemoryUtils.buffer(8);
-    checkVarLong(buf, -1, 1);
+    checkVarInt64(buf, -1, 1);
     for (int i = 0; i < 9; i++) {
       for (int j = 0; j < i; j++) {
-        checkVarLong(buf(i), -1, 1);
-        checkVarLong(buf(i), 1, 1);
-        checkVarLong(buf(i), 1L << 6, 2);
-        checkVarLong(buf(i), 1L << 7, 2);
-        checkVarLong(buf(i), -(2 << 5), 1);
-        checkVarLong(buf(i), -(2 << 6), 2);
-        checkVarLong(buf(i), 1L << 13, 3);
-        checkVarLong(buf(i), 1L << 14, 3);
-        checkVarLong(buf(i), -(2 << 12), 2);
-        checkVarLong(buf(i), -(2 << 13), 3);
-        checkVarLong(buf(i), 1L << 19, 3);
-        checkVarLong(buf(i), 1L << 20, 4);
-        checkVarLong(buf(i), 1L << 21, 4);
-        checkVarLong(buf(i), -(2 << 19), 3);
-        checkVarLong(buf(i), -(2 << 20), 4);
-        checkVarLong(buf(i), 1L << 26, 4);
-        checkVarLong(buf(i), 1L << 27, 5);
-        checkVarLong(buf(i), 1L << 28, 5);
-        checkVarLong(buf(i), -(2 << 26), 4);
-        checkVarLong(buf(i), -(2 << 27), 5);
-        checkVarLong(buf(i), 1L << 30, 5);
-        checkVarLong(buf(i), -(2L << 29), 5);
-        checkVarLong(buf(i), 1L << 30, 5);
-        checkVarLong(buf(i), -(2L << 30), 5);
-        checkVarLong(buf(i), 1L << 32, 5);
-        checkVarLong(buf(i), -(2L << 31), 5);
-        checkVarLong(buf(i), 1L << 34, 6);
-        checkVarLong(buf(i), -(2L << 33), 5);
-        checkVarLong(buf(i), 1L << 35, 6);
-        checkVarLong(buf(i), -(2L << 34), 6);
-        checkVarLong(buf(i), 1L << 41, 7);
-        checkVarLong(buf(i), -(2L << 40), 6);
-        checkVarLong(buf(i), 1L << 42, 7);
-        checkVarLong(buf(i), -(2L << 41), 7);
-        checkVarLong(buf(i), 1L << 48, 8);
-        checkVarLong(buf(i), -(2L << 47), 7);
-        checkVarLong(buf(i), -(2L << 48), 8);
-        checkVarLong(buf(i), 1L << 49, 8);
-        checkVarLong(buf(i), -(2L << 48), 8);
-        checkVarLong(buf(i), -(2L << 54), 8);
-        checkVarLong(buf(i), 1L << 54, 8);
-        checkVarLong(buf(i), 1L << 55, 9);
-        checkVarLong(buf(i), 1L << 56, 9);
-        checkVarLong(buf(i), -(2L << 55), 9);
-        checkVarLong(buf(i), 1L << 62, 9);
-        checkVarLong(buf(i), -(2L << 62), 9);
-        checkVarLong(buf(i), 1L << 63 - 1, 9);
-        checkVarLong(buf(i), -(2L << 62), 9);
-        checkVarLong(buf(i), Long.MAX_VALUE, 9);
-        checkVarLong(buf(i), Long.MIN_VALUE, 9);
+        checkVarInt64(buf(i), -1, 1);
+        checkVarInt64(buf(i), 1, 1);
+        checkVarInt64(buf(i), 1L << 6, 2);
+        checkVarInt64(buf(i), 1L << 7, 2);
+        checkVarInt64(buf(i), -(2 << 5), 1);
+        checkVarInt64(buf(i), -(2 << 6), 2);
+        checkVarInt64(buf(i), 1L << 13, 3);
+        checkVarInt64(buf(i), 1L << 14, 3);
+        checkVarInt64(buf(i), -(2 << 12), 2);
+        checkVarInt64(buf(i), -(2 << 13), 3);
+        checkVarInt64(buf(i), 1L << 19, 3);
+        checkVarInt64(buf(i), 1L << 20, 4);
+        checkVarInt64(buf(i), 1L << 21, 4);
+        checkVarInt64(buf(i), -(2 << 19), 3);
+        checkVarInt64(buf(i), -(2 << 20), 4);
+        checkVarInt64(buf(i), 1L << 26, 4);
+        checkVarInt64(buf(i), 1L << 27, 5);
+        checkVarInt64(buf(i), 1L << 28, 5);
+        checkVarInt64(buf(i), -(2 << 26), 4);
+        checkVarInt64(buf(i), -(2 << 27), 5);
+        checkVarInt64(buf(i), 1L << 30, 5);
+        checkVarInt64(buf(i), -(2L << 29), 5);
+        checkVarInt64(buf(i), 1L << 30, 5);
+        checkVarInt64(buf(i), -(2L << 30), 5);
+        checkVarInt64(buf(i), 1L << 32, 5);
+        checkVarInt64(buf(i), -(2L << 31), 5);
+        checkVarInt64(buf(i), 1L << 34, 6);
+        checkVarInt64(buf(i), -(2L << 33), 5);
+        checkVarInt64(buf(i), 1L << 35, 6);
+        checkVarInt64(buf(i), -(2L << 34), 6);
+        checkVarInt64(buf(i), 1L << 41, 7);
+        checkVarInt64(buf(i), -(2L << 40), 6);
+        checkVarInt64(buf(i), 1L << 42, 7);
+        checkVarInt64(buf(i), -(2L << 41), 7);
+        checkVarInt64(buf(i), 1L << 48, 8);
+        checkVarInt64(buf(i), -(2L << 47), 7);
+        checkVarInt64(buf(i), -(2L << 48), 8);
+        checkVarInt64(buf(i), 1L << 49, 8);
+        checkVarInt64(buf(i), -(2L << 48), 8);
+        checkVarInt64(buf(i), -(2L << 54), 8);
+        checkVarInt64(buf(i), 1L << 54, 8);
+        checkVarInt64(buf(i), 1L << 55, 9);
+        checkVarInt64(buf(i), 1L << 56, 9);
+        checkVarInt64(buf(i), -(2L << 55), 9);
+        checkVarInt64(buf(i), 1L << 62, 9);
+        checkVarInt64(buf(i), -(2L << 62), 9);
+        checkVarInt64(buf(i), 1L << 63 - 1, 9);
+        checkVarInt64(buf(i), -(2L << 62), 9);
+        checkVarInt64(buf(i), Long.MAX_VALUE, 9);
+        checkVarInt64(buf(i), Long.MIN_VALUE, 9);
       }
     }
   }
 
-  private void checkVarLong(MemoryBuffer buf, long value, int bytesWritten) {
+  private void checkVarInt64(MemoryBuffer buf, long value, int bytesWritten) {
     int readerIndex = buf.readerIndex();
     assertEquals(buf.writerIndex(), readerIndex);
-    int actualBytesWritten = buf.writeVarLong(value);
+    int actualBytesWritten = buf.writeVarInt64(value);
     assertEquals(actualBytesWritten, bytesWritten);
-    long varLong = buf.readVarLong();
+    long varLong = buf.readVarInt64();
     assertEquals(buf.writerIndex(), buf.readerIndex());
     assertEquals(value, varLong);
-    // test slow read branch in `readVarLong`
-    assertEquals(buf.slice(readerIndex, buf.readerIndex() - readerIndex).readVarLong(), value);
+    // test slow read branch in `readVarInt64`
+    assertEquals(buf.slice(readerIndex, buf.readerIndex() - readerIndex).readVarInt64(), value);
   }
 
   @Test
-  public void testWritePositiveVarLong() {
+  public void testWriteVarUint64() {
     MemoryBuffer buf = MemoryUtils.buffer(8);
-    checkPositiveVarint64(buf, -1, 9);
+    checkVarUint64(buf, -1, 9);
     for (int i = 0; i < 9; i++) {
       for (int j = 0; j < i; j++) {
-        checkPositiveVarint64(buf(i), -1, 9);
-        checkPositiveVarint64(buf(i), 1, 1);
-        checkPositiveVarint64(buf(i), 1L << 6, 1);
-        checkPositiveVarint64(buf(i), 1L << 7, 2);
-        checkPositiveVarint64(buf(i), -(2 << 5), 9);
-        checkPositiveVarint64(buf(i), -(2 << 6), 9);
-        checkPositiveVarint64(buf(i), 1L << 13, 2);
-        checkPositiveVarint64(buf(i), 1L << 14, 3);
-        checkPositiveVarint64(buf(i), -(2 << 12), 9);
-        checkPositiveVarint64(buf(i), -(2 << 13), 9);
-        checkPositiveVarint64(buf(i), 1L << 20, 3);
-        checkPositiveVarint64(buf(i), 1L << 21, 4);
-        checkPositiveVarint64(buf(i), -(2 << 19), 9);
-        checkPositiveVarint64(buf(i), -(2 << 20), 9);
-        checkPositiveVarint64(buf(i), 1L << 27, 4);
-        checkPositiveVarint64(buf(i), 1L << 28, 5);
-        checkPositiveVarint64(buf(i), -(2 << 26), 9);
-        checkPositiveVarint64(buf(i), -(2 << 27), 9);
-        checkPositiveVarint64(buf(i), 1L << 30, 5);
-        checkPositiveVarint64(buf(i), -(2L << 29), 9);
-        checkPositiveVarint64(buf(i), 1L << 30, 5);
-        checkPositiveVarint64(buf(i), -(2L << 30), 9);
-        checkPositiveVarint64(buf(i), 1L << 32, 5);
-        checkPositiveVarint64(buf(i), -(2L << 31), 9);
-        checkPositiveVarint64(buf(i), 1L << 34, 5);
-        checkPositiveVarint64(buf(i), -(2L << 33), 9);
-        checkPositiveVarint64(buf(i), 1L << 35, 6);
-        checkPositiveVarint64(buf(i), -(2L << 34), 9);
-        checkPositiveVarint64(buf(i), 1L << 41, 6);
-        checkPositiveVarint64(buf(i), -(2L << 40), 9);
-        checkPositiveVarint64(buf(i), 1L << 42, 7);
-        checkPositiveVarint64(buf(i), -(2L << 41), 9);
-        checkPositiveVarint64(buf(i), 1L << 48, 7);
-        checkPositiveVarint64(buf(i), -(2L << 47), 9);
-        checkPositiveVarint64(buf(i), 1L << 49, 8);
-        checkPositiveVarint64(buf(i), -(2L << 48), 9);
-        checkPositiveVarint64(buf(i), 1L << 55, 8);
-        checkPositiveVarint64(buf(i), -(2L << 54), 9);
-        checkPositiveVarint64(buf(i), 1L << 56, 9);
-        checkPositiveVarint64(buf(i), -(2L << 55), 9);
-        checkPositiveVarint64(buf(i), 1L << 62, 9);
-        checkPositiveVarint64(buf(i), -(2L << 62), 9);
-        checkPositiveVarint64(buf(i), 1L << 63 - 1, 9);
-        checkPositiveVarint64(buf(i), -(2L << 62), 9);
-        checkPositiveVarint64(buf(i), Long.MAX_VALUE, 9);
-        checkPositiveVarint64(buf(i), Long.MIN_VALUE, 9);
+        checkVarUint64(buf(i), -1, 9);
+        checkVarUint64(buf(i), 1, 1);
+        checkVarUint64(buf(i), 1L << 6, 1);
+        checkVarUint64(buf(i), 1L << 7, 2);
+        checkVarUint64(buf(i), -(2 << 5), 9);
+        checkVarUint64(buf(i), -(2 << 6), 9);
+        checkVarUint64(buf(i), 1L << 13, 2);
+        checkVarUint64(buf(i), 1L << 14, 3);
+        checkVarUint64(buf(i), -(2 << 12), 9);
+        checkVarUint64(buf(i), -(2 << 13), 9);
+        checkVarUint64(buf(i), 1L << 20, 3);
+        checkVarUint64(buf(i), 1L << 21, 4);
+        checkVarUint64(buf(i), -(2 << 19), 9);
+        checkVarUint64(buf(i), -(2 << 20), 9);
+        checkVarUint64(buf(i), 1L << 27, 4);
+        checkVarUint64(buf(i), 1L << 28, 5);
+        checkVarUint64(buf(i), -(2 << 26), 9);
+        checkVarUint64(buf(i), -(2 << 27), 9);
+        checkVarUint64(buf(i), 1L << 30, 5);
+        checkVarUint64(buf(i), -(2L << 29), 9);
+        checkVarUint64(buf(i), 1L << 30, 5);
+        checkVarUint64(buf(i), -(2L << 30), 9);
+        checkVarUint64(buf(i), 1L << 32, 5);
+        checkVarUint64(buf(i), -(2L << 31), 9);
+        checkVarUint64(buf(i), 1L << 34, 5);
+        checkVarUint64(buf(i), -(2L << 33), 9);
+        checkVarUint64(buf(i), 1L << 35, 6);
+        checkVarUint64(buf(i), -(2L << 34), 9);
+        checkVarUint64(buf(i), 1L << 41, 6);
+        checkVarUint64(buf(i), -(2L << 40), 9);
+        checkVarUint64(buf(i), 1L << 42, 7);
+        checkVarUint64(buf(i), -(2L << 41), 9);
+        checkVarUint64(buf(i), 1L << 48, 7);
+        checkVarUint64(buf(i), -(2L << 47), 9);
+        checkVarUint64(buf(i), 1L << 49, 8);
+        checkVarUint64(buf(i), -(2L << 48), 9);
+        checkVarUint64(buf(i), 1L << 55, 8);
+        checkVarUint64(buf(i), -(2L << 54), 9);
+        checkVarUint64(buf(i), 1L << 56, 9);
+        checkVarUint64(buf(i), -(2L << 55), 9);
+        checkVarUint64(buf(i), 1L << 62, 9);
+        checkVarUint64(buf(i), -(2L << 62), 9);
+        checkVarUint64(buf(i), 1L << 63 - 1, 9);
+        checkVarUint64(buf(i), -(2L << 62), 9);
+        checkVarUint64(buf(i), Long.MAX_VALUE, 9);
+        checkVarUint64(buf(i), Long.MIN_VALUE, 9);
       }
     }
   }
 
-  private void checkPositiveVarint64(MemoryBuffer buf, long value, int bytesWritten) {
+  private void checkVarUint64(MemoryBuffer buf, long value, int bytesWritten) {
     int readerIndex = buf.readerIndex();
     assertEquals(buf.writerIndex(), readerIndex);
-    int actualBytesWritten = buf.writePositiveVarLong(value);
+    int actualBytesWritten = buf.writeVarUint64(value);
     assertEquals(actualBytesWritten, bytesWritten);
-    long varLong = buf.readPositiveVarLong();
+    long varLong = buf.readVarUint64();
     assertEquals(buf.writerIndex(), buf.readerIndex());
     assertEquals(value, varLong);
-    // test slow read branch in `readPositiveVarLong`
-    assertEquals(
-        buf.slice(readerIndex, buf.readerIndex() - readerIndex).readPositiveVarLong(), value);
+    // test slow read branch in `readVarUint64`
+    assertEquals(buf.slice(readerIndex, buf.readerIndex() - readerIndex).readVarUint64(), value);
   }
 
   @Test
-  public void testWritePositiveVarIntAligned() {
+  public void testWriteVarUint32Aligned() {
     MemoryBuffer buf = MemoryUtils.buffer(16);
-    assertEquals(buf.writePositiveVarIntAligned(1), 4);
+    assertEquals(buf.writeVarUint32Aligned(1), 4);
     assertEquals(buf.readPositiveAlignedVarInt(), 1);
-    assertEquals(buf.writePositiveVarIntAligned(1 << 5), 4);
+    assertEquals(buf.writeVarUint32Aligned(1 << 5), 4);
     assertEquals(buf.readPositiveAlignedVarInt(), 1 << 5);
-    assertEquals(buf.writePositiveVarIntAligned(1 << 10), 4);
+    assertEquals(buf.writeVarUint32Aligned(1 << 10), 4);
     assertEquals(buf.readPositiveAlignedVarInt(), 1 << 10);
-    assertEquals(buf.writePositiveVarIntAligned(1 << 15), 4);
+    assertEquals(buf.writeVarUint32Aligned(1 << 15), 4);
     assertEquals(buf.readPositiveAlignedVarInt(), 1 << 15);
-    assertEquals(buf.writePositiveVarIntAligned(1 << 20), 4);
+    assertEquals(buf.writeVarUint32Aligned(1 << 20), 4);
     assertEquals(buf.readPositiveAlignedVarInt(), 1 << 20);
-    assertEquals(buf.writePositiveVarIntAligned(1 << 25), 8);
+    assertEquals(buf.writeVarUint32Aligned(1 << 25), 8);
     assertEquals(buf.readPositiveAlignedVarInt(), 1 << 25);
-    assertEquals(buf.writePositiveVarIntAligned(1 << 30), 8);
+    assertEquals(buf.writeVarUint32Aligned(1 << 30), 8);
     assertEquals(buf.readPositiveAlignedVarInt(), 1 << 30);
-    assertEquals(buf.writePositiveVarIntAligned(Integer.MAX_VALUE), 8);
+    assertEquals(buf.writeVarUint32Aligned(Integer.MAX_VALUE), 8);
     assertEquals(buf.readPositiveAlignedVarInt(), Integer.MAX_VALUE);
     buf.writeByte((byte) 1); // make address unaligned.
     buf.writeShort((short) 1); // make address unaligned.
-    assertEquals(buf.writePositiveVarIntAligned(Integer.MAX_VALUE), 9);
+    assertEquals(buf.writeVarUint32Aligned(Integer.MAX_VALUE), 9);
     buf.readByte();
     buf.readShort();
     assertEquals(buf.readPositiveAlignedVarInt(), Integer.MAX_VALUE);
@@ -511,20 +509,20 @@ public class MemoryBufferTest {
   private void assertAligned(int i, MemoryBuffer buffer) {
     for (int j = 0; j < 31; j++) {
       buffer.writeByte((byte) i); // make address unaligned.
-      buffer.writePositiveVarIntAligned(1 << j);
+      buffer.writeVarUint32Aligned(1 << j);
       assertEquals(buffer.writerIndex() % 4, 0);
       buffer.readByte();
       assertEquals(buffer.readPositiveAlignedVarInt(), 1 << j);
       for (int k = 0; k < i % 4; k++) {
         buffer.writeByte((byte) i); // make address unaligned.
-        buffer.writePositiveVarIntAligned(1 << j);
+        buffer.writeVarUint32Aligned(1 << j);
         assertEquals(buffer.writerIndex() % 4, 0);
         buffer.readByte();
         assertEquals(buffer.readPositiveAlignedVarInt(), 1 << j);
       }
     }
     buffer.writeByte((byte) i); // make address unaligned.
-    buffer.writePositiveVarIntAligned(Integer.MAX_VALUE);
+    buffer.writeVarUint32Aligned(Integer.MAX_VALUE);
     assertEquals(buffer.writerIndex() % 4, 0);
     buffer.readByte();
     assertEquals(buffer.readPositiveAlignedVarInt(), Integer.MAX_VALUE);

--- a/java/fury-core/src/test/java/org/apache/fury/memory/MemoryBufferTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/memory/MemoryBufferTest.java
@@ -87,20 +87,20 @@ public class MemoryBufferTest {
       pos += 1;
       Platform.putShort(heapMemory, pos, Short.MAX_VALUE);
       pos += 2;
-      MemoryUtils.putInt(heapMemory, pos, Integer.MIN_VALUE);
+      LittleEndian.putInt(heapMemory, pos, Integer.MIN_VALUE);
       pos += 4;
       Platform.putLong(heapMemory, pos, Long.MAX_VALUE);
       pos += 8;
-      MemoryUtils.putDouble(heapMemory, pos, -1);
+      LittleEndian.putDouble(heapMemory, pos, -1);
       pos += 8;
-      MemoryUtils.putFloat(heapMemory, pos, -1);
+      LittleEndian.putFloat(heapMemory, pos, -1);
       assertEquals(buffer.getFloat((int) (pos - Platform.BYTE_ARRAY_OFFSET)), -1);
       pos -= 8;
       assertEquals(buffer.getDouble((int) (pos - Platform.BYTE_ARRAY_OFFSET)), -1);
       pos -= 8;
-      assertEquals(MemoryUtils.getLong(heapMemory, pos), Long.MAX_VALUE);
+      assertEquals(LittleEndian.getLong(heapMemory, pos), Long.MAX_VALUE);
       pos -= 4;
-      assertEquals(MemoryUtils.getInt(heapMemory, pos), Integer.MIN_VALUE);
+      assertEquals(LittleEndian.getInt(heapMemory, pos), Integer.MIN_VALUE);
       pos -= 2;
       assertEquals(buffer.getShort((int) (pos - Platform.BYTE_ARRAY_OFFSET)), Short.MAX_VALUE);
       pos -= 1;
@@ -539,7 +539,7 @@ public class MemoryBufferTest {
     byte[] data = new byte[4];
     data[0] = (byte) 0xac;
     data[1] = (byte) 0xed;
-    assertEquals(MemoryUtils.getShortB(data, 0), (short) 0xaced);
+    assertEquals(BigEndian.getShortB(data, 0), (short) 0xaced);
   }
 
   @Test
@@ -587,21 +587,21 @@ public class MemoryBufferTest {
     MemoryBuffer buf = MemoryUtils.buffer(80);
     int index = 0;
     {
-      int diff = MemoryUtils.putVarUint36Small(buf.getHeapMemory(), index, 10);
+      int diff = LittleEndian.putVarUint36Small(buf.getHeapMemory(), index, 10);
       assertEquals(buf.readVarUint36Small(), 10);
       buf.increaseReaderIndex(-diff);
       index += buf._unsafePutVarUint36Small(index, 10);
       assertEquals(buf.readVarUint36Small(), 10);
     }
     {
-      int diff = MemoryUtils.putVarUint36Small(buf.getHeapMemory(), index, Short.MAX_VALUE);
+      int diff = LittleEndian.putVarUint36Small(buf.getHeapMemory(), index, Short.MAX_VALUE);
       assertEquals(buf.readVarUint36Small(), Short.MAX_VALUE);
       buf.increaseReaderIndex(-diff);
       index += buf._unsafePutVarUint36Small(index, Short.MAX_VALUE);
       assertEquals(buf.readVarUint36Small(), Short.MAX_VALUE);
     }
     {
-      int diff = MemoryUtils.putVarUint36Small(buf.getHeapMemory(), index, Integer.MAX_VALUE);
+      int diff = LittleEndian.putVarUint36Small(buf.getHeapMemory(), index, Integer.MAX_VALUE);
       assertEquals(buf.readVarUint36Small(), Integer.MAX_VALUE);
       buf.increaseReaderIndex(-diff);
       index += buf._unsafePutVarUint36Small(index, Integer.MAX_VALUE);
@@ -609,7 +609,7 @@ public class MemoryBufferTest {
     }
     {
       int diff =
-          MemoryUtils.putVarUint36Small(
+          LittleEndian.putVarUint36Small(
               buf.getHeapMemory(), index, 0b111111111111111111111111111111111111L);
       assertEquals(buf.readVarUint36Small(), 0b111111111111111111111111111111111111L);
       buf.increaseReaderIndex(-diff);

--- a/java/fury-core/src/test/java/org/apache/fury/serializer/JavaSerializerTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/serializer/JavaSerializerTest.java
@@ -42,12 +42,12 @@ public class JavaSerializerTest extends FuryTestBase {
 
     private void writeObject(java.io.ObjectOutputStream s) throws IOException {
       s.defaultWriteObject();
-      s.writeInt32(age);
+      s.writeInt(age);
     }
 
     private void readObject(java.io.ObjectInputStream s) throws Exception {
       s.defaultReadObject();
-      this.age = s.readInt32();
+      this.age = s.readInt();
     }
   }
 

--- a/java/fury-core/src/test/java/org/apache/fury/serializer/JavaSerializerTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/serializer/JavaSerializerTest.java
@@ -29,7 +29,7 @@ import lombok.Data;
 import org.apache.fury.Fury;
 import org.apache.fury.FuryTestBase;
 import org.apache.fury.config.Language;
-import org.apache.fury.memory.MemoryUtils;
+import org.apache.fury.memory.BigEndian;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -70,7 +70,7 @@ public class JavaSerializerTest extends FuryTestBase {
       objectOutputStream.flush();
     }
     byte[] bytes = bas.toByteArray();
-    Assert.assertEquals(MemoryUtils.getShortB(bytes, 0), ObjectStreamConstants.STREAM_MAGIC);
+    Assert.assertEquals(BigEndian.getShortB(bytes, 0), ObjectStreamConstants.STREAM_MAGIC);
     Assert.assertTrue(JavaSerializer.serializedByJDK(bytes));
     Assert.assertTrue(JavaSerializer.serializedByJDK(ByteBuffer.wrap(bytes), 0));
     Fury fury = Fury.builder().build();

--- a/java/fury-core/src/test/java/org/apache/fury/serializer/JavaSerializerTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/serializer/JavaSerializerTest.java
@@ -29,7 +29,7 @@ import lombok.Data;
 import org.apache.fury.Fury;
 import org.apache.fury.FuryTestBase;
 import org.apache.fury.config.Language;
-import org.apache.fury.memory.MemoryBuffer;
+import org.apache.fury.memory.MemoryUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -70,7 +70,7 @@ public class JavaSerializerTest extends FuryTestBase {
       objectOutputStream.flush();
     }
     byte[] bytes = bas.toByteArray();
-    Assert.assertEquals(MemoryBuffer.getShortB(bytes, 0), ObjectStreamConstants.STREAM_MAGIC);
+    Assert.assertEquals(MemoryUtils.getShortB(bytes, 0), ObjectStreamConstants.STREAM_MAGIC);
     Assert.assertTrue(JavaSerializer.serializedByJDK(bytes));
     Assert.assertTrue(JavaSerializer.serializedByJDK(ByteBuffer.wrap(bytes), 0));
     Fury fury = Fury.builder().build();

--- a/java/fury-core/src/test/java/org/apache/fury/serializer/JavaSerializerTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/serializer/JavaSerializerTest.java
@@ -42,7 +42,7 @@ public class JavaSerializerTest extends FuryTestBase {
 
     private void writeObject(java.io.ObjectOutputStream s) throws IOException {
       s.defaultWriteObject();
-      s.writeInt(age);
+      s.writeInt32(age);
     }
 
     private void readObject(java.io.ObjectInputStream s) throws Exception {

--- a/java/fury-core/src/test/java/org/apache/fury/serializer/JavaSerializerTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/serializer/JavaSerializerTest.java
@@ -47,7 +47,7 @@ public class JavaSerializerTest extends FuryTestBase {
 
     private void readObject(java.io.ObjectInputStream s) throws Exception {
       s.defaultReadObject();
-      this.age = s.readInt();
+      this.age = s.readInt32();
     }
   }
 

--- a/java/fury-core/src/test/java/org/apache/fury/serializer/ObjectStreamSerializerTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/serializer/ObjectStreamSerializerTest.java
@@ -64,7 +64,7 @@ public class ObjectStreamSerializerTest extends FuryTestBase {
 
     private void writeObject(ObjectOutputStream s) throws IOException {
       s.defaultWriteObject();
-      s.writeInt(count);
+      s.writeInt32(count);
       s.writeObject(value);
     }
 
@@ -107,7 +107,7 @@ public class ObjectStreamSerializerTest extends FuryTestBase {
 
     private void writeObject(ObjectOutputStream s) throws IOException {
       s.defaultWriteObject();
-      s.writeInt(100);
+      s.writeInt32(100);
     }
 
     private void readObject(ObjectInputStream s) throws IOException, ClassNotFoundException {

--- a/java/fury-core/src/test/java/org/apache/fury/serializer/ObjectStreamSerializerTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/serializer/ObjectStreamSerializerTest.java
@@ -70,7 +70,7 @@ public class ObjectStreamSerializerTest extends FuryTestBase {
 
     private void readObject(ObjectInputStream s) throws IOException, ClassNotFoundException {
       s.defaultReadObject();
-      count = s.readInt();
+      count = s.readInt32();
       value = (char[]) s.readObject();
     }
   }
@@ -113,7 +113,7 @@ public class ObjectStreamSerializerTest extends FuryTestBase {
     private void readObject(ObjectInputStream s) throws IOException, ClassNotFoundException {
       // defaultReadObject compatible with putFields
       s.defaultReadObject();
-      Preconditions.checkArgument(s.readInt() == 100);
+      Preconditions.checkArgument(s.readInt32() == 100);
     }
   }
 

--- a/java/fury-core/src/test/java/org/apache/fury/serializer/ObjectStreamSerializerTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/serializer/ObjectStreamSerializerTest.java
@@ -64,13 +64,13 @@ public class ObjectStreamSerializerTest extends FuryTestBase {
 
     private void writeObject(ObjectOutputStream s) throws IOException {
       s.defaultWriteObject();
-      s.writeInt32(count);
+      s.writeInt(count);
       s.writeObject(value);
     }
 
     private void readObject(ObjectInputStream s) throws IOException, ClassNotFoundException {
       s.defaultReadObject();
-      count = s.readInt32();
+      count = s.readInt();
       value = (char[]) s.readObject();
     }
   }
@@ -107,13 +107,13 @@ public class ObjectStreamSerializerTest extends FuryTestBase {
 
     private void writeObject(ObjectOutputStream s) throws IOException {
       s.defaultWriteObject();
-      s.writeInt32(100);
+      s.writeInt(100);
     }
 
     private void readObject(ObjectInputStream s) throws IOException, ClassNotFoundException {
       // defaultReadObject compatible with putFields
       s.defaultReadObject();
-      Preconditions.checkArgument(s.readInt32() == 100);
+      Preconditions.checkArgument(s.readInt() == 100);
     }
   }
 

--- a/java/fury-core/src/test/java/org/apache/fury/serializer/PrimitiveSerializersTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/serializer/PrimitiveSerializersTest.java
@@ -94,7 +94,7 @@ public class PrimitiveSerializersTest extends FuryTestBase {
             Integer.MIN_VALUE,
             Long.MIN_VALUE,
             Long.MIN_VALUE,
-            -3763915443215605988L, // test Long.reverseBytes in readVarInt64OnBE
+            -3763915443215605988L, // test Long.reverseBytes in _readVarInt64OnBE
             Float.MIN_VALUE,
             Float.MIN_VALUE,
             Double.MIN_VALUE,

--- a/java/fury-core/src/test/java/org/apache/fury/serializer/PrimitiveSerializersTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/serializer/PrimitiveSerializersTest.java
@@ -94,7 +94,7 @@ public class PrimitiveSerializersTest extends FuryTestBase {
             Integer.MIN_VALUE,
             Long.MIN_VALUE,
             Long.MIN_VALUE,
-            -3763915443215605988L, // test Long.reverseBytes in readVarLongOnBE
+            -3763915443215605988L, // test Long.reverseBytes in readVarInt64OnBE
             Float.MIN_VALUE,
             Float.MIN_VALUE,
             Double.MIN_VALUE,

--- a/java/fury-core/src/test/java/org/apache/fury/serializer/ReplaceResolveSerializerTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/serializer/ReplaceResolveSerializerTest.java
@@ -315,7 +315,7 @@ public class ReplaceResolveSerializerTest extends FuryTestBase {
 
     private void readObject(java.io.ObjectInputStream s) throws Exception {
       s.defaultReadObject();
-      this.state = s.readInt();
+      this.state = s.readInt32();
     }
   }
 
@@ -551,7 +551,7 @@ public class ReplaceResolveSerializerTest extends FuryTestBase {
 
     @Override
     public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
-      f1 = in.readInt();
+      f1 = in.readInt32();
     }
 
     private Object writeReplace() {

--- a/java/fury-core/src/test/java/org/apache/fury/serializer/ReplaceResolveSerializerTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/serializer/ReplaceResolveSerializerTest.java
@@ -310,12 +310,12 @@ public class ReplaceResolveSerializerTest extends FuryTestBase {
 
     private void writeObject(java.io.ObjectOutputStream s) throws IOException {
       s.defaultWriteObject();
-      s.writeInt32(state);
+      s.writeInt(state);
     }
 
     private void readObject(java.io.ObjectInputStream s) throws Exception {
       s.defaultReadObject();
-      this.state = s.readInt32();
+      this.state = s.readInt();
     }
   }
 
@@ -546,12 +546,12 @@ public class ReplaceResolveSerializerTest extends FuryTestBase {
 
     @Override
     public void writeExternal(ObjectOutput out) throws IOException {
-      out.writeInt32(f1);
+      out.writeInt(f1);
     }
 
     @Override
     public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
-      f1 = in.readInt32();
+      f1 = in.readInt();
     }
 
     private Object writeReplace() {

--- a/java/fury-core/src/test/java/org/apache/fury/serializer/ReplaceResolveSerializerTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/serializer/ReplaceResolveSerializerTest.java
@@ -310,7 +310,7 @@ public class ReplaceResolveSerializerTest extends FuryTestBase {
 
     private void writeObject(java.io.ObjectOutputStream s) throws IOException {
       s.defaultWriteObject();
-      s.writeInt(state);
+      s.writeInt32(state);
     }
 
     private void readObject(java.io.ObjectInputStream s) throws Exception {
@@ -546,7 +546,7 @@ public class ReplaceResolveSerializerTest extends FuryTestBase {
 
     @Override
     public void writeExternal(ObjectOutput out) throws IOException {
-      out.writeInt(f1);
+      out.writeInt32(f1);
     }
 
     @Override

--- a/java/fury-core/src/test/java/org/apache/fury/serializer/StringSerializerTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/serializer/StringSerializerTest.java
@@ -85,8 +85,7 @@ public class StringSerializerTest extends FuryTestBase {
       if (STRING_VALUE_FIELD_IS_BYTES) {
         return readJDK11String(buffer);
       } else if (STRING_VALUE_FIELD_IS_CHARS) {
-        return StringSerializer.newCharsStringZeroCopy(
-            buffer.readChars(buffer.readPositiveVarInt()));
+        return StringSerializer.newCharsStringZeroCopy(buffer.readChars(buffer.readVarUint32()));
       }
       return null;
     } catch (Exception e) {
@@ -384,7 +383,7 @@ public class StringSerializerTest extends FuryTestBase {
       assertEquals(serializer.read(buffer), "abc你好");
       byte[] bytes = "abc你好".getBytes(StandardCharsets.UTF_8);
       byte UTF8 = 2;
-      buffer.writePositiveVarLong(((long) bytes.length) << 2 | UTF8);
+      buffer.writeVarUint64(((long) bytes.length) << 2 | UTF8);
       buffer.writeBytes(bytes);
       assertEquals(serializer.read(buffer), "abc你好");
       assertEquals(buffer.readerIndex(), buffer.writerIndex());

--- a/java/fury-core/src/test/java/org/apache/fury/serializer/collection/CollectionSerializersTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/serializer/collection/CollectionSerializersTest.java
@@ -538,7 +538,7 @@ public class CollectionSerializersTest extends FuryTestBase {
 
     @Override
     public Collection newCollection(MemoryBuffer buffer) {
-      int numElements = buffer.readPositiveVarInt();
+      int numElements = buffer.readVarUint32();
       setNumElements(numElements);
       return new ArrayList<>(numElements);
     }

--- a/java/fury-core/src/test/java/org/apache/fury/serializer/test/Inaccessible.java
+++ b/java/fury-core/src/test/java/org/apache/fury/serializer/test/Inaccessible.java
@@ -54,9 +54,9 @@ class Inaccessible implements Externalizable {
 
   @Override
   public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
-    this.x = in.readInt();
-    this.y = in.readInt();
-    int len = in.readInt();
+    this.x = in.readInt32();
+    this.y = in.readInt32();
+    int len = in.readInt32();
     byte[] arr = new byte[len];
     Preconditions.checkArgument(in.read(arr) == len);
     this.bytes = arr;

--- a/java/fury-core/src/test/java/org/apache/fury/serializer/test/Inaccessible.java
+++ b/java/fury-core/src/test/java/org/apache/fury/serializer/test/Inaccessible.java
@@ -46,17 +46,17 @@ class Inaccessible implements Externalizable {
 
   @Override
   public void writeExternal(ObjectOutput out) throws IOException {
-    out.writeInt32(x);
-    out.writeInt32(y);
-    out.writeInt32(bytes.length);
+    out.writeInt(x);
+    out.writeInt(y);
+    out.writeInt(bytes.length);
     out.write(bytes);
   }
 
   @Override
   public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
-    this.x = in.readInt32();
-    this.y = in.readInt32();
-    int len = in.readInt32();
+    this.x = in.readInt();
+    this.y = in.readInt();
+    int len = in.readInt();
     byte[] arr = new byte[len];
     Preconditions.checkArgument(in.read(arr) == len);
     this.bytes = arr;

--- a/java/fury-core/src/test/java/org/apache/fury/serializer/test/Inaccessible.java
+++ b/java/fury-core/src/test/java/org/apache/fury/serializer/test/Inaccessible.java
@@ -46,9 +46,9 @@ class Inaccessible implements Externalizable {
 
   @Override
   public void writeExternal(ObjectOutput out) throws IOException {
-    out.writeInt(x);
-    out.writeInt(y);
-    out.writeInt(bytes.length);
+    out.writeInt32(x);
+    out.writeInt32(y);
+    out.writeInt32(bytes.length);
     out.write(bytes);
   }
 

--- a/java/fury-format/src/main/java/org/apache/fury/format/encoder/Encoders.java
+++ b/java/fury-format/src/main/java/org/apache/fury/format/encoder/Encoders.java
@@ -152,7 +152,7 @@ public class Encoders {
         @Override
         public T decode(byte[] bytes) {
           MemoryBuffer buffer = MemoryUtils.wrap(bytes);
-          long peerSchemaHash = buffer.readLong();
+          long peerSchemaHash = buffer.readInt64();
           if (peerSchemaHash != schemaHash) {
             throw new ClassNotCompatibleException(
                 String.format(

--- a/java/fury-format/src/main/java/org/apache/fury/format/encoder/Encoders.java
+++ b/java/fury-format/src/main/java/org/apache/fury/format/encoder/Encoders.java
@@ -169,7 +169,7 @@ public class Encoders {
         @Override
         public byte[] encode(T obj) {
           buffer.writerIndex(0);
-          buffer.writeLong(schemaHash);
+          buffer.writeInt64(schemaHash);
           writer.setBuffer(buffer);
           writer.reset();
           BinaryRow row = toRow(obj);

--- a/java/fury-format/src/test/java/org/apache/fury/format/CrossLanguageTest.java
+++ b/java/fury-format/src/test/java/org/apache/fury/format/CrossLanguageTest.java
@@ -460,8 +460,8 @@ public class CrossLanguageTest {
 
     MemoryBuffer intBandBuffer = MemoryUtils.wrap(Files.readAllBytes(intBandDataFile));
     outOfBandBuffer = MemoryUtils.wrap(Files.readAllBytes(outOfBandDataFile));
-    int len1 = outOfBandBuffer.readInt();
-    int len2 = outOfBandBuffer.readInt();
+    int len1 = outOfBandBuffer.readInt32();
+    int len2 = outOfBandBuffer.readInt32();
     buffers = Arrays.asList(outOfBandBuffer.slice(8, len1), outOfBandBuffer.slice(8 + len1, len2));
     objects = (List<?>) fury.deserialize(intBandBuffer, buffers);
     Assert.assertNotNull(objects);

--- a/java/fury-format/src/test/java/org/apache/fury/format/CrossLanguageTest.java
+++ b/java/fury-format/src/test/java/org/apache/fury/format/CrossLanguageTest.java
@@ -443,8 +443,8 @@ public class CrossLanguageTest {
     Path outOfBandDataFile =
         Files.createTempFile("test_serialize_arrow_out_of_band", "out_of_band.data");
     MemoryBuffer outOfBandBuffer = MemoryUtils.buffer(32);
-    outOfBandBuffer.writeInt(bufferObjects.get(0).totalBytes());
-    outOfBandBuffer.writeInt(bufferObjects.get(1).totalBytes());
+    outOfBandBuffer.writeInt32(bufferObjects.get(0).totalBytes());
+    outOfBandBuffer.writeInt32(bufferObjects.get(1).totalBytes());
     bufferObjects.get(0).writeTo(outOfBandBuffer);
     bufferObjects.get(1).writeTo(outOfBandBuffer);
     Files.write(outOfBandDataFile, outOfBandBuffer.getBytes(0, outOfBandBuffer.writerIndex()));

--- a/python/pyfury/_util.pyx
+++ b/python/pyfury/_util.pyx
@@ -347,7 +347,7 @@ cdef class Buffer:
     cpdef inline write_varint32(self, int32_t value):
         self.grow(<int8_t>5)
         cdef int32_t actual_bytes_written = self.c_buffer.get()\
-            .PutPositiveVarInt32(self.writer_index, value)
+            .PutVarUint32(self.writer_index, value)
         self.writer_index += actual_bytes_written
         return actual_bytes_written
 
@@ -357,7 +357,7 @@ cdef class Buffer:
             int8_t b
             int32_t result
         if self._c_size - self.reader_index > 5:
-            result = self.c_buffer.get().GetPositiveVarInt32(
+            result = self.c_buffer.get().GetVarUint32(
                 self.reader_index, &read_length)
             self.reader_index += read_length
             return result

--- a/python/pyfury/includes/libutil.pxd
+++ b/python/pyfury/includes/libutil.pxd
@@ -63,9 +63,9 @@ cdef extern from "fury/util/buffer.h" namespace "fury" nogil:
 
         inline double GetDouble(uint32_t offset)
 
-        inline uint32_t PutPositiveVarInt32(uint32_t offset, int32_t value)
+        inline uint32_t PutVarUint32(uint32_t offset, int32_t value)
 
-        inline int32_t GetPositiveVarInt32(uint32_t offset, uint32_t *readBytesLength)
+        inline int32_t GetVarUint32(uint32_t offset, uint32_t *readBytesLength)
 
         void Copy(uint32_t start, uint32_t nbytes,
                   uint8_t* out, uint32_t offset) const

--- a/scala/src/main/scala/org/apache/fury/serializer/scala/CollectionSerializer.scala
+++ b/scala/src/main/scala/org/apache/fury/serializer/scala/CollectionSerializer.scala
@@ -55,7 +55,7 @@ abstract class AbstractScalaCollectionSerializer[A, T <: Iterable[A]](fury: Fury
   }
 
   override def newCollection(buffer: MemoryBuffer): util.Collection[_] = {
-    val numElements = buffer.readPositiveVarInt()
+    val numElements = buffer.readVarUint32()
     setNumElements(numElements)
     val factory = fury.readRef(buffer).asInstanceOf[Factory[A, T]]
     val builder = factory.newBuilder
@@ -149,7 +149,7 @@ class ScalaCollectionSerializer[A, T <: Iterable[A]] (fury: Fury, cls: Class[T])
   override def onCollectionWrite(buffer: MemoryBuffer, value: T): util.Collection[_] = {
     val factory: Factory[A, Any] = value.iterableFactory.iterableFactory
     val adapter = new CollectionAdapter[A, T](value)
-    buffer.writePositiveVarInt(adapter.size)
+    buffer.writeVarUint32(adapter.size)
     fury.writeRef(buffer, factory)
     adapter
   }
@@ -163,7 +163,7 @@ class ScalaCollectionSerializer[A, T <: Iterable[A]] (fury: Fury, cls: Class[T])
 class ScalaSortedSetSerializer[A, T <: scala.collection.SortedSet[A]](fury: Fury, cls: Class[T])
   extends AbstractScalaCollectionSerializer[A, T](fury, cls) {
   override def onCollectionWrite(buffer: MemoryBuffer, value: T): util.Collection[_] = {
-    buffer.writePositiveVarInt(value.size)
+    buffer.writeVarUint32(value.size)
     val factory = value.sortedIterableFactory.evidenceIterableFactory[Any](
       value.ordering.asInstanceOf[Ordering[Any]])
     fury.writeRef(buffer, factory)
@@ -179,7 +179,7 @@ class ScalaSortedSetSerializer[A, T <: scala.collection.SortedSet[A]](fury: Fury
 class ScalaSeqSerializer[A, T <: scala.collection.Seq[A]](fury: Fury, cls: Class[T])
   extends AbstractScalaCollectionSerializer[A, T](fury, cls)  {
   override def onCollectionWrite(buffer: MemoryBuffer, value: T): util.Collection[_] = {
-    buffer.writePositiveVarInt(value.size)
+    buffer.writeVarUint32(value.size)
     val factory: Factory[A, Any] = value.iterableFactory.iterableFactory
     fury.writeRef(buffer, factory)
     new ListAdapter[Any](value)

--- a/scala/src/main/scala/org/apache/fury/serializer/scala/MapSerializer.scala
+++ b/scala/src/main/scala/org/apache/fury/serializer/scala/MapSerializer.scala
@@ -56,7 +56,7 @@ abstract class AbstractScalaMapSerializer[K, V, T](fury: Fury, cls: Class[T])
   }
 
   override def newMap(buffer: MemoryBuffer): util.Map[_, _] = {
-    val numElements = buffer.readPositiveVarInt()
+    val numElements = buffer.readVarUint32()
     setNumElements(numElements)
     val factory = fury.readRef(buffer).asInstanceOf[Factory[(K, V), T]]
     val builder = factory.newBuilder
@@ -116,7 +116,7 @@ class ScalaMapSerializer[K, V, T <: scala.collection.Map[K, V]](fury: Fury, cls:
   extends AbstractScalaMapSerializer[K, V, T](fury, cls) {
 
   override def onMapWrite(buffer: MemoryBuffer, value: T): util.Map[_, _] = {
-    buffer.writePositiveVarInt(value.size)
+    buffer.writeVarUint32(value.size)
     val factory = value.mapFactory.mapFactory[Any, Any].asInstanceOf[Factory[Any, Any]]
     fury.writeRef(buffer, factory)
     new MapAdapter[K, V](value)
@@ -131,7 +131,7 @@ class ScalaMapSerializer[K, V, T <: scala.collection.Map[K, V]](fury: Fury, cls:
 class ScalaSortedMapSerializer[K, V, T <: scala.collection.SortedMap[K, V]](fury: Fury, cls: Class[T])
   extends AbstractScalaMapSerializer[K, V, T](fury, cls) {
   override def onMapWrite(buffer: MemoryBuffer, value: T): util.Map[_, _] = {
-    buffer.writePositiveVarInt(value.size)
+    buffer.writeVarUint32(value.size)
     val factory = value.sortedMapFactory.sortedMapFactory[Any, Any](
       value.ordering.asInstanceOf[Ordering[Any]]).asInstanceOf[Factory[Any, Any]]
     fury.writeRef(buffer, factory)


### PR DESCRIPTION
This PR refactor `MemoryBuffer` by:
- Rename all methods in name for unsigned varint/varlong write/read methods from write/readPositiveXXX.
- Rename all methods of get/put/read/writeType to type with number. For example, rename `readInt` to `readInt32`
- Remove rebundant code in `MemoryBuffer`
- Rename unsafe method as `_unsafeXXX`

