### PR TITLE
perf(java): fastpath for read/write small varint in range [0,127]

### DIFF
--- a/java/fury-core/src/main/java/org/apache/fury/logging/LoggerFactory.java
+++ b/java/fury-core/src/main/java/org/apache/fury/logging/LoggerFactory.java
@@ -27,7 +27,7 @@ import org.apache.fury.util.GraalvmSupport;
 public class LoggerFactory {
   private static volatile boolean disableLogging;
   private static volatile boolean useSlf4jlogger;
-  private static volatile int logLevel;
+  private static volatile int logLevel = 2;
 
   public static void disableLogging() {
     disableLogging = true;
@@ -47,7 +47,7 @@ public class LoggerFactory {
 
   public static Logger getLogger(Class<?> clazz) {
     if (disableLogging) {
-      return new NilLogger();
+      return new FuryLogger(clazz, logLevel);
     } else {
       if (GraalvmSupport.IN_GRAALVM_NATIVE_IMAGE || !useSlf4jlogger) {
         return new FuryLogger(clazz, logLevel);

--- a/java/fury-core/src/main/java/org/apache/fury/memory/MemoryBuffer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/memory/MemoryBuffer.java
@@ -1783,6 +1783,22 @@ public final class MemoryBuffer {
   }
 
   /**
+   * Fast path for read a unsigned varint which is mostly a smaller value in 7 bits value in [0, 127). When the
+   * value is equal or greater than 127, the read will be a little slower.
+   */
+  public int readVarUint32Small7() {
+    int readIdx = readerIndex;
+    if (size - readIdx > 0) {
+      byte v = UNSAFE.getByte(heapMemory, address + readIdx++);
+      if ((v & 0x80) == 0) {
+        readerIndex = readIdx;
+        return v;
+      }
+    }
+    return readVarUint32Small14();
+  }
+
+  /**
    * Fast path for read a unsigned varint which is mostly a smaller value in 14 bits value in [0, 16384). When the
    * value is equal or greater than 16384, the read will be a little slower.
    */

--- a/java/fury-core/src/main/java/org/apache/fury/memory/MemoryBuffer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/memory/MemoryBuffer.java
@@ -1783,10 +1783,10 @@ public final class MemoryBuffer {
   }
 
   /**
-   * Fast path for read a unsigned varint which is mostly a smaller value in [0, 16384). When the
+   * Fast path for read a unsigned varint which is mostly a smaller value in 14 bits value in [0, 16384). When the
    * value is equal or greater than 16384, the read will be a little slower.
    */
-  public int readVarUint32Small() {
+  public int readVarUint32Small14() {
     int readIdx = readerIndex;
     if (size - readIdx >= 5) {
       int fourByteValue = _unsafeGetInt32(readIdx++);

--- a/java/fury-core/src/main/java/org/apache/fury/memory/MemoryBuffer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/memory/MemoryBuffer.java
@@ -1601,7 +1601,7 @@ public final class MemoryBuffer {
     int readIdx = readerIndex;
     int result;
     if (size - readIdx < 5) {
-      result = readVarUint32Slow();
+      result = (int) readVarUint36Slow();
     } else {
       long address = this.address;
       // | 1bit + 7bits | 1bit + 7bits | 1bit + 7bits | 1bit + 7bits |
@@ -1644,7 +1644,7 @@ public final class MemoryBuffer {
     int readIdx = readerIndex;
     int result;
     if (size - readIdx < 5) {
-      result = readVarUint32Slow();
+      result = (int) readVarUint36Slow();
     } else {
       long address = this.address;
       int fourByteValue = Integer.reverseBytes(UNSAFE.getInt(heapMemory, address + readIdx));
@@ -1750,7 +1750,7 @@ public final class MemoryBuffer {
   public int readVarUint32() {
     int readIdx = readerIndex;
     if (size - readIdx < 5) {
-      return readVarUint32Slow();
+      return (int) readVarUint36Slow();
     }
     // | 1bit + 7bits | 1bit + 7bits | 1bit + 7bits | 1bit + 7bits |
     int fourByteValue = _unsafeGetInt32(readIdx);
@@ -1786,7 +1786,7 @@ public final class MemoryBuffer {
    * Fast path for read a unsigned varint which is mostly a smaller value in [0, 16384). When the
    * value is equal or greater than 16384, the read will be a little slower.
    */
-  public int readVarUintSmall() {
+  public int readVarUint32Small() {
     int readIdx = readerIndex;
     if (size - readIdx >= 5) {
       int fourByteValue = _unsafeGetInt32(readIdx++);
@@ -1805,33 +1805,8 @@ public final class MemoryBuffer {
       readerIndex = readIdx;
       return binarySize;
     } else {
-      return readVarUint32Slow();
+      return (int) readVarUint36Slow();
     }
-  }
-
-  private int readVarUint32Slow() {
-    // Note:
-    //  Loop are not used here to improve performance,
-    //  we manually unroll the loop for better performance.
-    int b = readByte();
-    int result = b & 0x7F;
-    if ((b & 0x80) != 0) {
-      b = readByte();
-      result |= (b & 0x7F) << 7;
-      if ((b & 0x80) != 0) {
-        b = readByte();
-        result |= (b & 0x7F) << 14;
-        if ((b & 0x80) != 0) {
-          b = readByte();
-          result |= (b & 0x7F) << 21;
-          if ((b & 0x80) != 0) {
-            b = readByte();
-            result |= (b & 0x7F) << 28;
-          }
-        }
-      }
-    }
-    return result;
   }
 
   /** Reads the 1-9 byte int part of a var long. */
@@ -2188,7 +2163,7 @@ public final class MemoryBuffer {
       }
       readerIndex = readIdx;
     } else {
-      binarySize = readVarUint32Slow();
+      binarySize = (int) readVarUint36Slow();
       readIdx = readerIndex;
     }
     int diff = size - readIdx;

--- a/java/fury-core/src/main/java/org/apache/fury/memory/MemoryBuffer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/memory/MemoryBuffer.java
@@ -731,19 +731,6 @@ public final class MemoryBuffer {
    */
   public int writeVarInt32(int v) {
     ensure(writerIndex + 8);
-    return _unsafeWriteVarInt32(v);
-  }
-
-  /**
-   * Writes a 1-5 byte int.
-   *
-   * @return The number of bytes written.
-   */
-  public int writeVarUint32(int v) {
-    // ensure at least 8 bytes are writable at once, so jvm-jit
-    // generated code is smaller. Otherwise, `MapRefResolver.writeRefOrNull`
-    // may be `callee is too large`/`already compiled into a big method`
-    ensure(writerIndex + 8);
     int varintBytes = _unsafePutVarUint36Small(writerIndex, ((long) v << 1) ^ (v >> 31));
     writerIndex += varintBytes;
     return varintBytes;
@@ -759,6 +746,21 @@ public final class MemoryBuffer {
     // CHECKSTYLE.ON:MethodName
     // Ensure negatives close to zero is encode in little bytes.
     int varintBytes = _unsafePutVarUint36Small(writerIndex, ((long) v << 1) ^ (v >> 31));
+    writerIndex += varintBytes;
+    return varintBytes;
+  }
+
+  /**
+   * Writes a 1-5 byte int.
+   *
+   * @return The number of bytes written.
+   */
+  public int writeVarUint32(int v) {
+    // ensure at least 8 bytes are writable at once, so jvm-jit
+    // generated code is smaller. Otherwise, `MapRefResolver.writeRefOrNull`
+    // may be `callee is too large`/`already compiled into a big method`
+    ensure(writerIndex + 8);
+    int varintBytes = _unsafePutVarUint36Small(writerIndex, v);
     writerIndex += varintBytes;
     return varintBytes;
   }
@@ -1041,16 +1043,14 @@ public final class MemoryBuffer {
    */
   public int writeVarInt64(long value) {
     ensure(writerIndex + 9);
-    value = (value << 1) ^ (value >> 63);
-    return _unsafeWriteVarUint64(value);
+    return _unsafeWriteVarUint64((value << 1) ^ (value >> 63));
   }
 
   @CodegenInvoke
   // CHECKSTYLE.OFF:MethodName
-  public int _unsafeWriteVarInt3264(long value) {
+  public int _unsafeWriteVarInt64(long value) {
     // CHECKSTYLE.ON:MethodName
-    value = (value << 1) ^ (value >> 63);
-    return _unsafeWriteVarUint64(value);
+    return _unsafeWriteVarUint64((value << 1) ^ (value >> 63));
   }
 
   public int writeVarUint64(long value) {

--- a/java/fury-core/src/main/java/org/apache/fury/resolver/ClassResolver.java
+++ b/java/fury-core/src/main/java/org/apache/fury/resolver/ClassResolver.java
@@ -1466,7 +1466,7 @@ public class ClassResolver {
 
   // Note: Thread safe fot jit thread to call.
   public Expression skipRegisteredClassExpr(Expression buffer) {
-    return new Invoke(buffer, "readVarUintSmall");
+    return new Invoke(buffer, "readVarUintSmall14");
   }
 
   /**

--- a/java/fury-core/src/main/java/org/apache/fury/resolver/ClassResolver.java
+++ b/java/fury-core/src/main/java/org/apache/fury/resolver/ClassResolver.java
@@ -1466,7 +1466,7 @@ public class ClassResolver {
 
   // Note: Thread safe fot jit thread to call.
   public Expression skipRegisteredClassExpr(Expression buffer) {
-    return new Invoke(buffer, "readVarUintSmall14");
+    return new Invoke(buffer, "readVarUint32Small14");
   }
 
   /**

--- a/java/fury-core/src/main/java/org/apache/fury/resolver/ClassResolver.java
+++ b/java/fury-core/src/main/java/org/apache/fury/resolver/ClassResolver.java
@@ -1204,9 +1204,9 @@ public class ClassResolver {
   public void writeClassAndUpdateCache(MemoryBuffer buffer, Class<?> cls) {
     // fast path for common type
     if (cls == Integer.class) {
-      buffer.writeVarUint32(INTEGER_CLASS_ID << 1);
+      buffer.writeVarUint32Small7(INTEGER_CLASS_ID << 1);
     } else if (cls == Long.class) {
-      buffer.writeVarUint32(LONG_CLASS_ID << 1);
+      buffer.writeVarUint32Small7(LONG_CLASS_ID << 1);
     } else {
       writeClass(buffer, getOrUpdateClassInfo(cls));
     }
@@ -1380,7 +1380,7 @@ public class ClassResolver {
    */
   public void writeClassDefs(MemoryBuffer buffer) {
     MetaContext metaContext = fury.getSerializationContext().getMetaContext();
-    buffer.writeVarUint32(metaContext.writingClassDefs.size());
+    buffer.writeVarUint32Small7(metaContext.writingClassDefs.size());
     for (ClassDef classDef : metaContext.writingClassDefs) {
       classDef.writeClassDef(buffer);
     }

--- a/java/fury-core/src/main/java/org/apache/fury/resolver/ClassResolver.java
+++ b/java/fury-core/src/main/java/org/apache/fury/resolver/ClassResolver.java
@@ -1290,7 +1290,7 @@ public class ClassResolver {
         metaContext,
         "Meta context must be set before serialization,"
             + " please set meta context by SerializationContext.setMetaContext");
-    int id = buffer.readVarUint32Small();
+    int id = buffer.readVarUint32Small14();
     List<ClassInfo> readClassInfos = metaContext.readClassInfos;
     ClassInfo classInfo = readClassInfos.get(id);
     if (classInfo == null) {
@@ -1313,7 +1313,7 @@ public class ClassResolver {
         metaContext,
         "Meta context must be set before serialization,"
             + " please set meta context by SerializationContext.setMetaContext");
-    int id = buffer.readVarUint32Small();
+    int id = buffer.readVarUint32Small14();
     List<ClassInfo> readClassInfos = metaContext.readClassInfos;
     ClassInfo classInfo = readClassInfos.get(id);
     if (classInfo == null) {
@@ -1397,7 +1397,7 @@ public class ClassResolver {
     int classDefOffset = buffer.readInt32();
     int readerIndex = buffer.readerIndex();
     buffer.readerIndex(classDefOffset);
-    int numClassDefs = buffer.readVarUint32Small();
+    int numClassDefs = buffer.readVarUint32Small14();
     for (int i = 0; i < numClassDefs; i++) {
       ClassDef readClassDef = ClassDef.readClassDef(buffer);
       // Share same class def to reduce memory footprint, since there may be many meta context.
@@ -1580,7 +1580,7 @@ public class ClassResolver {
     // use classId
     if ((flag & 0x80) != 0) { // class id is written using multiple bytes.
       buffer.increaseReaderIndex(-1);
-      classId = (short) buffer.readVarUint32Small();
+      classId = (short) buffer.readVarUint32Small14();
     } else {
       classId = (short) (flag & 0x7F);
     }

--- a/java/fury-core/src/main/java/org/apache/fury/resolver/ClassResolver.java
+++ b/java/fury-core/src/main/java/org/apache/fury/resolver/ClassResolver.java
@@ -1290,7 +1290,7 @@ public class ClassResolver {
         metaContext,
         "Meta context must be set before serialization,"
             + " please set meta context by SerializationContext.setMetaContext");
-    int id = buffer.readVarUintSmall();
+    int id = buffer.readVarUint32Small();
     List<ClassInfo> readClassInfos = metaContext.readClassInfos;
     ClassInfo classInfo = readClassInfos.get(id);
     if (classInfo == null) {
@@ -1313,7 +1313,7 @@ public class ClassResolver {
         metaContext,
         "Meta context must be set before serialization,"
             + " please set meta context by SerializationContext.setMetaContext");
-    int id = buffer.readVarUintSmall();
+    int id = buffer.readVarUint32Small();
     List<ClassInfo> readClassInfos = metaContext.readClassInfos;
     ClassInfo classInfo = readClassInfos.get(id);
     if (classInfo == null) {
@@ -1397,7 +1397,7 @@ public class ClassResolver {
     int classDefOffset = buffer.readInt32();
     int readerIndex = buffer.readerIndex();
     buffer.readerIndex(classDefOffset);
-    int numClassDefs = buffer.readVarUintSmall();
+    int numClassDefs = buffer.readVarUint32Small();
     for (int i = 0; i < numClassDefs; i++) {
       ClassDef readClassDef = ClassDef.readClassDef(buffer);
       // Share same class def to reduce memory footprint, since there may be many meta context.
@@ -1580,7 +1580,7 @@ public class ClassResolver {
     // use classId
     if ((flag & 0x80) != 0) { // class id is written using multiple bytes.
       buffer.increaseReaderIndex(-1);
-      classId = (short) buffer.readVarUintSmall();
+      classId = (short) buffer.readVarUint32Small();
     } else {
       classId = (short) (flag & 0x7F);
     }

--- a/java/fury-core/src/main/java/org/apache/fury/resolver/MapRefResolver.java
+++ b/java/fury-core/src/main/java/org/apache/fury/resolver/MapRefResolver.java
@@ -149,7 +149,7 @@ public final class MapRefResolver implements RefResolver {
     byte headFlag = buffer.readByte();
     if (headFlag == Fury.REF_FLAG) {
       // read reference id and get object from reference resolver
-      int referenceId = buffer.readVarUint32Small();
+      int referenceId = buffer.readVarUint32Small14();
       readObject = getReadObject(referenceId);
     } else {
       readObject = null;
@@ -170,7 +170,7 @@ public final class MapRefResolver implements RefResolver {
     byte headFlag = buffer.readByte();
     if (headFlag == Fury.REF_FLAG) {
       // read reference id and get object from reference resolver
-      readObject = getReadObject(buffer.readVarUint32Small());
+      readObject = getReadObject(buffer.readVarUint32Small14());
     } else {
       readObject = null;
       if (headFlag == Fury.REF_VALUE_FLAG) {

--- a/java/fury-core/src/main/java/org/apache/fury/resolver/MapRefResolver.java
+++ b/java/fury-core/src/main/java/org/apache/fury/resolver/MapRefResolver.java
@@ -149,7 +149,7 @@ public final class MapRefResolver implements RefResolver {
     byte headFlag = buffer.readByte();
     if (headFlag == Fury.REF_FLAG) {
       // read reference id and get object from reference resolver
-      int referenceId = buffer.readVarUintSmall();
+      int referenceId = buffer.readVarUint32Small();
       readObject = getReadObject(referenceId);
     } else {
       readObject = null;
@@ -170,7 +170,7 @@ public final class MapRefResolver implements RefResolver {
     byte headFlag = buffer.readByte();
     if (headFlag == Fury.REF_FLAG) {
       // read reference id and get object from reference resolver
-      readObject = getReadObject(buffer.readVarUintSmall());
+      readObject = getReadObject(buffer.readVarUint32Small());
     } else {
       readObject = null;
       if (headFlag == Fury.REF_VALUE_FLAG) {

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/ArraySerializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/ArraySerializers.java
@@ -82,7 +82,7 @@ public class ArraySerializers {
     @Override
     public void write(MemoryBuffer buffer, T[] arr) {
       int len = arr.length;
-      buffer.writeInt32(len);
+      buffer.writeVarUint32Small7(len);
       RefResolver refResolver = fury.getRefResolver();
       Serializer componentSerializer = this.componentTypeSerializer;
       if (componentSerializer != null) {
@@ -112,7 +112,7 @@ public class ArraySerializers {
     @Override
     public void xwrite(MemoryBuffer buffer, T[] arr) {
       int len = arr.length;
-      buffer.writeVarUint32(len);
+      buffer.writeVarUint32Small7(len);
       // TODO(chaokunyang) use generics by creating component serializers to multi-dimension array.
       for (T t : arr) {
         fury.xwriteRef(buffer, t);
@@ -122,7 +122,7 @@ public class ArraySerializers {
     @Override
     public T[] read(MemoryBuffer buffer) {
       // Some jdk8 will crash if use varint, why?
-      int numElements = buffer.readInt32();
+      int numElements = buffer.readVarUint32Small7();
       Object[] value = newArray(numElements);
       RefResolver refResolver = fury.getRefResolver();
       refResolver.reference(value);
@@ -563,7 +563,7 @@ public class ArraySerializers {
     @Override
     public void write(MemoryBuffer buffer, String[] value) {
       int len = value.length;
-      buffer.writeVarUint32(len);
+      buffer.writeVarUint32Small7(len);
       if (len == 0) {
         return;
       }
@@ -615,7 +615,7 @@ public class ArraySerializers {
     @Override
     public void xwrite(MemoryBuffer buffer, String[] value) {
       int len = value.length;
-      buffer.writeVarUint32(len);
+      buffer.writeVarUint32Small7(len);
       for (String elem : value) {
         if (elem != null) {
           buffer.writeByte(Fury.REF_VALUE_FLAG);
@@ -660,7 +660,7 @@ public class ArraySerializers {
   static void writePrimitiveArray(
       MemoryBuffer buffer, Object arr, int offset, int numElements, int elemSize) {
     int size = Math.multiplyExact(numElements, elemSize);
-    buffer.writeVarUint32(size);
+    buffer.writeVarUint32Small7(size);
     int writerIndex = buffer.writerIndex();
     int end = writerIndex + size;
     buffer.ensure(end);

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/ArraySerializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/ArraySerializers.java
@@ -591,7 +591,7 @@ public class ArraySerializers {
 
     @Override
     public String[] read(MemoryBuffer buffer) {
-      int numElements = buffer.readVarUint32Small14();
+      int numElements = buffer.readVarUint32Small7();
       String[] value = new String[numElements];
       if (numElements == 0) {
         return value;

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/ArraySerializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/ArraySerializers.java
@@ -160,7 +160,7 @@ public class ArraySerializers {
 
     @Override
     public T[] xread(MemoryBuffer buffer) {
-      int numElements = buffer.readVarUint32();
+      int numElements = buffer.readVarUint32Small7();
       Object[] value = newArray(numElements);
       for (int i = 0; i < numElements; i++) {
         value[i] = fury.xreadRef(buffer);
@@ -268,7 +268,7 @@ public class ArraySerializers {
         buf.copyToUnsafe(0, values, offset, size);
         return values;
       } else {
-        int size = buffer.readVarUint32();
+        int size = buffer.readVarUint32Small7();
         int numElements = size / elemSize;
         boolean[] values = new boolean[numElements];
         buffer.readToUnsafe(values, offset, size);
@@ -303,7 +303,7 @@ public class ArraySerializers {
         buf.copyToUnsafe(0, values, offset, size);
         return values;
       } else {
-        int size = buffer.readVarUint32();
+        int size = buffer.readVarUint32Small7();
         byte[] values = new byte[size];
         buffer.readToUnsafe(values, offset, size);
         return values;
@@ -338,7 +338,7 @@ public class ArraySerializers {
         buf.copyToUnsafe(0, values, offset, size);
         return values;
       } else {
-        int size = buffer.readVarUint32();
+        int size = buffer.readVarUint32Small7();
         int numElements = size / elemSize;
         char[] values = new char[numElements];
         buffer.readToUnsafe(values, offset, size);
@@ -389,7 +389,7 @@ public class ArraySerializers {
         buf.copyToUnsafe(0, values, offset, size);
         return values;
       } else {
-        int size = buffer.readVarUint32();
+        int size = buffer.readVarUint32Small7();
         int numElements = size / elemSize;
         short[] values = new short[numElements];
         buffer.readToUnsafe(values, offset, size);
@@ -425,7 +425,7 @@ public class ArraySerializers {
         buf.copyToUnsafe(0, values, offset, size);
         return values;
       } else {
-        int size = buffer.readVarUint32();
+        int size = buffer.readVarUint32Small7();
         int numElements = size / elemSize;
         int[] values = new int[numElements];
         buffer.readToUnsafe(values, offset, size);
@@ -461,7 +461,7 @@ public class ArraySerializers {
         buf.copyToUnsafe(0, values, offset, size);
         return values;
       } else {
-        int size = buffer.readVarUint32();
+        int size = buffer.readVarUint32Small7();
         int numElements = size / elemSize;
         long[] values = new long[numElements];
         buffer.readToUnsafe(values, offset, size);
@@ -497,7 +497,7 @@ public class ArraySerializers {
         buf.copyToUnsafe(0, values, offset, size);
         return values;
       } else {
-        int size = buffer.readVarUint32();
+        int size = buffer.readVarUint32Small7();
         int numElements = size / elemSize;
         float[] values = new float[numElements];
         buffer.readToUnsafe(values, offset, size);
@@ -533,7 +533,7 @@ public class ArraySerializers {
         buf.copyToUnsafe(0, values, offset, size);
         return values;
       } else {
-        int size = buffer.readVarUint32();
+        int size = buffer.readVarUint32Small7();
         int numElements = size / elemSize;
         double[] values = new double[numElements];
         buffer.readToUnsafe(values, offset, size);
@@ -628,7 +628,7 @@ public class ArraySerializers {
 
     @Override
     public String[] xread(MemoryBuffer buffer) {
-      int numElements = buffer.readVarUint32();
+      int numElements = buffer.readVarUint32Small7();
       String[] value = new String[numElements];
       for (int i = 0; i < numElements; i++) {
         if (buffer.readByte() == Fury.REF_VALUE_FLAG) {

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/ArraySerializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/ArraySerializers.java
@@ -591,7 +591,7 @@ public class ArraySerializers {
 
     @Override
     public String[] read(MemoryBuffer buffer) {
-      int numElements = buffer.readVarUintSmall();
+      int numElements = buffer.readVarUint32Small();
       String[] value = new String[numElements];
       if (numElements == 0) {
         return value;

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/ArraySerializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/ArraySerializers.java
@@ -591,7 +591,7 @@ public class ArraySerializers {
 
     @Override
     public String[] read(MemoryBuffer buffer) {
-      int numElements = buffer.readVarUint32Small();
+      int numElements = buffer.readVarUint32Small14();
       String[] value = new String[numElements];
       if (numElements == 0) {
         return value;

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/PrimitiveSerializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/PrimitiveSerializers.java
@@ -232,7 +232,7 @@ public class PrimitiveSerializers {
         case SLI:
           return new Invoke(buffer, ensureBounds ? "writeSliInt64" : "_unsafeWriteSliInt64", v);
         case PVL:
-          return new Invoke(buffer, ensureBounds ? "writeVarInt64" : "_unsafeWriteVarInt3264", v);
+          return new Invoke(buffer, ensureBounds ? "writeVarInt64" : "_unsafeWriteVarInt64", v);
         default:
           throw new UnsupportedOperationException("Unsupported long encoding " + longEncoding);
       }

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/Serializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/Serializers.java
@@ -322,7 +322,7 @@ public class Serializers {
 
     @Override
     public void write(MemoryBuffer buffer, Enum value) {
-      buffer.writeVarUint32(value.ordinal());
+      buffer.writeVarUint32Small7(value.ordinal());
     }
 
     @Override
@@ -339,9 +339,9 @@ public class Serializers {
     @Override
     public void write(MemoryBuffer buffer, BigDecimal value) {
       final byte[] bytes = value.unscaledValue().toByteArray();
-      buffer.writeVarUint32(value.scale());
-      buffer.writeVarUint32(value.precision());
-      buffer.writeVarUint32(bytes.length);
+      buffer.writeVarUint32Small7(value.scale());
+      buffer.writeVarUint32Small7(value.precision());
+      buffer.writeVarUint32Small7(bytes.length);
       buffer.writeBytes(bytes);
     }
 
@@ -364,7 +364,7 @@ public class Serializers {
     @Override
     public void write(MemoryBuffer buffer, BigInteger value) {
       final byte[] bytes = value.toByteArray();
-      buffer.writeVarUint32(bytes.length);
+      buffer.writeVarUint32Small7(bytes.length);
       buffer.writeBytes(bytes);
     }
 

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/Serializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/Serializers.java
@@ -327,7 +327,7 @@ public class Serializers {
 
     @Override
     public Enum read(MemoryBuffer buffer) {
-      return enumConstants[buffer.readVarUint32Small14()];
+      return enumConstants[buffer.readVarUint32Small7()];
     }
   }
 

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/Serializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/Serializers.java
@@ -327,7 +327,7 @@ public class Serializers {
 
     @Override
     public Enum read(MemoryBuffer buffer) {
-      return enumConstants[buffer.readVarUintSmall()];
+      return enumConstants[buffer.readVarUint32Small()];
     }
   }
 

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/Serializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/Serializers.java
@@ -347,9 +347,9 @@ public class Serializers {
 
     @Override
     public BigDecimal read(MemoryBuffer buffer) {
-      int scale = buffer.readVarUint32();
-      int precision = buffer.readVarUint32();
-      int len = buffer.readVarUint32();
+      int scale = buffer.readVarUint32Small7();
+      int precision = buffer.readVarUint32Small7();
+      int len = buffer.readVarUint32Small7();
       byte[] bytes = buffer.readBytes(len);
       final BigInteger bigInteger = new BigInteger(bytes);
       return new BigDecimal(bigInteger, scale, new MathContext(precision));
@@ -370,7 +370,7 @@ public class Serializers {
 
     @Override
     public BigInteger read(MemoryBuffer buffer) {
-      int len = buffer.readVarUint32();
+      int len = buffer.readVarUint32Small7();
       byte[] bytes = buffer.readBytes(len);
       return new BigInteger(bytes);
     }

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/Serializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/Serializers.java
@@ -327,7 +327,7 @@ public class Serializers {
 
     @Override
     public Enum read(MemoryBuffer buffer) {
-      return enumConstants[buffer.readVarUint32Small()];
+      return enumConstants[buffer.readVarUint32Small14()];
     }
   }
 

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/StringSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/StringSerializer.java
@@ -646,7 +646,7 @@ public final class StringSerializer extends Serializer<String> {
   }
 
   public String readUTF8String(MemoryBuffer buffer) {
-    int numBytes = buffer.readVarUint32Small();
+    int numBytes = buffer.readVarUint32Small14();
     buffer.checkReadableBytes(numBytes);
     final byte[] targetArray = buffer.getHeapMemory();
     if (targetArray != null) {

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/StringSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/StringSerializer.java
@@ -646,7 +646,7 @@ public final class StringSerializer extends Serializer<String> {
   }
 
   public String readUTF8String(MemoryBuffer buffer) {
-    int numBytes = buffer.readVarUintSmall();
+    int numBytes = buffer.readVarUint32Small();
     buffer.checkReadableBytes(numBytes);
     final byte[] targetArray = buffer.getHeapMemory();
     if (targetArray != null) {

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/collection/AbstractCollectionSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/collection/AbstractCollectionSerializer.java
@@ -439,7 +439,7 @@ public abstract class AbstractCollectionSerializer<T> extends Serializer<T> {
   public void xwrite(MemoryBuffer buffer, T value) {
     Collection collection = (Collection) value;
     int len = collection.size();
-    buffer.writeVarUint32(len);
+    buffer.writeVarUint32Small7(len);
     xwriteElements(fury, buffer, collection);
   }
 

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/collection/AbstractCollectionSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/collection/AbstractCollectionSerializer.java
@@ -493,7 +493,7 @@ public abstract class AbstractCollectionSerializer<T> extends Serializer<T> {
    * will raise NPE.
    */
   public Collection newCollection(MemoryBuffer buffer) {
-    numElements = buffer.readVarUintSmall();
+    numElements = buffer.readVarUint32Small();
     if (constructor == null) {
       constructor = ReflectionUtils.getCtrHandle(type, true);
     }

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/collection/AbstractCollectionSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/collection/AbstractCollectionSerializer.java
@@ -493,7 +493,7 @@ public abstract class AbstractCollectionSerializer<T> extends Serializer<T> {
    * will raise NPE.
    */
   public Collection newCollection(MemoryBuffer buffer) {
-    numElements = buffer.readVarUint32Small14();
+    numElements = buffer.readVarUint32Small7();
     if (constructor == null) {
       constructor = ReflectionUtils.getCtrHandle(type, true);
     }

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/collection/AbstractCollectionSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/collection/AbstractCollectionSerializer.java
@@ -493,7 +493,7 @@ public abstract class AbstractCollectionSerializer<T> extends Serializer<T> {
    * will raise NPE.
    */
   public Collection newCollection(MemoryBuffer buffer) {
-    numElements = buffer.readVarUint32Small();
+    numElements = buffer.readVarUint32Small14();
     if (constructor == null) {
       constructor = ReflectionUtils.getCtrHandle(type, true);
     }

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/collection/AbstractMapSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/collection/AbstractMapSerializer.java
@@ -704,7 +704,7 @@ public abstract class AbstractMapSerializer<T> extends Serializer<T> {
    * will raise NPE.
    */
   public Map newMap(MemoryBuffer buffer) {
-    numElements = buffer.readVarUint32();
+    numElements = buffer.readVarUint32Small7();
     if (constructor == null) {
       constructor = ReflectionUtils.getCtrHandle(type, true);
     }

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/collection/ChildContainerSerializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/collection/ChildContainerSerializers.java
@@ -136,7 +136,7 @@ public class ChildContainerSerializers {
 
     @Override
     public Collection onCollectionWrite(MemoryBuffer buffer, T value) {
-      buffer.writeVarUint32(value.size());
+      buffer.writeVarUint32Small7(value.size());
       for (Serializer slotsSerializer : slotsSerializers) {
         slotsSerializer.write(buffer, value);
       }
@@ -185,7 +185,7 @@ public class ChildContainerSerializers {
 
     @Override
     public Map onMapWrite(MemoryBuffer buffer, T value) {
-      buffer.writeVarUint32(value.size());
+      buffer.writeVarUint32Small7(value.size());
       for (Serializer slotsSerializer : slotsSerializers) {
         slotsSerializer.write(buffer, value);
       }

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/collection/CollectionSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/collection/CollectionSerializer.java
@@ -36,7 +36,7 @@ public class CollectionSerializer<T extends Collection> extends AbstractCollecti
 
   @Override
   public Collection onCollectionWrite(MemoryBuffer buffer, T value) {
-    buffer.writeVarUint32(value.size());
+    buffer.writeVarUint32Small7(value.size());
     return value;
   }
 

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/collection/CollectionSerializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/collection/CollectionSerializers.java
@@ -71,7 +71,7 @@ public class CollectionSerializers {
 
     @Override
     public ArrayList newCollection(MemoryBuffer buffer) {
-      int numElements = buffer.readVarUintSmall();
+      int numElements = buffer.readVarUint32Small();
       setNumElements(numElements);
       ArrayList arrayList = new ArrayList(numElements);
       fury.getRefResolver().reference(arrayList);

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/collection/CollectionSerializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/collection/CollectionSerializers.java
@@ -71,7 +71,7 @@ public class CollectionSerializers {
 
     @Override
     public ArrayList newCollection(MemoryBuffer buffer) {
-      int numElements = buffer.readVarUint32Small14();
+      int numElements = buffer.readVarUint32Small7();
       setNumElements(numElements);
       ArrayList arrayList = new ArrayList(numElements);
       fury.getRefResolver().reference(arrayList);
@@ -126,7 +126,7 @@ public class CollectionSerializers {
 
     @Override
     public List<?> xread(MemoryBuffer buffer) {
-      int numElements = buffer.readVarUint32();
+      int numElements = buffer.readVarUint32Small7();
       Object[] arr = new Object[numElements];
       for (int i = 0; i < numElements; i++) {
         Object elem = fury.xreadRef(buffer);
@@ -148,7 +148,7 @@ public class CollectionSerializers {
 
     @Override
     public HashSet newCollection(MemoryBuffer buffer) {
-      int numElements = buffer.readVarUint32();
+      int numElements = buffer.readVarUint32Small7();
       setNumElements(numElements);
       HashSet hashSet = new HashSet(numElements);
       fury.getRefResolver().reference(hashSet);
@@ -168,7 +168,7 @@ public class CollectionSerializers {
 
     @Override
     public LinkedHashSet newCollection(MemoryBuffer buffer) {
-      int numElements = buffer.readVarUint32();
+      int numElements = buffer.readVarUint32Small7();
       setNumElements(numElements);
       LinkedHashSet hashSet = new LinkedHashSet(numElements);
       fury.getRefResolver().reference(hashSet);
@@ -200,7 +200,7 @@ public class CollectionSerializers {
     @SuppressWarnings("unchecked")
     @Override
     public T newCollection(MemoryBuffer buffer) {
-      int numElements = buffer.readVarUint32();
+      int numElements = buffer.readVarUint32Small7();
       setNumElements(numElements);
       T collection;
       Comparator comparator = (Comparator) fury.readRef(buffer);
@@ -250,7 +250,7 @@ public class CollectionSerializers {
 
     @Override
     public List<?> xread(MemoryBuffer buffer) {
-      buffer.readVarUint32();
+      buffer.readVarUint32Small7();
       return Collections.EMPTY_LIST;
     }
   }
@@ -282,7 +282,7 @@ public class CollectionSerializers {
 
     @Override
     public Set<?> xread(MemoryBuffer buffer) {
-      buffer.readVarUint32();
+      buffer.readVarUint32Small7();
       return Collections.EMPTY_SET;
     }
   }
@@ -332,7 +332,7 @@ public class CollectionSerializers {
 
     @Override
     public List<?> xread(MemoryBuffer buffer) {
-      buffer.readVarUint32();
+      buffer.readVarUint32Small7();
       return Collections.singletonList(fury.xreadRef(buffer));
     }
   }
@@ -366,7 +366,7 @@ public class CollectionSerializers {
 
     @Override
     public Set<?> xread(MemoryBuffer buffer) {
-      buffer.readVarUint32();
+      buffer.readVarUint32Small7();
       return Collections.singleton(fury.xreadRef(buffer));
     }
   }
@@ -380,7 +380,7 @@ public class CollectionSerializers {
 
     @Override
     public ConcurrentSkipListSet newCollection(MemoryBuffer buffer) {
-      int numElements = buffer.readVarUint32();
+      int numElements = buffer.readVarUint32Small7();
       setNumElements(numElements);
       Comparator comparator = (Comparator) fury.readRef(buffer);
       ConcurrentSkipListSet skipListSet = new ConcurrentSkipListSet(comparator);
@@ -397,7 +397,7 @@ public class CollectionSerializers {
 
     @Override
     public Vector newCollection(MemoryBuffer buffer) {
-      int numElements = buffer.readVarUint32();
+      int numElements = buffer.readVarUint32Small7();
       setNumElements(numElements);
       Vector<Object> vector = new Vector<>(numElements);
       fury.getRefResolver().reference(vector);
@@ -413,7 +413,7 @@ public class CollectionSerializers {
 
     @Override
     public ArrayDeque newCollection(MemoryBuffer buffer) {
-      int numElements = buffer.readVarUint32();
+      int numElements = buffer.readVarUint32Small7();
       setNumElements(numElements);
       ArrayDeque deque = new ArrayDeque(numElements);
       fury.getRefResolver().reference(deque);
@@ -453,7 +453,7 @@ public class CollectionSerializers {
       Class elemClass = fury.getClassResolver().readClassInfo(buffer).getCls();
       EnumSet object = EnumSet.noneOf(elemClass);
       Serializer elemSerializer = fury.getClassResolver().getSerializer(elemClass);
-      int length = buffer.readVarUint32();
+      int length = buffer.readVarUint32Small7();
       for (int i = 0; i < length; i++) {
         object.add(elemSerializer.read(buffer));
       }
@@ -475,7 +475,7 @@ public class CollectionSerializers {
 
     @Override
     public BitSet read(MemoryBuffer buffer) {
-      long[] values = buffer.readLongs(buffer.readVarUint32());
+      long[] values = buffer.readLongs(buffer.readVarUint32Small7());
       return BitSet.valueOf(values);
     }
   }
@@ -493,7 +493,7 @@ public class CollectionSerializers {
 
     @Override
     public PriorityQueue newCollection(MemoryBuffer buffer) {
-      int numElements = buffer.readVarUint32();
+      int numElements = buffer.readVarUint32Small7();
       setNumElements(numElements);
       Comparator comparator = (Comparator) fury.readRef(buffer);
       PriorityQueue queue = new PriorityQueue(comparator);

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/collection/CollectionSerializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/collection/CollectionSerializers.java
@@ -71,7 +71,7 @@ public class CollectionSerializers {
 
     @Override
     public ArrayList newCollection(MemoryBuffer buffer) {
-      int numElements = buffer.readVarUint32Small();
+      int numElements = buffer.readVarUint32Small14();
       setNumElements(numElements);
       ArrayList arrayList = new ArrayList(numElements);
       fury.getRefResolver().reference(arrayList);

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/collection/CollectionSerializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/collection/CollectionSerializers.java
@@ -192,7 +192,7 @@ public class CollectionSerializers {
 
     @Override
     public Collection onCollectionWrite(MemoryBuffer buffer, T value) {
-      buffer.writeVarUint32(value.size());
+      buffer.writeVarUint32Small7(value.size());
       fury.writeRef(buffer, value.comparator());
       return value;
     }
@@ -240,7 +240,7 @@ public class CollectionSerializers {
     @Override
     public void xwrite(MemoryBuffer buffer, List<?> value) {
       // write length
-      buffer.writeVarUint32(0);
+      buffer.writeVarUint32Small7(0);
     }
 
     @Override
@@ -272,7 +272,7 @@ public class CollectionSerializers {
     @Override
     public void xwrite(MemoryBuffer buffer, Set<?> value) {
       // write length
-      buffer.writeVarUint32(0);
+      buffer.writeVarUint32Small7(0);
     }
 
     @Override
@@ -321,7 +321,7 @@ public class CollectionSerializers {
 
     @Override
     public void xwrite(MemoryBuffer buffer, List<?> value) {
-      buffer.writeVarUint32(1);
+      buffer.writeVarUint32Small7(1);
       fury.xwriteRef(buffer, value.get(0));
     }
 
@@ -355,7 +355,7 @@ public class CollectionSerializers {
 
     @Override
     public void xwrite(MemoryBuffer buffer, Set<?> value) {
-      buffer.writeVarUint32(1);
+      buffer.writeVarUint32Small7(1);
       fury.xwriteRef(buffer, value.iterator().next());
     }
 
@@ -442,7 +442,7 @@ public class CollectionSerializers {
       }
       fury.getClassResolver().writeClassAndUpdateCache(buffer, elemClass);
       Serializer serializer = fury.getClassResolver().getSerializer(elemClass);
-      buffer.writeVarUint32(object.size());
+      buffer.writeVarUint32Small7(object.size());
       for (Object element : object) {
         serializer.write(buffer, element);
       }
@@ -486,7 +486,7 @@ public class CollectionSerializers {
     }
 
     public Collection onCollectionWrite(MemoryBuffer buffer, PriorityQueue value) {
-      buffer.writeVarUint32(value.size());
+      buffer.writeVarUint32Small7(value.size());
       fury.writeRef(buffer, value.comparator());
       return value;
     }

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/collection/FuryArrayAsListSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/collection/FuryArrayAsListSerializer.java
@@ -39,7 +39,7 @@ public final class FuryArrayAsListSerializer extends CollectionSerializer<ArrayA
   }
 
   public Collection newCollection(MemoryBuffer buffer) {
-    int numElements = buffer.readVarUint32();
+    int numElements = buffer.readVarUint32Small7();
     setNumElements(numElements);
     return new ArrayAsList(numElements);
   }

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/collection/GuavaCollectionSerializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/collection/GuavaCollectionSerializers.java
@@ -184,7 +184,7 @@ public class GuavaCollectionSerializers {
 
     @Override
     public Collection onCollectionWrite(MemoryBuffer buffer, T value) {
-      buffer.writeVarUint32(value.size());
+      buffer.writeVarUint32Small7(value.size());
       fury.writeRef(buffer, value.comparator());
       return value;
     }
@@ -319,7 +319,7 @@ public class GuavaCollectionSerializers {
 
     @Override
     public Map onMapWrite(MemoryBuffer buffer, T value) {
-      buffer.writeVarUint32(value.size());
+      buffer.writeVarUint32Small7(value.size());
       fury.writeRef(buffer, value.comparator());
       return value;
     }

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/collection/GuavaCollectionSerializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/collection/GuavaCollectionSerializers.java
@@ -53,7 +53,7 @@ public class GuavaCollectionSerializers {
 
     @Override
     public T xread(MemoryBuffer buffer) {
-      int size = buffer.readVarUint32();
+      int size = buffer.readVarUint32Small7();
       List list = new ArrayList<>();
       xreadElements(fury, buffer, list, size);
       return xnewInstance(list);
@@ -71,7 +71,7 @@ public class GuavaCollectionSerializers {
 
     @Override
     public Collection newCollection(MemoryBuffer buffer) {
-      int numElements = buffer.readVarUint32();
+      int numElements = buffer.readVarUint32Small7();
       setNumElements(numElements);
       return new CollectionContainer<>(numElements);
     }
@@ -122,7 +122,7 @@ public class GuavaCollectionSerializers {
 
     @Override
     public Collection newCollection(MemoryBuffer buffer) {
-      int numElements = buffer.readVarUint32();
+      int numElements = buffer.readVarUint32Small7();
       setNumElements(numElements);
       return new CollectionContainer(numElements);
     }
@@ -153,7 +153,7 @@ public class GuavaCollectionSerializers {
 
     @Override
     public Collection newCollection(MemoryBuffer buffer) {
-      int numElements = buffer.readVarUint32();
+      int numElements = buffer.readVarUint32Small7();
       setNumElements(numElements);
       return new CollectionContainer<>(numElements);
     }
@@ -191,7 +191,7 @@ public class GuavaCollectionSerializers {
 
     @Override
     public Collection newCollection(MemoryBuffer buffer) {
-      int numElements = buffer.readVarUint32();
+      int numElements = buffer.readVarUint32Small7();
       setNumElements(numElements);
       Comparator comparator = (Comparator) fury.readRef(buffer);
       return new SortedCollectionContainer(comparator, numElements);
@@ -216,7 +216,7 @@ public class GuavaCollectionSerializers {
 
     @Override
     public Map newMap(MemoryBuffer buffer) {
-      int numElements = buffer.readVarUint32();
+      int numElements = buffer.readVarUint32Small7();
       setNumElements(numElements);
       return new MapContainer(numElements);
     }
@@ -241,7 +241,7 @@ public class GuavaCollectionSerializers {
 
     @Override
     public T xread(MemoryBuffer buffer) {
-      int size = buffer.readVarUint32();
+      int size = buffer.readVarUint32Small7();
       Map map = new HashMap();
       xreadElements(fury, buffer, map, size);
       return xnewInstance(map);
@@ -326,7 +326,7 @@ public class GuavaCollectionSerializers {
 
     @Override
     public Map newMap(MemoryBuffer buffer) {
-      int numElements = buffer.readVarUint32();
+      int numElements = buffer.readVarUint32Small7();
       setNumElements(numElements);
       Comparator comparator = (Comparator) fury.readRef(buffer);
       return new SortedMapContainer<>(comparator, numElements);

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/collection/ImmutableCollectionSerializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/collection/ImmutableCollectionSerializers.java
@@ -109,7 +109,7 @@ public class ImmutableCollectionSerializers {
 
     @Override
     public Collection newCollection(MemoryBuffer buffer) {
-      int numElements = buffer.readVarUint32();
+      int numElements = buffer.readVarUint32Small7();
       setNumElements(numElements);
       if (Platform.JAVA_VERSION > 8) {
         return new CollectionContainer<>(numElements);
@@ -141,7 +141,7 @@ public class ImmutableCollectionSerializers {
 
     @Override
     public Collection newCollection(MemoryBuffer buffer) {
-      int numElements = buffer.readVarUint32();
+      int numElements = buffer.readVarUint32Small7();
       setNumElements(numElements);
       if (Platform.JAVA_VERSION > 8) {
         return new CollectionContainer<>(numElements);
@@ -173,7 +173,7 @@ public class ImmutableCollectionSerializers {
 
     @Override
     public Map newMap(MemoryBuffer buffer) {
-      int numElements = buffer.readVarUint32();
+      int numElements = buffer.readVarUint32Small7();
       setNumElements(numElements);
       if (Platform.JAVA_VERSION > 8) {
         return new JDKImmutableMapContainer(numElements);

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/collection/MapSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/collection/MapSerializer.java
@@ -36,7 +36,7 @@ public class MapSerializer<T extends Map> extends AbstractMapSerializer<T> {
 
   @Override
   public Map onMapWrite(MemoryBuffer buffer, T value) {
-    buffer.writeVarUint32(value.size());
+    buffer.writeVarUint32Small7(value.size());
     return value;
   }
 

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/collection/MapSerializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/collection/MapSerializers.java
@@ -122,7 +122,7 @@ public class MapSerializers {
 
     @Override
     public Map onMapWrite(MemoryBuffer buffer, T value) {
-      buffer.writeVarUint32(value.size());
+      buffer.writeVarUint32Small7(value.size());
       fury.writeRef(buffer, value.comparator());
       return value;
     }
@@ -164,7 +164,7 @@ public class MapSerializers {
     @Override
     public void xwrite(MemoryBuffer buffer, Map<?, ?> value) {
       // write length
-      buffer.writeVarUint32(0);
+      buffer.writeVarUint32Small7(0);
     }
 
     @Override
@@ -213,7 +213,7 @@ public class MapSerializers {
 
     @Override
     public void xwrite(MemoryBuffer buffer, Map<?, ?> value) {
-      buffer.writeVarUint32(1);
+      buffer.writeVarUint32Small7(1);
       Map.Entry entry = value.entrySet().iterator().next();
       fury.xwriteRef(buffer, entry.getKey());
       fury.xwriteRef(buffer, entry.getValue());
@@ -299,7 +299,7 @@ public class MapSerializers {
 
     @Override
     public Map onMapWrite(MemoryBuffer buffer, EnumMap value) {
-      buffer.writeVarUint32(value.size());
+      buffer.writeVarUint32Small7(value.size());
       Class keyType = (Class) Platform.getObject(value, keyTypeFieldOffset);
       fury.getClassResolver().writeClassAndUpdateCache(buffer, keyType);
       return value;
@@ -322,7 +322,7 @@ public class MapSerializers {
 
     @Override
     public void write(MemoryBuffer buffer, Map<String, T> value) {
-      buffer.writeVarUint32(value.size());
+      buffer.writeVarUint32Small7(value.size());
       for (Map.Entry<String, T> e : value.entrySet()) {
         fury.writeJavaStringRef(buffer, e.getKey());
         // If value is a collection, the `newCollection` method will record itself to

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/collection/MapSerializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/collection/MapSerializers.java
@@ -63,7 +63,7 @@ public class MapSerializers {
 
     @Override
     public HashMap newMap(MemoryBuffer buffer) {
-      int numElements = buffer.readVarUint32();
+      int numElements = buffer.readVarUint32Small7();
       setNumElements(numElements);
       HashMap hashMap = new HashMap(numElements);
       fury.getRefResolver().reference(hashMap);
@@ -83,7 +83,7 @@ public class MapSerializers {
 
     @Override
     public LinkedHashMap newMap(MemoryBuffer buffer) {
-      int numElements = buffer.readVarUint32();
+      int numElements = buffer.readVarUint32Small7();
       setNumElements(numElements);
       LinkedHashMap hashMap = new LinkedHashMap(numElements);
       fury.getRefResolver().reference(hashMap);
@@ -103,7 +103,7 @@ public class MapSerializers {
 
     @Override
     public LazyMap newMap(MemoryBuffer buffer) {
-      int numElements = buffer.readVarUint32();
+      int numElements = buffer.readVarUint32Small7();
       setNumElements(numElements);
       LazyMap map = new LazyMap(numElements);
       fury.getRefResolver().reference(map);
@@ -130,7 +130,7 @@ public class MapSerializers {
     @SuppressWarnings("unchecked")
     @Override
     public Map newMap(MemoryBuffer buffer) {
-      setNumElements(buffer.readVarUint32());
+      setNumElements(buffer.readVarUint32Small7());
       T map;
       Comparator comparator = (Comparator) fury.readRef(buffer);
       if (type == TreeMap.class) {
@@ -174,7 +174,7 @@ public class MapSerializers {
 
     @Override
     public Map<?, ?> xread(MemoryBuffer buffer) {
-      buffer.readVarUint32();
+      buffer.readVarUint32Small7();
       return Collections.EMPTY_MAP;
     }
   }
@@ -228,7 +228,7 @@ public class MapSerializers {
 
     @Override
     public Map<?, ?> xread(MemoryBuffer buffer) {
-      buffer.readVarUint32();
+      buffer.readVarUint32Small7();
       Object key = fury.xreadRef(buffer);
       Object value = fury.xreadRef(buffer);
       return Collections.singletonMap(key, value);
@@ -243,7 +243,7 @@ public class MapSerializers {
 
     @Override
     public ConcurrentHashMap newMap(MemoryBuffer buffer) {
-      int numElements = buffer.readVarUint32();
+      int numElements = buffer.readVarUint32Small7();
       setNumElements(numElements);
       ConcurrentHashMap map = new ConcurrentHashMap(numElements);
       fury.getRefResolver().reference(map);
@@ -265,7 +265,7 @@ public class MapSerializers {
 
     @Override
     public ConcurrentSkipListMap newMap(MemoryBuffer buffer) {
-      int numElements = buffer.readVarUint32();
+      int numElements = buffer.readVarUint32Small7();
       setNumElements(numElements);
       Comparator comparator = (Comparator) fury.readRef(buffer);
       ConcurrentSkipListMap map = new ConcurrentSkipListMap(comparator);
@@ -307,7 +307,7 @@ public class MapSerializers {
 
     @Override
     public EnumMap newMap(MemoryBuffer buffer) {
-      setNumElements(buffer.readVarUint32());
+      setNumElements(buffer.readVarUint32Small7());
       Class<?> keyType = fury.getClassResolver().readClassInfo(buffer).getCls();
       return new EnumMap(keyType);
     }

--- a/java/fury-core/src/main/java/org/apache/fury/type/ClassDef.java
+++ b/java/fury-core/src/main/java/org/apache/fury/type/ClassDef.java
@@ -234,7 +234,7 @@ public class ClassDef implements Serializable {
   private static String readSharedString(MemoryBuffer buffer, List<String> strings) {
     String str;
     if (buffer.readBoolean()) {
-      return strings.get(buffer.readVarUint32Small14());
+      return strings.get(buffer.readVarUint32Small7());
     } else {
       str = new String(buffer.readBytesAndSize(), StandardCharsets.UTF_8);
       strings.add(str);

--- a/java/fury-core/src/main/java/org/apache/fury/type/ClassDef.java
+++ b/java/fury-core/src/main/java/org/apache/fury/type/ClassDef.java
@@ -234,7 +234,7 @@ public class ClassDef implements Serializable {
   private static String readSharedString(MemoryBuffer buffer, List<String> strings) {
     String str;
     if (buffer.readBoolean()) {
-      return strings.get(buffer.readVarUint32Small());
+      return strings.get(buffer.readVarUint32Small14());
     } else {
       str = new String(buffer.readBytesAndSize(), StandardCharsets.UTF_8);
       strings.add(str);

--- a/java/fury-core/src/main/java/org/apache/fury/type/ClassDef.java
+++ b/java/fury-core/src/main/java/org/apache/fury/type/ClassDef.java
@@ -167,14 +167,14 @@ public class ClassDef implements Serializable {
       MemoryBuffer buf = MemoryUtils.buffer(32);
       IdentityObjectIntMap<String> map = new IdentityObjectIntMap<>(8, 0.5f);
       writeSharedString(buf, map, className);
-      buf.writeVarUint32(fieldsInfo.size());
+      buf.writeVarUint32Small7(fieldsInfo.size());
       for (FieldInfo fieldInfo : fieldsInfo) {
         writeSharedString(buf, map, fieldInfo.definedClass);
         byte[] bytes = fieldInfo.fieldName.getBytes(StandardCharsets.UTF_8);
         buf.writePrimitiveArrayWithSize(bytes, Platform.BYTE_ARRAY_OFFSET, bytes.length);
         fieldInfo.fieldType.write(buf);
       }
-      buf.writeVarUint32(extMeta.size());
+      buf.writeVarUint32Small7(extMeta.size());
       extMeta.forEach(
           (k, v) -> {
             byte[] keyBytes = k.getBytes(StandardCharsets.UTF_8);
@@ -199,7 +199,7 @@ public class ClassDef implements Serializable {
     if (id >= 0) {
       // TODO use flagged varint.
       buffer.writeBoolean(true);
-      buffer.writeVarUint32(id);
+      buffer.writeVarUint32Small7(id);
     } else {
       buffer.writeBoolean(false);
       byte[] bytes = str.getBytes(StandardCharsets.UTF_8);

--- a/java/fury-core/src/main/java/org/apache/fury/type/ClassDef.java
+++ b/java/fury-core/src/main/java/org/apache/fury/type/ClassDef.java
@@ -234,7 +234,7 @@ public class ClassDef implements Serializable {
   private static String readSharedString(MemoryBuffer buffer, List<String> strings) {
     String str;
     if (buffer.readBoolean()) {
-      return strings.get(buffer.readVarUintSmall());
+      return strings.get(buffer.readVarUint32Small());
     } else {
       str = new String(buffer.readBytesAndSize(), StandardCharsets.UTF_8);
       strings.add(str);

--- a/java/fury-core/src/main/java/org/apache/fury/type/ClassDef.java
+++ b/java/fury-core/src/main/java/org/apache/fury/type/ClassDef.java
@@ -212,13 +212,13 @@ public class ClassDef implements Serializable {
     List<String> strings = new ArrayList<>();
     String className = readSharedString(buffer, strings);
     List<FieldInfo> fieldInfos = new ArrayList<>();
-    int numFields = buffer.readVarUint32();
+    int numFields = buffer.readVarUint32Small7();
     for (int i = 0; i < numFields; i++) {
       String definedClass = readSharedString(buffer, strings);
       String fieldName = new String(buffer.readBytesAndSize(), StandardCharsets.UTF_8);
       fieldInfos.add(new FieldInfo(definedClass, fieldName, FieldType.read(buffer)));
     }
-    int extMetaSize = buffer.readVarUint32();
+    int extMetaSize = buffer.readVarUint32Small7();
     Map<String, String> extMeta = new HashMap<>();
     for (int i = 0; i < extMetaSize; i++) {
       extMeta.put(

--- a/java/fury-core/src/test/java/org/apache/fury/memory/MemoryBufferTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/memory/MemoryBufferTest.java
@@ -583,6 +583,23 @@ public class MemoryBufferTest {
   }
 
   @Test
+  public void testVarUint32Small7() {
+    MemoryBuffer buf = MemoryUtils.buffer(1);
+    buf.writeVarUint32Small7(1);
+    assertEquals(buf.readVarUint32Small7(), 1);
+    assertEquals(buf.writeVarUint32Small7(127), 1);
+    assertEquals(buf.readVarUint32Small7(), 127);
+    assertEquals(buf.writeVarUint32Small7(Short.MAX_VALUE), 3);
+    assertEquals(buf.readVarUint32Small7(), Short.MAX_VALUE);
+    assertEquals(buf.writeVarUint32Small7(Integer.MAX_VALUE), 5);
+    assertEquals(buf.readVarUint32Small7(), Integer.MAX_VALUE);
+    assertEquals(buf.writeVarUint32Small7(-1), 5);
+    assertEquals(buf.readVarUint32Small7(), -1);
+    assertEquals(buf.writeVarUint32Small7(0), 1);
+    assertEquals(buf.readVarUint32Small7(), 0);
+  }
+
+  @Test
   public void testVarUint36Small() {
     MemoryBuffer buf = MemoryUtils.buffer(80);
     int index = 0;

--- a/scala/src/main/scala/org/apache/fury/serializer/scala/CollectionSerializer.scala
+++ b/scala/src/main/scala/org/apache/fury/serializer/scala/CollectionSerializer.scala
@@ -149,7 +149,7 @@ class ScalaCollectionSerializer[A, T <: Iterable[A]] (fury: Fury, cls: Class[T])
   override def onCollectionWrite(buffer: MemoryBuffer, value: T): util.Collection[_] = {
     val factory: Factory[A, Any] = value.iterableFactory.iterableFactory
     val adapter = new CollectionAdapter[A, T](value)
-    buffer.writeVarUint32(adapter.size)
+    buffer.writeVarUint32Small7(adapter.size)
     fury.writeRef(buffer, factory)
     adapter
   }
@@ -163,7 +163,7 @@ class ScalaCollectionSerializer[A, T <: Iterable[A]] (fury: Fury, cls: Class[T])
 class ScalaSortedSetSerializer[A, T <: scala.collection.SortedSet[A]](fury: Fury, cls: Class[T])
   extends AbstractScalaCollectionSerializer[A, T](fury, cls) {
   override def onCollectionWrite(buffer: MemoryBuffer, value: T): util.Collection[_] = {
-    buffer.writeVarUint32(value.size)
+    buffer.writeVarUint32Small7(value.size)
     val factory = value.sortedIterableFactory.evidenceIterableFactory[Any](
       value.ordering.asInstanceOf[Ordering[Any]])
     fury.writeRef(buffer, factory)
@@ -179,7 +179,7 @@ class ScalaSortedSetSerializer[A, T <: scala.collection.SortedSet[A]](fury: Fury
 class ScalaSeqSerializer[A, T <: scala.collection.Seq[A]](fury: Fury, cls: Class[T])
   extends AbstractScalaCollectionSerializer[A, T](fury, cls)  {
   override def onCollectionWrite(buffer: MemoryBuffer, value: T): util.Collection[_] = {
-    buffer.writeVarUint32(value.size)
+    buffer.writeVarUint32Small7(value.size)
     val factory: Factory[A, Any] = value.iterableFactory.iterableFactory
     fury.writeRef(buffer, factory)
     new ListAdapter[Any](value)

--- a/scala/src/main/scala/org/apache/fury/serializer/scala/MapSerializer.scala
+++ b/scala/src/main/scala/org/apache/fury/serializer/scala/MapSerializer.scala
@@ -116,7 +116,7 @@ class ScalaMapSerializer[K, V, T <: scala.collection.Map[K, V]](fury: Fury, cls:
   extends AbstractScalaMapSerializer[K, V, T](fury, cls) {
 
   override def onMapWrite(buffer: MemoryBuffer, value: T): util.Map[_, _] = {
-    buffer.writeVarUint32(value.size)
+    buffer.writeVarUint32Small7(value.size)
     val factory = value.mapFactory.mapFactory[Any, Any].asInstanceOf[Factory[Any, Any]]
     fury.writeRef(buffer, factory)
     new MapAdapter[K, V](value)
@@ -131,7 +131,7 @@ class ScalaMapSerializer[K, V, T <: scala.collection.Map[K, V]](fury: Fury, cls:
 class ScalaSortedMapSerializer[K, V, T <: scala.collection.SortedMap[K, V]](fury: Fury, cls: Class[T])
   extends AbstractScalaMapSerializer[K, V, T](fury, cls) {
   override def onMapWrite(buffer: MemoryBuffer, value: T): util.Map[_, _] = {
-    buffer.writeVarUint32(value.size)
+    buffer.writeVarUint32Small7(value.size)
     val factory = value.sortedMapFactory.sortedMapFactory[Any, Any](
       value.ordering.asInstanceOf[Ordering[Any]]).asInstanceOf[Factory[Any, Any]]
     fury.writeRef(buffer, factory)


### PR DESCRIPTION
## What does this PR do?
This PR add fastpath for read/write small varint in range `[0,127]`.

This PR also fix wrong log level setting in #1492
<!-- Describe the purpose of this PR. -->


## Related issues

<!--
Is there any related issue? Please attach here.

- #xxxx0
- #xxxx1
- #xxxx2
-->


## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/incubator-fury/issues/new/choose) describing the need to do so and update the document if necessary.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?


## Benchmark
With this PR:
![image](https://github.com/apache/incubator-fury/assets/12445254/7ed6f885-9547-414a-a5c4-fd4e77487248)

Before this PR:
![image](https://github.com/apache/incubator-fury/assets/12445254/08a39519-cb0d-4992-8faf-8957842e8473)


<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.
-->
