### PR TITLE
chore(java): deprecate  serializeJavaObjectAndClass/deserializeJavaObjectAndClass API

### DIFF
--- a/java/fury-core/src/main/java/org/apache/fury/BaseFury.java
+++ b/java/fury-core/src/main/java/org/apache/fury/BaseFury.java
@@ -149,17 +149,31 @@ public interface BaseFury {
 
   <T> T deserializeJavaObject(FuryReadableChannel channel, Class<T> cls);
 
+  /** This method is deprecated, please use {@link #serialize} instead. */
+  @Deprecated
   byte[] serializeJavaObjectAndClass(Object obj);
 
+  /** This method is deprecated, please use {@link #serialize} instead. */
+  @Deprecated
   void serializeJavaObjectAndClass(MemoryBuffer buffer, Object obj);
 
+  /** This method is deprecated, please use {@link #serialize} instead. */
+  @Deprecated
   void serializeJavaObjectAndClass(OutputStream outputStream, Object obj);
 
+  /** This method is deprecated, please use {@link #deserialize} instead. */
+  @Deprecated
   Object deserializeJavaObjectAndClass(byte[] data);
 
+  /** This method is deprecated, please use {@link #deserialize} instead. */
+  @Deprecated
   Object deserializeJavaObjectAndClass(MemoryBuffer buffer);
 
+  /** This method is deprecated, please use {@link #deserialize} instead. */
+  @Deprecated
   Object deserializeJavaObjectAndClass(FuryInputStream inputStream);
 
+  /** This method is deprecated, please use {@link #deserialize} instead. */
+  @Deprecated
   Object deserializeJavaObjectAndClass(FuryReadableChannel channel);
 }


### PR DESCRIPTION
<!--
**Thanks for contributing to Fury.**

**If this is your first time opening a PR on fury, you can refer to [CONTRIBUTING.md](https://github.com/apache/incubator-fury/blob/main/CONTRIBUTING.md).**

Contribution Checklist

    - The **Apache Fury (incubating)** community has restrictions on the naming of pr titles. You can also find instructions in [CONTRIBUTING.md](https://github.com/apache/incubator-fury/blob/main/CONTRIBUTING.md).

    - Fury has a strong focus on performance. If the PR you submit will have an impact on performance, please benchmark it first and provide the benchmark result here.
-->

## What does this PR do?
This PR deprecates serializeJavaObjectAndClass/deserializeJavaObjectAndClass API.
This APi is vargue and kind of duplicate with `Fury#serialize`. 
It doesn't provide `BufferCallback` support too.

We should make our API minimal and does not bloat it
<!-- Describe the purpose of this PR. -->


## Related issues

<!--
Is there any related issue? Please attach here.

- #xxxx0
- #xxxx1
- #xxxx2
-->


## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/incubator-fury/issues/new/choose) describing the need to do so and update the document if necessary.
-->

- [x] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?


## Benchmark

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.
-->
