### PR TITLE
perf(java): Optimize MetaStringDecoder

### DIFF
--- a/java/fury-core/src/main/java/org/apache/fury/meta/MetaStringDecoder.java
+++ b/java/fury-core/src/main/java/org/apache/fury/meta/MetaStringDecoder.java
@@ -75,10 +75,15 @@ public class MetaStringDecoder {
       int byteIndex = bitIndex / 8;
       int intraByteIndex = bitIndex % 8;
       // Extract the 5-bit character value across byte boundaries if needed
-      int charValue =
-          ((data[byteIndex] & 0xFF) << 8)
-              | (byteIndex + 1 < data.length ? (data[byteIndex + 1] & 0xFF) : 0);
-      charValue = (byte) ((charValue >> (11 - intraByteIndex)) & bitMask);
+      int charValue;
+      if (intraByteIndex > 3) {
+        charValue =
+            ((data[byteIndex] & 0xFF) << 8)
+                | (byteIndex + 1 < data.length ? (data[byteIndex + 1] & 0xFF) : 0);
+        charValue = (byte) ((charValue >> (11 - intraByteIndex)) & bitMask);
+      } else {
+        charValue = data[byteIndex] >> (3 - intraByteIndex) & bitMask;
+      }
       bitIndex += 5;
       decoded.append(decodeLowerSpecialChar(charValue));
     }
@@ -100,10 +105,15 @@ public class MetaStringDecoder {
       int intraByteIndex = bitIndex % 8;
 
       // Extract the 6-bit character value across byte boundaries if needed
-      int charValue =
-          ((data[byteIndex] & 0xFF) << 8)
-              | (byteIndex + 1 < data.length ? (data[byteIndex + 1] & 0xFF) : 0);
-      charValue = ((byte) ((charValue >> (10 - intraByteIndex)) & bitMask));
+      int charValue;
+      if (intraByteIndex > 2) {
+        charValue =
+            ((data[byteIndex] & 0xFF) << 8)
+                | (byteIndex + 1 < data.length ? (data[byteIndex + 1] & 0xFF) : 0);
+        charValue = ((byte) ((charValue >> (10 - intraByteIndex)) & bitMask));
+      } else {
+        charValue = data[byteIndex] >> (2 - intraByteIndex) & bitMask;
+      }
       bitIndex += 6;
       decoded.append(decodeLowerUpperDigitSpecialChar(charValue));
     }


### PR DESCRIPTION
<!--
**Thanks for contributing to Fury.**

**If this is your first time opening a PR on fury, you can refer to [CONTRIBUTING.md](https://github.com/apache/incubator-fury/blob/main/CONTRIBUTING.md).**

Contribution Checklist

    - The **Apache Fury (incubating)** community has restrictions on the naming of pr titles. You can also find instructions in [CONTRIBUTING.md](https://github.com/apache/incubator-fury/blob/main/CONTRIBUTING.md).

    - Fury has a strong focus on performance. If the PR you submit will have an impact on performance, please benchmark it first and provide the benchmark result here.
-->

## What does this PR do?

<!-- Describe the purpose of this PR. -->
When `MetaStringDecoder` is decoding, it will read two bytes at a time from the `data` and then perform the operation. This PR determines whether to skip the byte value. If it does not skip the byte decoding, it will only read one byte from the data.

## Related issues

<!--
Is there any related issue? Please attach here.

- #xxxx0
- #xxxx1
- #xxxx2
-->


## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/incubator-fury/issues/new/choose) describing the need to do so and update the document if necessary.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?


## Benchmark

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.
-->
