### PR TITLE
fix(license): remove benchmark license when build

### DIFF
--- a/ci/release.py
+++ b/ci/release.py
@@ -38,7 +38,7 @@ def prepare(v: str):
     try:
         subprocess.check_call(f"git checkout -b {branch}", shell=True)
         bump_version(version=v, l="all")
-        subprocess.check_call(f"git add -u", shell=True)
+        subprocess.check_call("git add -u", shell=True)
         subprocess.check_call(f"git commit -m 'prepare release for {v}'", shell=True)
     except BaseException:
         logger.exception("Prepare branch failed")
@@ -258,7 +258,7 @@ def _parse_args():
 
     prepare_parser = subparsers.add_parser(
         "prepare",
-        description=f"Prepare release branch",
+        description="Prepare release branch",
     )
     prepare_parser.add_argument("-v", type=str, help="new version")
     prepare_parser.set_defaults(func=prepare)

--- a/ci/release.py
+++ b/ci/release.py
@@ -57,7 +57,7 @@ def build(v: str):
     subprocess.check_call(f"git checkout releases-{v}", shell=True)
     branch = f"releases-{v}"
     src_tar = f"apache-fury-{v}-incubating-src.tar.gz"
-    # _check_all_committed()
+    _check_all_committed()
     _strip_unnecessary_license()
     subprocess.check_call(
         "git add LICENSE && git commit -m 'remove benchmark from license'", shell=True

--- a/ci/release.py
+++ b/ci/release.py
@@ -68,7 +68,7 @@ def build(v: str):
         f"--prefix=apache-fury-{v}-incubating-src/ {branch}",
         shell=True,
     )
-    subprocess.check_call("git reset --hard HEAD~")
+    subprocess.check_call("git reset --hard HEAD~", shell=True)
     os.chdir("dist")
     logger.info("Start to generate signature")
     subprocess.check_call(


### PR DESCRIPTION
## What does this PR do?
Benchmark code are excluded from source release, we should remove license mention in the final LICENSE file.

The NOTICE fof those files are empty, so no need to change NOTICE file


## Related issues

#1389 


## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/incubator-fury/issues/new/choose) describing the need to do so and update the document if necessary.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?


## Benchmark

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.
-->
