### PR TITLE
feat(java/python/golang): concat meta string len with flags

### DIFF
--- a/java/fury-core/src/main/java/org/apache/fury/memory/MemoryBuffer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/memory/MemoryBuffer.java
@@ -397,12 +397,6 @@ public final class MemoryBuffer {
     UNSAFE.putByte(heapMemory, pos, b);
   }
 
-  // CHECKSTYLE.OFF:MethodName
-  public void _unsafePutByte(int index, byte b) {
-    // CHECKSTYLE.ON:MethodName
-    UNSAFE.putByte(heapMemory, address + index, b);
-  }
-
   public boolean getBoolean(int index) {
     final long pos = address + index;
     checkPosition(index, pos, 1);
@@ -443,15 +437,6 @@ public final class MemoryBuffer {
       value = Short.reverseBytes(value);
     }
     UNSAFE.putShort(heapMemory, pos, value);
-  }
-
-  // CHECKSTYLE.OFF:MethodName
-  public void _unsafePutInt16(int index, short value) {
-    // CHECKSTYLE.ON:MethodName
-    if (!LITTLE_ENDIAN) {
-      value = Short.reverseBytes(value);
-    }
-    UNSAFE.putShort(heapMemory, address + index, value);
   }
 
   public int getInt32(int index) {
@@ -510,7 +495,7 @@ public final class MemoryBuffer {
   }
 
   // CHECKSTYLE.OFF:MethodName
-  public void _unsafePutInt64(int index, long value) {
+  private void _unsafePutInt64(int index, long value) {
     // CHECKSTYLE.ON:MethodName
     if (!LITTLE_ENDIAN) {
       value = Long.reverseBytes(value);

--- a/java/fury-core/src/main/java/org/apache/fury/resolver/MetaStringResolver.java
+++ b/java/fury-core/src/main/java/org/apache/fury/resolver/MetaStringResolver.java
@@ -80,7 +80,6 @@ public final class MetaStringResolver {
 
   public void writeMetaStringBytes(MemoryBuffer buffer, MetaStringBytes byteString) {
     short id = byteString.dynamicWriteStringId;
-    int writerIndex = buffer.writerIndex();
     if (id == MetaStringBytes.DEFAULT_DYNAMIC_WRITE_STRING_ID) {
       id = dynamicWriteStringId++;
       byteString.dynamicWriteStringId = id;
@@ -93,7 +92,7 @@ public final class MetaStringResolver {
       buffer.writeInt64(byteString.hashCode);
       buffer.writeBytes(byteString.bytes);
     } else {
-      buffer.writeVarUint32Small7(((writerIndex + 1) << 1) | 1);
+      buffer.writeVarUint32Small7(((id + 1) << 1) | 1);
     }
   }
 

--- a/java/fury-core/src/main/java/org/apache/fury/resolver/MetaStringResolver.java
+++ b/java/fury-core/src/main/java/org/apache/fury/resolver/MetaStringResolver.java
@@ -86,67 +86,65 @@ public final class MetaStringResolver {
       byteString.dynamicWriteStringId = id;
       MetaStringBytes[] dynamicWrittenMetaString = this.dynamicWrittenString;
       if (dynamicWrittenMetaString.length <= id) {
-        MetaStringBytes[] tmp = new MetaStringBytes[id * 2];
-        System.arraycopy(dynamicWrittenMetaString, 0, tmp, 0, dynamicWrittenMetaString.length);
-        dynamicWrittenMetaString = tmp;
-        this.dynamicWrittenString = tmp;
+        dynamicWrittenMetaString = growWrite(id);
       }
       dynamicWrittenMetaString[id] = byteString;
-      int bytesLen = byteString.bytes.length;
-      buffer.increaseWriterIndex(11 + bytesLen);
-      buffer._unsafePutByte(writerIndex, USE_STRING_VALUE);
-      // Since duplicate enum string writing are avoided by dynamic id,
-      // use 8-byte hash won't increase too much space.
-      buffer._unsafePutInt64(writerIndex + 1, byteString.hashCode);
-      buffer._unsafePutInt16(writerIndex + 9, (short) bytesLen);
-      buffer.put(writerIndex + 11, byteString.bytes, 0, bytesLen);
+      buffer.writeVarUint32Small7(byteString.bytes.length << 1);
+      buffer.writeInt64(byteString.hashCode);
+      buffer.writeBytes(byteString.bytes);
     } else {
-      buffer.increaseWriterIndex(3);
-      buffer._unsafePutByte(writerIndex, USE_STRING_ID);
-      buffer._unsafePutInt16(writerIndex + 1, id);
+      buffer.writeVarUint32Small7(((writerIndex + 1) << 1) | 1);
     }
   }
 
+  private MetaStringBytes[] growWrite(int id) {
+    MetaStringBytes[] tmp = new MetaStringBytes[id * 2];
+    System.arraycopy(dynamicWrittenString, 0, tmp, 0, dynamicWrittenString.length);
+    return this.dynamicWrittenString = tmp;
+  }
+
   MetaStringBytes readMetaStringBytes(MemoryBuffer buffer) {
-    if (buffer.readByte() == USE_STRING_VALUE) {
+    int header = buffer.readVarUint32Small7();
+    int len = header >>> 1;
+    if ((header & 0b1) == 0) {
       long hashCode = buffer.readInt64();
-      MetaStringBytes byteString = trySkipMetaStringBytes(buffer, hashCode);
+      MetaStringBytes byteString = trySkipMetaStringBytes(buffer, len, hashCode);
       updateDynamicString(byteString);
       return byteString;
     } else {
-      return dynamicReadStringIds[buffer.readInt16()];
+      return dynamicReadStringIds[len - 1];
     }
   }
 
   MetaStringBytes readMetaStringBytes(MemoryBuffer buffer, MetaStringBytes cache) {
-    if (buffer.readByte() == USE_STRING_VALUE) {
+    int header = buffer.readVarUint32Small7();
+    int len = header >>> 1;
+    if ((header & 0b1) == 0) {
       long hashCode = buffer.readInt64();
       if (cache.hashCode == hashCode) {
         // skip byteString data
-        buffer.increaseReaderIndex(2 + cache.bytes.length);
+        buffer.increaseReaderIndex(len);
         updateDynamicString(cache);
         return cache;
       } else {
-        MetaStringBytes byteString = trySkipMetaStringBytes(buffer, hashCode);
+        MetaStringBytes byteString = trySkipMetaStringBytes(buffer, len, hashCode);
         updateDynamicString(byteString);
         return byteString;
       }
     } else {
-      return dynamicReadStringIds[buffer.readInt16()];
+      return dynamicReadStringIds[len - 1];
     }
   }
 
   /** Read enum string by try to reuse previous read {@link MetaStringBytes} object. */
-  private MetaStringBytes trySkipMetaStringBytes(MemoryBuffer buffer, long hashCode) {
+  private MetaStringBytes trySkipMetaStringBytes(MemoryBuffer buffer, int len, long hashCode) {
     MetaStringBytes byteString = hash2MetaStringBytesMap.get(hashCode);
     if (byteString == null) {
-      int strBytesLength = buffer.readInt16();
-      byte[] strBytes = buffer.readBytes(strBytesLength);
-      byteString = new MetaStringBytes(strBytes, hashCode);
+      byteString = new MetaStringBytes(buffer.readBytes(len), hashCode);
       hash2MetaStringBytesMap.put(hashCode, byteString);
     } else {
       // skip byteString data
-      buffer.increaseReaderIndex(2 + byteString.bytes.length);
+      buffer.increaseReaderIndex(len);
     }
     return byteString;
   }
@@ -155,12 +153,15 @@ public final class MetaStringResolver {
     short currentDynamicReadId = dynamicReadStringId++;
     MetaStringBytes[] dynamicReadStringIds = this.dynamicReadStringIds;
     if (dynamicReadStringIds.length <= currentDynamicReadId) {
-      MetaStringBytes[] tmp = new MetaStringBytes[currentDynamicReadId * 2];
-      System.arraycopy(dynamicReadStringIds, 0, tmp, 0, dynamicReadStringIds.length);
-      dynamicReadStringIds = tmp;
-      this.dynamicReadStringIds = tmp;
+      dynamicReadStringIds = growRead(currentDynamicReadId);
     }
     dynamicReadStringIds[currentDynamicReadId] = byteString;
+  }
+
+  private MetaStringBytes[] growRead(int id) {
+    MetaStringBytes[] tmp = new MetaStringBytes[id * 2];
+    System.arraycopy(dynamicReadStringIds, 0, tmp, 0, dynamicReadStringIds.length);
+    return this.dynamicReadStringIds = tmp;
   }
 
   public void reset() {

--- a/java/fury-core/src/test/java/org/apache/fury/FuryTestBase.java
+++ b/java/fury-core/src/test/java/org/apache/fury/FuryTestBase.java
@@ -32,6 +32,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.apache.fury.config.CompatibleMode;
+import org.apache.fury.config.FuryBuilder;
 import org.apache.fury.config.Language;
 import org.apache.fury.io.ClassLoaderObjectInputStream;
 import org.apache.fury.memory.MemoryBuffer;
@@ -51,6 +52,10 @@ public abstract class FuryTestBase {
 
   public static Fury getJavaFury() {
     return javaFuryLocal.get();
+  }
+
+  public static FuryBuilder builder() {
+    return Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(false);
   }
 
   @DataProvider

--- a/java/fury-core/src/test/java/org/apache/fury/memory/MemoryBufferTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/memory/MemoryBufferTest.java
@@ -109,9 +109,9 @@ public class MemoryBufferTest {
     {
       MemoryBuffer buffer = MemoryUtils.buffer(1024);
       int index = 0;
-      buffer._unsafePutByte(index, Byte.MIN_VALUE);
+      buffer.putByte(index, Byte.MIN_VALUE);
       index += 1;
-      buffer._unsafePutInt16(index, Short.MAX_VALUE);
+      buffer.putInt16(index, Short.MAX_VALUE);
       index += 2;
       buffer.putInt32(index, Integer.MIN_VALUE);
       index += 4;

--- a/java/fury-core/src/test/java/org/apache/fury/memory/MemoryBufferTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/memory/MemoryBufferTest.java
@@ -115,7 +115,7 @@ public class MemoryBufferTest {
       index += 2;
       buffer.putInt32(index, Integer.MIN_VALUE);
       index += 4;
-      buffer._unsafePutInt64(index, Long.MAX_VALUE);
+      buffer.putInt64(index, Long.MAX_VALUE);
       index += 8;
       buffer.putFloat64(index, -1);
       index += 8;

--- a/java/fury-core/src/test/java/org/apache/fury/resolver/ClassResolverTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/resolver/ClassResolverTest.java
@@ -178,6 +178,13 @@ public class ClassResolverTest extends FuryTestBase {
 
   interface Interface2 {}
 
+  @Test
+  public void testSerializeClassesShared() {
+    Fury fury = builder().build();
+    serDeCheck(fury, Foo.class);
+    serDeCheck(fury, Arrays.asList(Foo.class, Foo.class));
+  }
+
   @Test(dataProvider = "referenceTrackingConfig")
   public void testSerializeClasses(boolean referenceTracking) {
     Fury fury =

--- a/java/fury-core/src/test/java/org/apache/fury/resolver/ClassResolverTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/resolver/ClassResolverTest.java
@@ -221,7 +221,7 @@ public class ClassResolverTest extends FuryTestBase {
       classResolver.writeClassInternal(buffer, getClass());
       int writerIndex = buffer.writerIndex();
       classResolver.writeClassInternal(buffer, getClass());
-      Assert.assertEquals(buffer.writerIndex(), writerIndex + 7);
+      Assert.assertEquals(buffer.writerIndex(), writerIndex + 3);
       buffer.writerIndex(0);
     }
     {

--- a/java/fury-core/src/test/java/org/apache/fury/serializer/UnexistedClassSerializersTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/serializer/UnexistedClassSerializersTest.java
@@ -60,7 +60,7 @@ public class UnexistedClassSerializersTest extends FuryTestBase {
         .toArray(Object[][]::new);
   }
 
-  private FuryBuilder builder() {
+  private FuryBuilder furyBuilder() {
     return Fury.builder()
         .withLanguage(Language.JAVA)
         .withCompatibleMode(CompatibleMode.COMPATIBLE)
@@ -72,7 +72,7 @@ public class UnexistedClassSerializersTest extends FuryTestBase {
   public void testSkipUnexisted(
       boolean referenceTracking, boolean enableCodegen1, boolean enableCodegen2) {
     Fury fury =
-        builder()
+        furyBuilder()
             .withRefTracking(referenceTracking)
             .withCodegen(enableCodegen1)
             .withCompatibleMode(CompatibleMode.COMPATIBLE)
@@ -86,7 +86,7 @@ public class UnexistedClassSerializersTest extends FuryTestBase {
       Object pojo = Struct.createPOJO(structClass);
       byte[] bytes = fury.serialize(pojo);
       Fury fury2 =
-          builder()
+          furyBuilder()
               .withRefTracking(referenceTracking)
               .withCodegen(enableCodegen2)
               .withClassLoader(classLoader)
@@ -103,7 +103,7 @@ public class UnexistedClassSerializersTest extends FuryTestBase {
       boolean enableCodegen2,
       boolean enableCodegen3) {
     Fury fury =
-        builder()
+        furyBuilder()
             .withRefTracking(referenceTracking)
             .withCodegen(enableCodegen1)
             .withMetaContextShare(true)
@@ -119,7 +119,7 @@ public class UnexistedClassSerializersTest extends FuryTestBase {
       fury.getSerializationContext().setMetaContext(context1);
       byte[] bytes = fury.serialize(pojo);
       Fury fury2 =
-          builder()
+          furyBuilder()
               .withRefTracking(referenceTracking)
               .withCodegen(enableCodegen2)
               .withMetaContextShare(true)
@@ -132,7 +132,7 @@ public class UnexistedClassSerializersTest extends FuryTestBase {
       fury2.getSerializationContext().setMetaContext(context2);
       byte[] bytes2 = fury2.serialize(o2);
       Fury fury3 =
-          builder()
+          furyBuilder()
               .withRefTracking(referenceTracking)
               .withCodegen(enableCodegen3)
               .withMetaContextShare(true)
@@ -153,7 +153,7 @@ public class UnexistedClassSerializersTest extends FuryTestBase {
       boolean enableCodegen2,
       boolean enableCodegen3) {
     Fury fury =
-        builder()
+        furyBuilder()
             .withRefTracking(referenceTracking)
             .withCodegen(enableCodegen1)
             .withMetaContextShare(true)
@@ -168,14 +168,14 @@ public class UnexistedClassSerializersTest extends FuryTestBase {
           Struct.createStructClass("TestSkipUnexistedClass3", 2)
         }) {
       Fury fury2 =
-          builder()
+          furyBuilder()
               .withRefTracking(referenceTracking)
               .withCodegen(enableCodegen2)
               .withMetaContextShare(true)
               .withClassLoader(classLoader)
               .build();
       Fury fury3 =
-          builder()
+          furyBuilder()
               .withRefTracking(referenceTracking)
               .withCodegen(enableCodegen3)
               .withMetaContextShare(true)
@@ -202,12 +202,12 @@ public class UnexistedClassSerializersTest extends FuryTestBase {
 
   @Test
   public void testThrowExceptionIfClassNotExist() {
-    Fury fury = builder().withDeserializeUnexistedClass(false).build();
+    Fury fury = furyBuilder().withDeserializeUnexistedClass(false).build();
     ClassLoader classLoader = getClass().getClassLoader();
     Class<?> structClass = Struct.createNumberStructClass("TestSkipUnexistedClass1", 2);
     Object pojo = Struct.createPOJO(structClass);
     Fury fury2 =
-        builder().withDeserializeUnexistedClass(false).withClassLoader(classLoader).build();
+        furyBuilder().withDeserializeUnexistedClass(false).withClassLoader(classLoader).build();
     byte[] bytes = fury.serialize(pojo);
     Assert.assertThrows(RuntimeException.class, () -> fury2.deserialize(bytes));
   }

--- a/python/pyfury/_fury.py
+++ b/python/pyfury/_fury.py
@@ -766,15 +766,15 @@ class Fury:
     def serialize_nonref(self, buffer, obj):
         cls = type(obj)
         if cls is str:
-            buffer.write_int16(STRING_CLASS_ID)
+            buffer.write_varint32(STRING_CLASS_ID << 1)
             buffer.write_string(obj)
             return
         elif cls is int:
-            buffer.write_int16(PYINT_CLASS_ID)
+            buffer.write_varint32(PYINT_CLASS_ID << 1)
             buffer.write_varint64(obj)
             return
         elif cls is bool:
-            buffer.write_int16(PYBOOL_CLASS_ID)
+            buffer.write_varint32(PYBOOL_CLASS_ID << 1)
             buffer.write_bool(obj)
             return
         else:

--- a/python/pyfury/_fury.py
+++ b/python/pyfury/_fury.py
@@ -48,8 +48,6 @@ from pyfury._serializer import (
     PYBOOL_CLASS_ID,
     STRING_CLASS_ID,
     PICKLE_CLASS_ID,
-    USE_CLASSNAME,
-    USE_CLASS_ID,
     NOT_NULL_STRING_FLAG,
     NOT_NULL_PYINT_FLAG,
     NOT_NULL_PYBOOL_FLAG,
@@ -747,15 +745,15 @@ class Fury:
     def serialize_ref(self, buffer, obj, classinfo=None):
         cls = type(obj)
         if cls is str:
-            buffer.write_int24(NOT_NULL_STRING_FLAG)
+            buffer.write_int16(NOT_NULL_STRING_FLAG)
             buffer.write_string(obj)
             return
         elif cls is int:
-            buffer.write_int24(NOT_NULL_PYINT_FLAG)
+            buffer.write_int16(NOT_NULL_PYINT_FLAG)
             buffer.write_varint64(obj)
             return
         elif cls is bool:
-            buffer.write_int24(NOT_NULL_PYBOOL_FLAG)
+            buffer.write_int16(NOT_NULL_PYBOOL_FLAG)
             buffer.write_bool(obj)
             return
         if self.ref_resolver.write_ref_or_null(buffer, obj):

--- a/python/pyfury/_serialization.pyx
+++ b/python/pyfury/_serialization.pyx
@@ -947,19 +947,19 @@ cdef class Fury:
             self, Buffer buffer, obj, ClassInfo classinfo=None):
         cls = type(obj)
         if cls is str:
-            buffer.write_varint32(NOT_NULL_STRING_FLAG << 1)
+            buffer.write_int16(NOT_NULL_STRING_FLAG)
             buffer.write_string(obj)
             return
         elif cls is int:
-            buffer.write_varint32(NOT_NULL_PYINT_FLAG << 1)
+            buffer.write_int16(NOT_NULL_PYINT_FLAG)
             buffer.write_varint64(obj)
             return
         elif cls is bool:
-            buffer.write_varint32(NOT_NULL_PYBOOL_FLAG << 1)
+            buffer.write_int16(NOT_NULL_PYBOOL_FLAG)
             buffer.write_bool(obj)
             return
         elif cls is float:
-            buffer.write_varint32(NOT_NULL_PYFLOAT_FLAG << 1)
+            buffer.write_int16(NOT_NULL_PYFLOAT_FLAG)
             buffer.write_double(obj)
             return
         if self.ref_resolver.write_ref_or_null(buffer, obj):

--- a/python/pyfury/_serialization.pyx
+++ b/python/pyfury/_serialization.pyx
@@ -2240,7 +2240,7 @@ cdef class SliceSerializer(Serializer):
             if step is None:
                 buffer.write_int8(NULL_FLAG)
             else:
-                buffer.write_int16(NOT_NULL_VALUE_FLAG)
+                buffer.write_int8(NOT_NULL_VALUE_FLAG)
                 self.fury.serialize_nonref(buffer, step)
 
     cpdef inline read(self, Buffer buffer):

--- a/python/pyfury/_serialization.pyx
+++ b/python/pyfury/_serialization.pyx
@@ -947,19 +947,19 @@ cdef class Fury:
             self, Buffer buffer, obj, ClassInfo classinfo=None):
         cls = type(obj)
         if cls is str:
-            buffer.write_int16(NOT_NULL_STRING_FLAG)
+            buffer.write_varint32(NOT_NULL_STRING_FLAG << 1)
             buffer.write_string(obj)
             return
         elif cls is int:
-            buffer.write_int16(NOT_NULL_PYINT_FLAG)
+            buffer.write_varint32(NOT_NULL_PYINT_FLAG << 1)
             buffer.write_varint64(obj)
             return
         elif cls is bool:
-            buffer.write_int16(NOT_NULL_PYBOOL_FLAG)
+            buffer.write_varint32(NOT_NULL_PYBOOL_FLAG << 1)
             buffer.write_bool(obj)
             return
         elif cls is float:
-            buffer.write_int16(NOT_NULL_PYFLOAT_FLAG)
+            buffer.write_varint32(NOT_NULL_PYFLOAT_FLAG << 1)
             buffer.write_double(obj)
             return
         if self.ref_resolver.write_ref_or_null(buffer, obj):

--- a/python/pyfury/_serialization.pyx
+++ b/python/pyfury/_serialization.pyx
@@ -972,19 +972,19 @@ cdef class Fury:
     cpdef inline serialize_nonref(self, Buffer buffer, obj):
         cls = type(obj)
         if cls is str:
-            buffer.write_int16(STRING_CLASS_ID)
+            buffer.write_varint32(STRING_CLASS_ID << 1)
             buffer.write_string(obj)
             return
         elif cls is int:
-            buffer.write_int16(PYINT_CLASS_ID)
+            buffer.write_varint32(PYINT_CLASS_ID << 1)
             buffer.write_varint64(obj)
             return
         elif cls is bool:
-            buffer.write_int16(PYBOOL_CLASS_ID)
+            buffer.write_varint32(PYBOOL_CLASS_ID << 1)
             buffer.write_bool(obj)
             return
         elif cls is float:
-            buffer.write_int16(PYFLOAT_CLASS_ID)
+            buffer.write_varint32(PYFLOAT_CLASS_ID << 1)
             buffer.write_double(obj)
             return
         cdef ClassInfo classinfo = self.class_resolver.get_or_create_classinfo(cls)

--- a/python/pyfury/_serialization.pyx
+++ b/python/pyfury/_serialization.pyx
@@ -1606,16 +1606,16 @@ cdef class CollectionSerializer(Serializer):
         for s in value:
             cls = type(s)
             if cls is str:
-                buffer.write_int8(NOT_NULL_STRING_FLAG)
+                buffer.write_int16(NOT_NULL_STRING_FLAG)
                 buffer.write_string(s)
             elif cls is int:
-                buffer.write_int8(NOT_NULL_PYINT_FLAG)
+                buffer.write_int16(NOT_NULL_PYINT_FLAG)
                 buffer.write_varint64(s)
             elif cls is bool:
-                buffer.write_int8(NOT_NULL_PYBOOL_FLAG)
+                buffer.write_int16(NOT_NULL_PYBOOL_FLAG)
                 buffer.write_bool(s)
             elif cls is float:
-                buffer.write_int8(NOT_NULL_PYFLOAT_FLAG)
+                buffer.write_int16(NOT_NULL_PYFLOAT_FLAG)
                 buffer.write_double(s)
             else:
                 if not ref_resolver.write_ref_or_null(buffer, s):
@@ -1793,7 +1793,7 @@ cdef class MapSerializer(Serializer):
         for k, v in value.items():
             key_cls = type(k)
             if key_cls is str:
-                buffer.write_int8(NOT_NULL_STRING_FLAG)
+                buffer.write_int16(NOT_NULL_STRING_FLAG)
                 buffer.write_string(k)
             else:
                 if not self.ref_resolver.write_ref_or_null(buffer, k):
@@ -1802,10 +1802,10 @@ cdef class MapSerializer(Serializer):
                     key_classinfo.serializer.write(buffer, k)
             value_cls = type(v)
             if value_cls is str:
-                buffer.write_int8(NOT_NULL_STRING_FLAG)
+                buffer.write_int16(NOT_NULL_STRING_FLAG)
                 buffer.write_string(v)
             elif value_cls is int:
-                buffer.write_int8(NOT_NULL_PYINT_FLAG)
+                buffer.write_int16(NOT_NULL_PYINT_FLAG)
                 buffer.write_varint64(v)
             elif value_cls is bool:
                 buffer.write_int16(NOT_NULL_PYBOOL_FLAG)
@@ -2240,7 +2240,7 @@ cdef class SliceSerializer(Serializer):
             if step is None:
                 buffer.write_int8(NULL_FLAG)
             else:
-                buffer.write_int8(NOT_NULL_VALUE_FLAG)
+                buffer.write_int16(NOT_NULL_VALUE_FLAG)
                 self.fury.serialize_nonref(buffer, step)
 
     cpdef inline read(self, Buffer buffer):

--- a/python/pyfury/serializer.py
+++ b/python/pyfury/serializer.py
@@ -216,7 +216,7 @@ class PandasRangeIndexSerializer(Serializer):
         stop = value.stop
         step = value.step
         if type(start) is int:
-            buffer.write_int24(NOT_NULL_PYINT_FLAG)
+            buffer.write_int16(NOT_NULL_PYINT_FLAG)
             buffer.write_varint64(start)
         else:
             if start is None:
@@ -225,7 +225,7 @@ class PandasRangeIndexSerializer(Serializer):
                 buffer.write_int8(NOT_NULL_VALUE_FLAG)
                 fury.serialize_nonref(buffer, start)
         if type(stop) is int:
-            buffer.write_int24(NOT_NULL_PYINT_FLAG)
+            buffer.write_int16(NOT_NULL_PYINT_FLAG)
             buffer.write_varint64(stop)
         else:
             if stop is None:
@@ -234,7 +234,7 @@ class PandasRangeIndexSerializer(Serializer):
                 buffer.write_int8(NOT_NULL_VALUE_FLAG)
                 fury.serialize_nonref(buffer, stop)
         if type(step) is int:
-            buffer.write_int24(NOT_NULL_PYINT_FLAG)
+            buffer.write_int16(NOT_NULL_PYINT_FLAG)
             buffer.write_varint64(step)
         else:
             if step is None:

--- a/python/pyfury/tests/test_serializer.py
+++ b/python/pyfury/tests/test_serializer.py
@@ -432,7 +432,9 @@ def test_unsupported_callback():
 
 def test_slice():
     fury = Fury(language=Language.PYTHON, ref_tracking=True)
-    assert fury.deserialize(fury.serialize(slice(1, None, "10"))) == slice(1, None, "10")
+    assert fury.deserialize(fury.serialize(slice(1, None, "10"))) == slice(
+        1, None, "10"
+    )
     assert fury.deserialize(fury.serialize(slice(1, 100, 10))) == slice(1, 100, 10)
     assert fury.deserialize(fury.serialize(slice(1, None, 10))) == slice(1, None, 10)
     assert fury.deserialize(fury.serialize(slice(10, 10, None))) == slice(10, 10, None)

--- a/python/pyfury/tests/test_serializer.py
+++ b/python/pyfury/tests/test_serializer.py
@@ -432,6 +432,7 @@ def test_unsupported_callback():
 
 def test_slice():
     fury = Fury(language=Language.PYTHON, ref_tracking=True)
+    assert fury.deserialize(fury.serialize(slice(1, None, "10"))) == slice(1, None, "10")
     assert fury.deserialize(fury.serialize(slice(1, 100, 10))) == slice(1, 100, 10)
     assert fury.deserialize(fury.serialize(slice(1, None, 10))) == slice(1, None, 10)
     assert fury.deserialize(fury.serialize(slice(10, 10, None))) == slice(10, 10, None)


### PR DESCRIPTION
## What does this PR do?
This PR concats meta string len with flags and use varint encoding to encode such info, which can reduce 2 bytes for every meta string at most times.

This PPR reduced serialized size a little: 415 bytes -> 407 bytes when class is not registered in java
```
Before this PR:
Fury | MEDIA_CONTENT | false | array | 415 |

With this PR:
Fury | MEDIA_CONTENT | false | array | 407 |
```


## Related issues

Closes #1518 
Closes #1519 
Closes #1520
Closes #1521

## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/incubator-fury/issues/new/choose) describing the need to do so and update the document if necessary.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?


## Benchmark

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.
-->
