### PR TITLE
chore(doc): rename guide document name

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ go get github.com/apache/incubator-fury/go/fury
 ```
 
 ## Quickstart
-Here we give a quick start about how to use Fury, see [user guide](https://github.com/apache/incubator-fury/blob/main/docs/README.md) for more details about [java](https://github.com/apache/incubator-fury/blob/main/docs/guide/java_object_graph_guide.md), [cross language](https://github.com/apache/incubator-fury/blob/main/docs/guide/xlang_object_graph_guide.md), and [row format](https://github.com/apache/incubator-fury/blob/main/docs/guide/row_format_guide.md).
+Here we give a quick start about how to use Fury, see [user guide](docs/README.md) for more details about [java](docs/guide/java_serialization_guide.md), [cross language](docs/guide/xlang_serialization_guide.md), and [row format](docs/guide/row_format_guide.md).
 
 ### Fury java object graph serialization
 If you don't have cross-language requirements, using this mode will

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # User Guide
-- For Cross Language Object Graph Guide, see [xlang serialization guide](guide/xlang_object_graph_guide.md) doc.
-- For Java Object Graph Guide, see [java serialization guide](guide/java_object_graph_guide.md) doc.
+- For Cross Language Object Graph Guide, see [xlang serialization guide](guide/xlang_serialization_guide.md) doc.
+- For Java Object Graph Guide, see [java serialization guide](guide/java_serialization_guide.md) doc.
 - For Row Format Guide, see [row format guide](guide/row_format_guide.md) doc.
 - For Scala Guide, see [scala guide](guide/scala_guide.md) doc.
 - For using Fury with GraalVM native image, see [graalvm native image guide](guide/graalvm_guide.md) doc.

--- a/docs/guide/java_serialization_guide.md
+++ b/docs/guide/java_serialization_guide.md
@@ -1,5 +1,5 @@
 ---
-title: Java Object Graph Guide
+title: Java Serialization Guide
 sidebar_position: 0
 id: java_object_graph_guide
 ---

--- a/docs/guide/xlang_serialization_guide.md
+++ b/docs/guide/xlang_serialization_guide.md
@@ -1,5 +1,5 @@
 ---
-title: Xlang Object Graph Guide
+title: Xlang Serialization Guide
 sidebar_position: 2
 id: xlang_object_graph_guide
 ---


### PR DESCRIPTION

## What does this PR do?

THis PR renames guide document name by rename `object graph` to serialization. This help reduce confusion.

## Is there any related issue? Please attach here.




## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/incubator-fury/issues/new/choose) describing the need to do so and update the document if necessary.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?


## Benchmark

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.
-->
