### PR TITLE
Update pom.xml

### DIFF
--- a/java/fury-core/pom.xml
+++ b/java/fury-core/pom.xml
@@ -48,7 +48,7 @@
 
   <properties>
     <maven.compiler.source>8</maven.compiler.source>
-    <maven.compiler.target>8</maven.compiler.target>
+    <maven.compiler.release>8</maven.compiler.release>
     <fury.java.rootdir>${basedir}/..</fury.java.rootdir>
   </properties>
 


### PR DESCRIPTION
fix using high version jdk compile to low version such as jdk8 using --release instead of -target
solve the https://github.com/apache/incubator-fury/issues/1577

> Starting JDK 9, the javac executable can accept the --release option to specify against which Java SE release you want to build the project. For example, you have JDK 11 installed and used by Maven, but you want to build the project against Java 8. The --release option ensures that the code is compiled following the rules of the programming language of the specified release, and that generated classes target the release as well as the public API of that release. This means that, unlike the [-source and -target options](https://maven.apache.org/plugins/maven-compiler-plugin/examples/set-compiler-source-and-target.html), the compiler will detect and generate an error when using APIs that don't exist in previous releases of Java SE.
https://maven.apache.org/plugins/maven-compiler-plugin/examples/set-compiler-release.html

