### PR TITLE
fix(release): make incubating after version in release artifacts

### DIFF
--- a/ci/release.py
+++ b/ci/release.py
@@ -43,11 +43,11 @@ def build(v: str):
     os.mkdir("dist")
     subprocess.check_call(f"git checkout releases-{v}", shell=True)
     branch = f"releases-{v}"
-    src_tar = f"apache-fury-incubating-{v}-src.tar.gz"
+    src_tar = f"apache-fury-{v}-incubating-src.tar.gz"
     subprocess.check_call(
         f"git archive --format=tar.gz "
         f"--output=dist/{src_tar} "
-        f"--prefix=apache-fury-incubating-{v}-src/ {branch}",
+        f"--prefix=apache-fury-{v}-incubating-src/ {branch}",
         shell=True,
     )
     os.chdir("dist")
@@ -60,7 +60,7 @@ def build(v: str):
 
 
 def verify(v):
-    src_tar = f"apache-fury-incubating-{v}-src.tar.gz"
+    src_tar = f"apache-fury-{v}-incubating-src.tar.gz"
     subprocess.check_call(f"gpg --verify {src_tar}.asc {src_tar}", shell=True)
     logger.info("Verified signature")
     subprocess.check_call(f"sha512sum --check {src_tar}.sha512", shell=True)


### PR DESCRIPTION


## What does this PR do?

This PR  makes `incubating` comes after `version` in release artifacts. 

For example: from `apache-fury-incubating-0.5.0-src.tar.gz` to `apache-fury-0.5.0-incubating-src.tar.gz`


## Related issues

#1389 


## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/incubator-fury/issues/new/choose) describing the need to do so and update the document if necessary.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?


## Benchmark

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.
-->
