### PR TITLE
perf(java): optimize read string code size

### DIFF
--- a/java/fury-core/src/main/java/org/apache/fury/serializer/StringSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/StringSerializer.java
@@ -223,10 +223,13 @@ public final class StringSerializer extends Serializer<String> {
 
   @CodegenInvoke
   public String readBytesString(MemoryBuffer buffer) {
-    long header = Platform.IS_LITTLE_ENDIAN ? buffer.readVarUint36SmallOnLE() : buffer.readVarUint36SmallOnBE();
+    long header =
+        Platform.IS_LITTLE_ENDIAN
+            ? buffer.readVarUint36SmallOnLE()
+            : buffer.readVarUint36SmallOnBE();
     byte coder = (byte) (header & 0b11);
     int numBytes = (int) (header >>> 2);
-    byte[] bytes = buffer.readBytes(numBytes);;
+    byte[] bytes = buffer.readBytes(numBytes);
     if (coder != UTF8) {
       return newBytesStringZeroCopy(coder, bytes);
     } else {
@@ -236,7 +239,10 @@ public final class StringSerializer extends Serializer<String> {
 
   @CodegenInvoke
   public String readCompressedCharsString(MemoryBuffer buffer) {
-    long header = Platform.IS_LITTLE_ENDIAN ? buffer.readVarUint36SmallOnLE() : buffer.readVarUint36SmallOnBE();
+    long header =
+        Platform.IS_LITTLE_ENDIAN
+            ? buffer.readVarUint36SmallOnLE()
+            : buffer.readVarUint36SmallOnBE();
     byte coder = (byte) (header & 0b11);
     int numBytes = (int) (header >>> 2);
     if (coder == LATIN1) {

--- a/java/fury-core/src/test/java/org/apache/fury/memory/MemoryBufferTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/memory/MemoryBufferTest.java
@@ -594,7 +594,8 @@ public class MemoryBufferTest {
       int diff = MemoryUtils.putVarUint36Small(buf.getHeapMemory(), index, Short.MAX_VALUE);
       assertEquals(buf.readVarUint36Small(), Short.MAX_VALUE);
       buf.increaseReaderIndex(-diff);
-      long v = Platform.IS_LITTLE_ENDIAN ? buf.readVarUint36SmallOnLE() : buf.readVarUint36SmallOnBE();
+      long v =
+          Platform.IS_LITTLE_ENDIAN ? buf.readVarUint36SmallOnLE() : buf.readVarUint36SmallOnBE();
       assertEquals(v, Short.MAX_VALUE);
       buf.increaseReaderIndex(-diff);
       index += buf.unsafePutVarUint36Small(index, Short.MAX_VALUE);
@@ -604,7 +605,8 @@ public class MemoryBufferTest {
       int diff = MemoryUtils.putVarUint36Small(buf.getHeapMemory(), index, Integer.MAX_VALUE);
       assertEquals(buf.readVarUint36Small(), Integer.MAX_VALUE);
       buf.increaseReaderIndex(-diff);
-      long v = Platform.IS_LITTLE_ENDIAN ? buf.readVarUint36SmallOnLE() : buf.readVarUint36SmallOnBE();
+      long v =
+          Platform.IS_LITTLE_ENDIAN ? buf.readVarUint36SmallOnLE() : buf.readVarUint36SmallOnBE();
       assertEquals(v, Integer.MAX_VALUE);
       buf.increaseReaderIndex(-diff);
       index += buf.unsafePutVarUint36Small(index, Integer.MAX_VALUE);
@@ -616,7 +618,8 @@ public class MemoryBufferTest {
               buf.getHeapMemory(), index, 0b111111111111111111111111111111111111L);
       assertEquals(buf.readVarUint36Small(), 0b111111111111111111111111111111111111L);
       buf.increaseReaderIndex(-diff);
-      long v = Platform.IS_LITTLE_ENDIAN ? buf.readVarUint36SmallOnLE() : buf.readVarUint36SmallOnBE();
+      long v =
+          Platform.IS_LITTLE_ENDIAN ? buf.readVarUint36SmallOnLE() : buf.readVarUint36SmallOnBE();
       assertEquals(v, 0b111111111111111111111111111111111111L);
       buf.increaseReaderIndex(-diff);
       buf.unsafePutVarUint36Small(index, 0b1000000000000000000000000000000000000L);

--- a/java/fury-core/src/test/java/org/apache/fury/memory/MemoryBufferTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/memory/MemoryBufferTest.java
@@ -594,12 +594,18 @@ public class MemoryBufferTest {
       int diff = MemoryUtils.putVarUint36Small(buf.getHeapMemory(), index, Short.MAX_VALUE);
       assertEquals(buf.readVarUint36Small(), Short.MAX_VALUE);
       buf.increaseReaderIndex(-diff);
+      long v = Platform.IS_LITTLE_ENDIAN ? buf.readVarUint36SmallOnLE() : buf.readVarUint36SmallOnBE();
+      assertEquals(v, Short.MAX_VALUE);
+      buf.increaseReaderIndex(-diff);
       index += buf.unsafePutVarUint36Small(index, Short.MAX_VALUE);
       assertEquals(buf.readVarUint36Small(), Short.MAX_VALUE);
     }
     {
       int diff = MemoryUtils.putVarUint36Small(buf.getHeapMemory(), index, Integer.MAX_VALUE);
       assertEquals(buf.readVarUint36Small(), Integer.MAX_VALUE);
+      buf.increaseReaderIndex(-diff);
+      long v = Platform.IS_LITTLE_ENDIAN ? buf.readVarUint36SmallOnLE() : buf.readVarUint36SmallOnBE();
+      assertEquals(v, Integer.MAX_VALUE);
       buf.increaseReaderIndex(-diff);
       index += buf.unsafePutVarUint36Small(index, Integer.MAX_VALUE);
       assertEquals(buf.readVarUint36Small(), Integer.MAX_VALUE);
@@ -609,6 +615,9 @@ public class MemoryBufferTest {
           MemoryUtils.putVarUint36Small(
               buf.getHeapMemory(), index, 0b111111111111111111111111111111111111L);
       assertEquals(buf.readVarUint36Small(), 0b111111111111111111111111111111111111L);
+      buf.increaseReaderIndex(-diff);
+      long v = Platform.IS_LITTLE_ENDIAN ? buf.readVarUint36SmallOnLE() : buf.readVarUint36SmallOnBE();
+      assertEquals(v, 0b111111111111111111111111111111111111L);
       buf.increaseReaderIndex(-diff);
       buf.unsafePutVarUint36Small(index, 0b1000000000000000000000000000000000000L);
       assertEquals(buf.readVarUint36Small(), 0); // overflow


### PR DESCRIPTION
<!--
**Thanks for contributing to Fury.**

**If this is your first time opening a PR on fury, you can refer to [CONTRIBUTING.md](https://github.com/apache/incubator-fury/blob/main/CONTRIBUTING.md).**

Contribution Checklist

    - The **Apache Fury (incubating)** community has restrictions on the naming of pr titles. You can also find instructions in [CONTRIBUTING.md](https://github.com/apache/incubator-fury/blob/main/CONTRIBUTING.md).

    - Fury has a strong focus on performance. If the PR you submit will have an impact on performance, please benchmark it first and provide the benchmark result here.
-->

## What does this PR do?
This PR optimize read string code size to speed up string serialization 
<!-- Describe the purpose of this PR. -->

## Related issues
#1486 

<!--
Is there any related issue? Please attach here.

- #xxxx0
- #xxxx1
- #xxxx2
-->


## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/incubator-fury/issues/new/choose) describing the need to do so and update the document if necessary.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?


## Benchmark
```
Before:
Benchmark                                  (bufferType)   (objectType)  (references)   Mode  Cnt        Score       Error  Units
UserTypeDeserializeSuite.fury_deserialize         array  MEDIA_CONTENT         false  thrpt   30  2622093.329 ± 79358.467  ops/s

This PR:
Benchmark                              (bufferType)   (objectType)  (references)   Mode  Cnt        Score        Error  Units

```
<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.
-->
