### PR TITLE
perf(java): Reduce unsafeWritePositiveVarLong bytecode size.

### DIFF
--- a/java/fury-core/src/main/java/org/apache/fury/memory/MemoryBuffer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/memory/MemoryBuffer.java
@@ -1697,64 +1697,56 @@ public final class MemoryBuffer {
     final int writerIndex = this.writerIndex;
     int varInt;
     varInt = (int) (value & 0x7F);
-    value >>>= 7;
-    if (value == 0) {
+    if (value >>> 7 == 0) {
       UNSAFE.putByte(heapMemory, address + writerIndex, (byte) varInt);
       this.writerIndex = writerIndex + 1;
       return 1;
     }
-    varInt |= (int) ((value & 0x7F) << 8) | 0x80;
-    value >>>= 7;
-    if (value == 0) {
+    varInt |= (((value & 0x3f80) << 1) | 0x80);
+    if (value >>> 14 == 0) {
       unsafePutInt(writerIndex, varInt);
       this.writerIndex = writerIndex + 2;
       return 2;
     }
-    varInt |= (int) ((value & 0x7F) << 16) | 0x8000;
-    value >>>= 7;
-    if (value == 0) {
+    varInt |= (((value & 0x1fc000) << 2) | 0x8000);
+    if (value >>> 21 == 0) {
       unsafePutInt(writerIndex, varInt);
       this.writerIndex = writerIndex + 3;
       return 3;
     }
-    varInt |= (int) ((value & 0x7F) << 24) | 0x800000;
-    value >>>= 7;
-    if (value == 0) {
+    varInt |= ((value & 0xfe00000) << 3) | 0x800000;
+    if (value >>> 28 == 0) {
       unsafePutInt(writerIndex, varInt);
       this.writerIndex = writerIndex + 4;
       return 4;
     }
     long varLong = (varInt & 0xFFFFFFFFL);
-    varLong |= ((value & 0x7F) << 32) | 0x80000000L;
-    value >>>= 7;
-    if (value == 0) {
+    varLong |= ((value & 0x7f0000000L) << 4) | 0x80000000L;
+    if (value >>> 35 == 0) {
       unsafePutLong(writerIndex, varLong);
       this.writerIndex = writerIndex + 5;
       return 5;
     }
-    varLong |= ((value & 0x7F) << 40) | 0x8000000000L;
-    value >>>= 7;
-    if (value == 0) {
+    varLong |= ((value & 0x3f800000000L) << 5) | 0x8000000000L;
+    if (value >>> 42 == 0) {
       unsafePutLong(writerIndex, varLong);
       this.writerIndex = writerIndex + 6;
       return 6;
     }
-    varLong |= ((value & 0x7F) << 48) | 0x800000000000L;
-    value >>>= 7;
-    if (value == 0) {
+    varLong |= ((value & 0x1fc0000000000L) << 6) | 0x800000000000L;
+    if (value >>> 49 == 0) {
       unsafePutLong(writerIndex, varLong);
       this.writerIndex = writerIndex + 7;
       return 7;
     }
-    varLong |= ((value & 0x7F) << 56) | 0x80000000000000L;
-    value >>>= 7;
+    varLong |= ((value & 0xfe000000000000L) << 7) | 0x80000000000000L;
+    value >>>= 56;
     if (value == 0) {
       unsafePutLong(writerIndex, varLong);
       this.writerIndex = writerIndex + 8;
       return 8;
     }
-    varLong |= 0x8000000000000000L;
-    unsafePutLong(writerIndex, varLong);
+    unsafePutLong(writerIndex, varLong | 0x8000000000000000L);
     UNSAFE.putByte(heapMemory, address + writerIndex + 8, (byte) (value & 0xFF));
     this.writerIndex = writerIndex + 9;
     return 9;


### PR DESCRIPTION
<!--
**Thanks for contributing to Fury.**

**If this is your first time opening a PR on fury, you can refer to [CONTRIBUTING.md](https://github.com/apache/incubator-fury/blob/main/CONTRIBUTING.md).**

Contribution Checklist

    - The **Apache Fury (incubating)** community has restrictions on the naming of pr titles. You can also find instructions in [CONTRIBUTING.md](https://github.com/apache/incubator-fury/blob/main/CONTRIBUTING.md).

    - Fury has a strong focus on performance. If the PR you submit will have an impact on performance, please benchmark it first and provide the benchmark result here.
-->

## Reduce unsafeWritePositiveVarLong bytecode size
Reduce bytecode size from 431 to 413.

<!-- Describe the purpose of this PR. -->


## Related issues
Through the calculation in advance to reduce memory
#1465 
<!--
Is there any related issue? Please attach here.

- #xxxx0
- #xxxx1
- #xxxx2
-->


## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/incubator-fury/issues/new/choose) describing the need to do so and update the document if necessary.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?


## Benchmark
pre
<img width="806" alt="image" src="https://github.com/apache/incubator-fury/assets/46820719/6627e8ef-b681-46cb-9edd-66839d875459">

after
<img width="849" alt="image" src="https://github.com/apache/incubator-fury/assets/46820719/ec97c0ed-3939-4149-981b-32957fd38f93">


<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.
-->
