### PR TITLE
chore(java): inline isDeclType in codegen

### DIFF
--- a/java/fury-core/src/main/java/org/apache/fury/builder/BaseObjectCodecBuilder.java
+++ b/java/fury-core/src/main/java/org/apache/fury/builder/BaseObjectCodecBuilder.java
@@ -742,8 +742,7 @@ public abstract class BaseObjectCodecBuilder extends CodecBuilder {
       builder.add(sameElementClass);
       //  if ((flags & Flags.NOT_DECL_ELEMENT_TYPE) == Flags.NOT_DECL_ELEMENT_TYPE)
       Literal notDeclTypeFlag = Literal.ofInt(CollectionFlags.NOT_DECL_ELEMENT_TYPE);
-      Expression isDeclType =
-          neq(new BitAnd(flags, notDeclTypeFlag), notDeclTypeFlag, "isDeclType");
+      Expression isDeclType = neq(new BitAnd(flags, notDeclTypeFlag), notDeclTypeFlag);
       Expression elemSerializer; // make it in scope of `if(sameElementClass)`
       boolean maybeDecl = visitFury(f -> f.getClassResolver().isSerializable(elemClass));
       TypeToken<?> serializerType = getSerializerType(elementType);
@@ -1256,8 +1255,7 @@ public abstract class BaseObjectCodecBuilder extends CodecBuilder {
           neq(new BitAnd(flags, notSameTypeFlag), notSameTypeFlag, "sameElementClass");
       //  if ((flags & Flags.NOT_DECL_ELEMENT_TYPE) == Flags.NOT_DECL_ELEMENT_TYPE)
       Literal notDeclTypeFlag = Literal.ofInt(CollectionFlags.NOT_DECL_ELEMENT_TYPE);
-      Expression isDeclType =
-          neq(new BitAnd(flags, notDeclTypeFlag), notDeclTypeFlag, "isDeclType");
+      Expression isDeclType = neq(new BitAnd(flags, notDeclTypeFlag), notDeclTypeFlag);
       Invoke serializer =
           inlineInvoke(readClassInfo(elemClass, buffer), "getSerializer", SERIALIZER_TYPE);
       TypeToken<?> serializerType = getSerializerType(elementType);


### PR DESCRIPTION
<!--
**Thanks for contributing to Fury.**

**If this is your first time opening a PR on fury, you can refer to [CONTRIBUTING.md](https://github.com/apache/incubator-fury/blob/main/CONTRIBUTING.md).**

Contribution Checklist

    - The **Apache Fury (incubating)** community has restrictions on the naming of pr titles. You can also find instructions in [CONTRIBUTING.md](https://github.com/apache/incubator-fury/blob/main/CONTRIBUTING.md).

    - Fury has a strong focus on performance. If the PR you submit will have an impact on performance, please benchmark it first and provide the benchmark result here.
-->

## What does this PR do?
THis pr inline  isDeclType in codegen


before this pr:
```java
      boolean isDeclType0 = (value14 & 4) != 4;
      Serializer serializer2;
      if (isDeclType0) {
          serializer2 = serializer0;
      } else {
          serializer2 = classResolver.readClassInfo(memoryBuffer6, imageClassInfoHolder).getSerializer();
      }
```

with this pr:
```
      Serializer serializer2;
      if ( (value14 & 4) != 4) {
          serializer2 = serializer0;
      } else {
          serializer2 = classResolver.readClassInfo(memoryBuffer6, imageClassInfoHolder).getSerializer();
      }
```
<!-- Describe the purpose of this PR. -->


## Related issues

<!--
Is there any related issue? Please attach here.

- #xxxx0
- #xxxx1
- #xxxx2
-->


## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/incubator-fury/issues/new/choose) describing the need to do so and update the document if necessary.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?


## Benchmark

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.
-->
