### PR TITLE
perf(java): generate list fori loop instead of iterator loop for list serialization

### DIFF
--- a/java/fury-core/src/main/java/org/apache/fury/builder/BaseObjectCodecBuilder.java
+++ b/java/fury-core/src/main/java/org/apache/fury/builder/BaseObjectCodecBuilder.java
@@ -34,6 +34,7 @@ import static org.apache.fury.collection.Collections.ofHashSet;
 import static org.apache.fury.serializer.CodegenSerializer.LazyInitBeanSerializer;
 import static org.apache.fury.type.TypeUtils.CLASS_TYPE;
 import static org.apache.fury.type.TypeUtils.COLLECTION_TYPE;
+import static org.apache.fury.type.TypeUtils.LIST_TYPE;
 import static org.apache.fury.type.TypeUtils.MAP_TYPE;
 import static org.apache.fury.type.TypeUtils.OBJECT_TYPE;
 import static org.apache.fury.type.TypeUtils.PRIMITIVE_BOOLEAN_TYPE;
@@ -711,7 +712,9 @@ public abstract class BaseObjectCodecBuilder extends CodecBuilder {
             TypeUtils.collectionOf(elementType),
             buffer,
             collection);
-    collection = onCollectionWrite;
+    boolean isList = List.class.isAssignableFrom(getRawType(collection.type()));
+    collection =
+        isList ? new Cast(onCollectionWrite.inline(), LIST_TYPE, "list") : onCollectionWrite;
     Expression size = new Invoke(collection, "size", PRIMITIVE_INT_TYPE);
     walkPath.add(elementType.toString());
     ListExpression builder = new ListExpression();


### PR DESCRIPTION
<!--
**Thanks for contributing to Fury.**

**If this is your first time opening a PR on fury, you can refer to [CONTRIBUTING.md](https://github.com/apache/incubator-fury/blob/main/CONTRIBUTING.md).**

Contribution Checklist

    - The **Apache Fury (incubating)** community has restrictions on the naming of pr titles. You can also find instructions in [CONTRIBUTING.md](https://github.com/apache/incubator-fury/blob/main/CONTRIBUTING.md).

    - Fury has a strong focus on performance. If the PR you submit will have an impact on performance, please benchmark it first and provide the benchmark result here.
-->

## What does this PR do?
generate list fori loop instead of iterator loop for list serialization
<!-- Describe the purpose of this PR. -->

Before this PR:
```java
  private void sameElementClassWrite(MemoryBuffer memoryBuffer2, int value3, int value4, java.util.Collection collection, boolean value5) {
      boolean isDeclType = (value4 & 4) != 4;
      Serializer serializer1;
      if (isDeclType) {
          serializer1 = serializer0;
      } else {
          serializer1 = imageClassInfoHolder.getSerializer();
      }
      java.util.Iterator iter = collection.iterator();
      int i = 0;
      while (iter.hasNext()) {
          org.apache.fury.benchmark.data.Image elemValue = (org.apache.fury.benchmark.data.Image)iter.next();
          if (value5) {
              if ((elemValue == null)) {
                  memoryBuffer2.writeByte(((byte)-3));
              } else {
                  memoryBuffer2.writeByte(((byte)0));
                  serializer1.write(memoryBuffer2, elemValue);
              }
          } else {
              serializer1.write(memoryBuffer2, elemValue);
          }
          i++;
      }
  }
```
![image](https://github.com/apache/incubator-fury/assets/12445254/3ad67bfc-0b36-4d74-bc5a-a0f50ebd0a9e)


With this PR:
```java
  private void sameElementClassWrite(MemoryBuffer memoryBuffer2, java.util.List list2, int value3, int value4, boolean value5) {
      boolean isDeclType = (value3 & 4) != 4;
      Serializer serializer1;
      if (isDeclType) {
          serializer1 = serializer0;
      } else {
          serializer1 = imageClassInfoHolder.getSerializer();
      }
      for (int i = 0; i < value4; i+=1) {
        Object object = list2.get(i);
        org.apache.fury.benchmark.data.Image castedValue = (org.apache.fury.benchmark.data.Image)object;
        if (value5) {
            if ((castedValue == null)) {
                memoryBuffer2.writeByte(((byte)-3));
            } else {
                memoryBuffer2.writeByte(((byte)0));
                serializer1.write(memoryBuffer2, castedValue);
            }
        } else {
            serializer1.write(memoryBuffer2, castedValue);
        }
      }
  }
```
![image](https://github.com/apache/incubator-fury/assets/12445254/08783615-aff8-48c3-b688-0ba6275e1964)

## Related issues

<!--
Is there any related issue? Please attach here.

- #xxxx0
- #xxxx1
- #xxxx2
-->


## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/incubator-fury/issues/new/choose) describing the need to do so and update the document if necessary.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?


## Benchmark

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.
-->
```
Before:
Benchmark                              (bufferType)   (objectType)  (references)   Mode  Cnt        Score        Error  Units
UserTypeSerializeSuite.fury_serialize         array  MEDIA_CONTENT         false  thrpt   30  3617413.349 ± 140849.598  ops/s

After:
Benchmark                              (bufferType)   (objectType)  (references)   Mode  Cnt        Score       Error  Units
UserTypeSerializeSuite.fury_serialize         array  MEDIA_CONTENT         false  thrpt   50  3795239.909 ± 77404.887  ops/s

```
