### PR TITLE
fix(java): Switch order of literals to prevent NullPointerException

### DIFF
--- a/java/fury-core/src/main/java/org/apache/fury/util/Platform.java
+++ b/java/fury-core/src/main/java/org/apache/fury/util/Platform.java
@@ -76,7 +76,7 @@ public final class Platform {
   static {
     boolean unalign;
     String arch = System.getProperty("os.arch", "");
-    if (arch.equals("ppc64le") || arch.equals("ppc64") || arch.equals("s390x")) {
+    if ("ppc64le".equals(arch) || "ppc64".equals(arch) || "s390x".equals(arch)) {
       // Since java.nio.Bits.unaligned() doesn't return true on ppc (See JDK-8165231), but
       // ppc64 and ppc64le support it
       unalign = true;


### PR DESCRIPTION
<!--
**Thanks for contributing to Fury.**

**If this is your first time opening a PR on fury, you can refer to [CONTRIBUTING.md](https://github.com/apache/incubator-fury/blob/main/CONTRIBUTING.md).**

Contribution Checklist

    - The **Apache Fury (incubating)** community has restrictions on the naming of pr titles. You can also find instructions in [CONTRIBUTING.md](https://github.com/apache/incubator-fury/blob/main/CONTRIBUTING.md).

    - Fury has a strong focus on performance. If the PR you submit will have an impact on performance, please benchmark it first and provide the benchmark result here.
-->

## What does this PR do?

<!-- Describe the purpose of this PR. -->
This change defensively switches the order of literals in comparison expressions to ensure that no null pointer exceptions are unexpectedly thrown. Runtime exceptions especially can cause exceptional and unexpected code paths to be taken, and this can result in unexpected behavior. 

Both simple vulnerabilities (like information disclosure) and complex vulnerabilities (like business logic flaws) can take advantage of these unexpected code paths.

Our changes look something like this:

```diff
  String fieldName = header.getFieldName();
  String fieldValue = header.getFieldValue();
- if(fieldName.equals("requestId")) {
+ if("requestId".equals(fieldName)) {
    logRequest(fieldValue);
  }
```

<details>
  <summary>More reading</summary>

  * [http://cwe.mitre.org/data/definitions/476.html](http://cwe.mitre.org/data/definitions/476.html)
  * [https://en.wikibooks.org/wiki/Java_Programming/Preventing_NullPointerException](https://en.wikibooks.org/wiki/Java_Programming/Preventing_NullPointerException)
  * [https://rules.sonarsource.com/java/RSPEC-1132/](https://rules.sonarsource.com/java/RSPEC-1132/)
</details>

Powered by: [pixeebot](https://docs.pixee.ai/) (codemod ID: [pixee:java/switch-literal-first](https://docs.pixee.ai/codemods/java/pixee_java_switch-literal-first)) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7CPixee-Bot-Java%2Fincubator-fury%7C0f666b987610b4f1602c06d26772090be7247bea)

<!--{"type":"DRIP","codemod":"pixee:java/switch-literal-first"}-->



