### PR TITLE
refactor(java): Detach MemoryBuffer from Fury

### DIFF
--- a/java/fury-core/src/main/java/org/apache/fury/memory/MemoryBufferManager.java
+++ b/java/fury-core/src/main/java/org/apache/fury/memory/MemoryBufferManager.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fury.memory;
+
+import java.util.function.Function;
+
+/** A class that manages MemoryBuffer for Fury. */
+public class MemoryBufferManager {
+  private static final int BUFFER_SIZE_LIMIT = 128 * 1024;
+  private static final int INITIAL_SIZE = 64;
+  private MemoryBuffer buffer;
+
+  public <R> R execute(Function<MemoryBuffer, R> action) {
+    try {
+      MemoryBuffer buf = getBuffer();
+      return action.apply(buf);
+    } finally {
+      resetBuffer();
+    }
+  }
+
+  private MemoryBuffer getBuffer() {
+    MemoryBuffer buf = buffer;
+    if (buf == null) {
+      buf = buffer = MemoryBuffer.newHeapBuffer(INITIAL_SIZE);
+    }
+    return buf;
+  }
+
+  private void resetBuffer() {
+    MemoryBuffer buf = buffer;
+    if (buf != null && buf.size() > BUFFER_SIZE_LIMIT) {
+      buffer = MemoryBuffer.newHeapBuffer(BUFFER_SIZE_LIMIT);
+    }
+    if (buf != null) {
+      buf.writerIndex(0);
+    }
+  }
+}

--- a/java/fury-core/src/test/java/org/apache/fury/StreamTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/StreamTest.java
@@ -34,6 +34,7 @@ import org.apache.fury.io.FuryInputStream;
 import org.apache.fury.io.FuryReadableChannel;
 import org.apache.fury.io.FuryStreamReader;
 import org.apache.fury.memory.MemoryBuffer;
+import org.apache.fury.memory.MemoryBufferManager;
 import org.apache.fury.test.bean.BeanA;
 import org.apache.fury.util.ReflectionUtils;
 import org.testng.annotations.Test;
@@ -140,7 +141,10 @@ public class StreamTest {
   }
 
   private void checkBuffer(Fury fury) {
-    Object buf = ReflectionUtils.getObjectFieldValue(fury, "buffer");
+    Object bufManager = ReflectionUtils.getObjectFieldValue(fury, "bufferManager");
+    MemoryBufferManager bufferManager = (MemoryBufferManager) bufManager;
+    assert bufferManager != null;
+    Object buf = ReflectionUtils.getObjectFieldValue(bufferManager, "buffer");
     MemoryBuffer buffer = (MemoryBuffer) buf;
     assert buffer != null;
     assertTrue(buffer.size() < 1000 * 1000);


### PR DESCRIPTION
<!--
**Thanks for contributing to Fury.**

**If this is your first time opening a PR on fury, you can refer to [CONTRIBUTING.md](https://github.com/apache/incubator-fury/blob/main/CONTRIBUTING.md).**

Contribution Checklist

    - The **Apache Fury (incubating)** community has restrictions on the naming of pr titles. You can also find instructions in [CONTRIBUTING.md](https://github.com/apache/incubator-fury/blob/main/CONTRIBUTING.md).

    - Fury has a strong focus on performance. If the PR you submit will have an impact on performance, please benchmark it first and provide the benchmark result here.
-->

## What does this PR do?

<!-- Describe the purpose of this PR. -->
Separate MemoryBuffer management tasks from Fury and reduce Fury class responsibilities.

## Related issues

<!--
Is there any related issue? Please attach here.

- #xxxx0
- #xxxx1
- #xxxx2
-->


## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/incubator-fury/issues/new/choose) describing the need to do so and update the document if necessary.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?


## Benchmark

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.
-->
