### PR TITLE
feat(java): support compatible mode for graalvm

### DIFF
--- a/integration_tests/graalvm_tests/src/main/java/org/apache/fury/graalvm/CompatibleExample.java
+++ b/integration_tests/graalvm_tests/src/main/java/org/apache/fury/graalvm/CompatibleExample.java
@@ -17,35 +17,26 @@
  * under the License.
  */
 
-package org.apache.fury.graalvm.record;
+package org.apache.fury.graalvm;
 
-import java.util.List;
-import java.util.Map;
 import org.apache.fury.Fury;
-import org.apache.fury.util.Preconditions;
+import org.apache.fury.config.CompatibleMode;
 
-public class RecordExample {
-  public record Record(int f1, String f2, List<String> f3, Map<String, Long> f4) {}
-
+public class CompatibleExample {
   static Fury fury;
 
   static {
-    fury = Fury.builder().requireClassRegistration(true).build();
+    fury =
+        Fury.builder()
+            .requireClassRegistration(true)
+            .withCompatibleMode(CompatibleMode.COMPATIBLE)
+            .build();
     // register and generate serializer code.
-    fury.register(Record.class, true);
-  }
-
-  static void test(Fury fury) {
-    Record record = new Record(10, "abc", List.of("str1", "str2"), Map.of("k1", 10L, "k2", 20L));
-    System.out.println(record);
-    byte[] bytes = fury.serialize(record);
-    Object o = fury.deserialize(bytes);
-    System.out.println(o);
-    Preconditions.checkArgument(record.equals(o));
+    fury.register(Foo.class, true);
   }
 
   public static void main(String[] args) {
-    test(fury);
-    System.out.println("RecordExample succeed");
+    Example.test(fury);
+    System.out.println("CompatibleExample succeed");
   }
 }

--- a/integration_tests/graalvm_tests/src/main/java/org/apache/fury/graalvm/CompatibleThreadSafeExample.java
+++ b/integration_tests/graalvm_tests/src/main/java/org/apache/fury/graalvm/CompatibleThreadSafeExample.java
@@ -17,35 +17,34 @@
  * under the License.
  */
 
-package org.apache.fury.graalvm.record;
+package org.apache.fury.graalvm;
 
-import java.util.List;
-import java.util.Map;
 import org.apache.fury.Fury;
-import org.apache.fury.util.Preconditions;
+import org.apache.fury.ThreadLocalFury;
+import org.apache.fury.ThreadSafeFury;
+import org.apache.fury.config.CompatibleMode;
 
-public class RecordExample {
-  public record Record(int f1, String f2, List<String> f3, Map<String, Long> f4) {}
-
-  static Fury fury;
+public class CompatibleThreadSafeExample {
+  static ThreadSafeFury fury;
 
   static {
-    fury = Fury.builder().requireClassRegistration(true).build();
-    // register and generate serializer code.
-    fury.register(Record.class, true);
+    fury =
+        new ThreadLocalFury(
+            classLoader -> {
+              Fury f =
+                  Fury.builder()
+                      .requireClassRegistration(true)
+                      .withCompatibleMode(CompatibleMode.COMPATIBLE)
+                      .build();
+              // register and generate serializer code.
+              f.register(Foo.class, true);
+              return f;
+            });
+    System.out.println("Init fury at build time");
   }
 
-  static void test(Fury fury) {
-    Record record = new Record(10, "abc", List.of("str1", "str2"), Map.of("k1", 10L, "k2", 20L));
-    System.out.println(record);
-    byte[] bytes = fury.serialize(record);
-    Object o = fury.deserialize(bytes);
-    System.out.println(o);
-    Preconditions.checkArgument(record.equals(o));
-  }
-
-  public static void main(String[] args) {
-    test(fury);
-    System.out.println("RecordExample succeed");
+  public static void main(String[] args) throws Throwable {
+    ThreadSafeExample.test(fury);
+    System.out.println("CompatibleThreadSafeExample succeed");
   }
 }

--- a/integration_tests/graalvm_tests/src/main/java/org/apache/fury/graalvm/Example.java
+++ b/integration_tests/graalvm_tests/src/main/java/org/apache/fury/graalvm/Example.java
@@ -33,7 +33,7 @@ public class Example {
     fury.register(Foo.class, true);
   }
 
-  public static void main(String[] args) {
+  static void test(Fury fury) {
     Preconditions.checkArgument("abc".equals(fury.deserialize(fury.serialize("abc"))));
     Preconditions.checkArgument(
         List.of(1, 2, 3).equals(fury.deserialize(fury.serialize(List.of(1, 2, 3)))));
@@ -46,5 +46,10 @@ public class Example {
     System.out.println(foo);
     System.out.println(o);
     Preconditions.checkArgument(foo.equals(o));
+  }
+
+  public static void main(String[] args) {
+    test(fury);
+    System.out.println("Example succeed");
   }
 }

--- a/integration_tests/graalvm_tests/src/main/java/org/apache/fury/graalvm/Main.java
+++ b/integration_tests/graalvm_tests/src/main/java/org/apache/fury/graalvm/Main.java
@@ -19,15 +19,19 @@
 
 package org.apache.fury.graalvm;
 
+import org.apache.fury.graalvm.record.CompatibleRecordExample;
 import org.apache.fury.graalvm.record.RecordExample;
 import org.apache.fury.graalvm.record.RecordExample2;
 
 public class Main {
   public static void main(String[] args) throws Throwable {
     Example.main(args);
+    CompatibleExample.main(args);
     RecordExample.main(args);
+    CompatibleRecordExample.main(args);
     RecordExample2.main(args);
     ThreadSafeExample.main(args);
+    CompatibleThreadSafeExample.main(args);
     ProxyExample.main(args);
     Benchmark.main(args);
   }

--- a/integration_tests/graalvm_tests/src/main/java/org/apache/fury/graalvm/ThreadSafeExample.java
+++ b/integration_tests/graalvm_tests/src/main/java/org/apache/fury/graalvm/ThreadSafeExample.java
@@ -46,6 +46,11 @@ public class ThreadSafeExample {
   }
 
   public static void main(String[] args) throws Throwable {
+    test(fury);
+    System.out.println("ThreadSafeExample succeed");
+  }
+
+  static void test(ThreadSafeFury fury) throws Throwable {
     ThreadSafeExample threadSafeExample = new ThreadSafeExample();
     threadSafeExample.test();
     System.out.println("single thread works");
@@ -61,7 +66,7 @@ public class ThreadSafeExample {
             }
           });
     }
-    Thread.sleep(3000);
+    Thread.sleep(1000);
     service.shutdown();
     service.awaitTermination(10, TimeUnit.SECONDS);
     System.out.println("tasks finished");

--- a/integration_tests/graalvm_tests/src/main/java/org/apache/fury/graalvm/record/CompatibleRecordExample.java
+++ b/integration_tests/graalvm_tests/src/main/java/org/apache/fury/graalvm/record/CompatibleRecordExample.java
@@ -19,33 +19,24 @@
 
 package org.apache.fury.graalvm.record;
 
-import java.util.List;
-import java.util.Map;
 import org.apache.fury.Fury;
-import org.apache.fury.util.Preconditions;
+import org.apache.fury.config.CompatibleMode;
 
-public class RecordExample {
-  public record Record(int f1, String f2, List<String> f3, Map<String, Long> f4) {}
-
+public class CompatibleRecordExample {
   static Fury fury;
 
   static {
-    fury = Fury.builder().requireClassRegistration(true).build();
+    fury =
+        Fury.builder()
+            .requireClassRegistration(true)
+            .withCompatibleMode(CompatibleMode.COMPATIBLE)
+            .build();
     // register and generate serializer code.
-    fury.register(Record.class, true);
-  }
-
-  static void test(Fury fury) {
-    Record record = new Record(10, "abc", List.of("str1", "str2"), Map.of("k1", 10L, "k2", 20L));
-    System.out.println(record);
-    byte[] bytes = fury.serialize(record);
-    Object o = fury.deserialize(bytes);
-    System.out.println(o);
-    Preconditions.checkArgument(record.equals(o));
+    fury.register(RecordExample.Record.class, true);
   }
 
   public static void main(String[] args) {
-    test(fury);
-    System.out.println("RecordExample succeed");
+    RecordExample.test(fury);
+    System.out.println("CompatibleRecordExample succeed");
   }
 }

--- a/integration_tests/graalvm_tests/src/main/java/org/apache/fury/graalvm/record/RecordExample2.java
+++ b/integration_tests/graalvm_tests/src/main/java/org/apache/fury/graalvm/record/RecordExample2.java
@@ -44,5 +44,6 @@ public class RecordExample2 {
     Foo foo = new Foo(10, "abc", List.of("str1", "str2"), Map.of("k1", 10L, "k2", 20L));
     Object o2 = fury.deserialize(fury.serialize(foo));
     Preconditions.checkArgument(foo.equals(o2));
+    System.out.println("RecordExample2 succeed");
   }
 }

--- a/integration_tests/graalvm_tests/src/main/resources/META-INF/native-image/org.apache.fury/graalvm_tests/native-image.properties
+++ b/integration_tests/graalvm_tests/src/main/resources/META-INF/native-image/org.apache.fury/graalvm_tests/native-image.properties
@@ -19,9 +19,11 @@
 # The unsafe offset get on build time may be different from runtime
 Args = -H:+ReportExceptionStackTraces \
   --initialize-at-build-time=org.apache.fury.graalvm.Example,\
+  org.apache.fury.graalvm.CompatibleExample,\
   org.apache.fury.graalvm.record.RecordExample,\
+  org.apache.fury.graalvm.record.CompatibleRecordExample,\
   org.apache.fury.graalvm.record.RecordExample2,\
   org.apache.fury.graalvm.ThreadSafeExample,\
+  org.apache.fury.graalvm.CompatibleThreadSafeExample,\
   org.apache.fury.graalvm.ProxyExample,\
-  org.apache.fury.graalvm.Benchmark,\
-  org.apache.fury.resolver.DisallowedList
+  org.apache.fury.graalvm.Benchmark

--- a/java/fury-core/src/main/java/org/apache/fury/builder/AccessorHelper.java
+++ b/java/fury-core/src/main/java/org/apache/fury/builder/AccessorHelper.java
@@ -34,7 +34,6 @@ import org.apache.fury.codegen.JaninoUtils;
 import org.apache.fury.logging.Logger;
 import org.apache.fury.logging.LoggerFactory;
 import org.apache.fury.reflect.ReflectionUtils;
-import org.apache.fury.reflect.UnsafeFieldAccessor;
 import org.apache.fury.type.Descriptor;
 import org.apache.fury.util.ClassLoaderUtils;
 import org.apache.fury.util.Preconditions;
@@ -44,8 +43,6 @@ import org.apache.fury.util.record.RecordUtils;
 /**
  * Define accessor helper methods in beanClass's classloader and same package to avoid reflective
  * call overhead. {@link sun.misc.Unsafe} is another method to avoid reflection cost.
- *
- * @see UnsafeFieldAccessor
  */
 public class AccessorHelper {
   private static final Logger LOG = LoggerFactory.getLogger(AccessorHelper.class);

--- a/java/fury-core/src/main/java/org/apache/fury/reflect/FieldAccessor.java
+++ b/java/fury-core/src/main/java/org/apache/fury/reflect/FieldAccessor.java
@@ -19,6 +19,8 @@
 
 package org.apache.fury.reflect;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.function.Function;
@@ -28,12 +30,15 @@ import java.util.function.ToIntFunction;
 import java.util.function.ToLongFunction;
 import org.apache.fury.memory.Platform;
 import org.apache.fury.type.TypeUtils;
+import org.apache.fury.util.GraalvmSupport;
 import org.apache.fury.util.Preconditions;
 import org.apache.fury.util.function.Functions;
 import org.apache.fury.util.function.ToByteFunction;
 import org.apache.fury.util.function.ToCharFunction;
 import org.apache.fury.util.function.ToFloatFunction;
 import org.apache.fury.util.function.ToShortFunction;
+import org.apache.fury.util.record.RecordUtils;
+import org.apache.fury.util.unsafe._JDKAccess;
 
 /**
  * Field accessor for primitive types and object types.
@@ -104,7 +109,7 @@ public abstract class FieldAccessor {
     private final Object getter;
 
     protected FieldGetter(Field field, Object getter) {
-      super(field);
+      super(field, -1);
       this.getter = getter;
     }
 
@@ -114,11 +119,8 @@ public abstract class FieldAccessor {
   }
 
   public static FieldAccessor createAccessor(Field field) {
-    Object getter;
-    try {
-      // record class fields are not allowed by JDK
-      ReflectionUtils.getFieldOffset(field);
-    } catch (UnsupportedOperationException e) {
+    if (RecordUtils.isRecord(field.getDeclaringClass())) {
+      Object getter;
       try {
         Method getterMethod = field.getDeclaringClass().getDeclaredMethod(field.getName());
         getter = Functions.makeGetterFunction(getterMethod);
@@ -144,6 +146,9 @@ public abstract class FieldAccessor {
       } else {
         return new ObjectGetter(field, (Function) getter);
       }
+    }
+    if (GraalvmSupport.isGraalBuildtime()) {
+      return new GeneratedAccessor(field);
     }
     if (field.getType() == boolean.class) {
       return new BooleanAccessor(field);
@@ -480,6 +485,42 @@ public abstract class FieldAccessor {
     @Override
     public Object get(Object obj) {
       return getter.apply(obj);
+    }
+  }
+
+  static class GeneratedAccessor extends FieldAccessor {
+    private final MethodHandle getter;
+    private final MethodHandle setter;
+
+    protected GeneratedAccessor(Field field) {
+      super(field, -1);
+      MethodHandles.Lookup lookup = _JDKAccess._trustedLookup(field.getDeclaringClass());
+      try {
+        this.getter =
+            lookup.findGetter(field.getDeclaringClass(), field.getName(), field.getType());
+        this.setter =
+            lookup.findSetter(field.getDeclaringClass(), field.getName(), field.getType());
+      } catch (IllegalAccessException | NoSuchFieldException ex) {
+        throw new RuntimeException(ex);
+      }
+    }
+
+    @Override
+    public Object get(Object obj) {
+      try {
+        return getter.invoke(obj);
+      } catch (Throwable e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    @Override
+    public void set(Object obj, Object value) {
+      try {
+        setter.invoke(obj, value);
+      } catch (Throwable e) {
+        throw new RuntimeException(e);
+      }
     }
   }
 }

--- a/java/fury-core/src/main/java/org/apache/fury/util/function/Functions.java
+++ b/java/fury-core/src/main/java/org/apache/fury/util/function/Functions.java
@@ -89,9 +89,6 @@ public class Functions {
   public static Object makeGetterFunction(Method method, Class<?> returnType) {
     MethodHandles.Lookup lookup = _JDKAccess._trustedLookup(method.getDeclaringClass());
     try {
-      // Why `lookup.findGetter` doesn't work?
-      // MethodHandle handle = lookup.findGetter(field.getDeclaringClass(), field.getName(),
-      // field.getType());
       MethodHandle handle = lookup.unreflect(method);
       return _JDKAccess.makeGetterFunction(lookup, handle, returnType);
     } catch (IllegalAccessException ex) {

--- a/java/fury-core/src/main/resources/META-INF/native-image/org.apache.fury/fury-core/native-image.properties
+++ b/java/fury-core/src/main/resources/META-INF/native-image/org.apache.fury/fury-core/native-image.properties
@@ -29,7 +29,6 @@ Args=--initialize-at-build-time=org.apache.fury.memory.MemoryBuffer,\
     org.apache.fury.serializer.Serializers,\
     org.apache.fury.serializer.shim.ShimDispatcher,\
     org.apache.fury.memory.Platform,\
-    org.apache.fury.reflect.ReflectionUtils,\
     org.apache.fury.util.unsafe._Lookup,\
     org.apache.fury.util.unsafe._JDKAccess,\
     org.apache.fury.type.Type,\
@@ -39,14 +38,12 @@ Args=--initialize-at-build-time=org.apache.fury.memory.MemoryBuffer,\
     org.apache.fury.serializer.JavaSerializer,\
     org.apache.fury.reflect.ReflectionUtils,\
     org.apache.fury.builder.ObjectCodecBuilder,\
-    com.google.common.reflect.Types$ClassOwnership$1,\
     org.apache.fury.shaded.org.codehaus.janino.Java$ArrayType,\
     org.apache.fury.serializer.LocaleSerializer,\
     org.apache.fury.shaded.org.codehaus.janino.Java$AbstractCompilationUnit$TypeImportOnDemandDeclaration,\
     org.apache.fury.shaded.org.codehaus.janino.Compiler,\
     org.apache.fury.shaded.org.codehaus.janino.UnitCompiler,\
     com.google.common.util.concurrent.SettableFuture,\
-    com.google.common.reflect.Types$JavaVersion$1,\
     org.apache.fury.config.FuryBuilder,\
     org.apache.fury.shaded.org.codehaus.janino.Java$MethodInvocation,\
     org.apache.fury.shaded.org.codehaus.janino.Java$FunctionDeclarator$FormalParameter,\
@@ -74,7 +71,6 @@ Args=--initialize-at-build-time=org.apache.fury.memory.MemoryBuffer,\
     org.apache.fury.shaded.org.codehaus.janino.Java$BreakableStatement,\
     org.apache.fury.shaded.org.codehaus.janino.Java$LocalVariableDeclarationStatement,\
     org.apache.fury.shaded.org.codehaus.janino.TokenStreamImpl$1,\
-    com.google.common.reflect.Types$TypeVariableInvocationHandler,\
     org.apache.fury.shaded.org.codehaus.janino.Java$ThisReference,\
     org.apache.fury.shaded.org.codehaus.janino.IClass,\
     org.apache.fury.shaded.org.codehaus.janino.Java$ClassLiteral,\
@@ -83,7 +79,6 @@ Args=--initialize-at-build-time=org.apache.fury.memory.MemoryBuffer,\
     org.apache.fury.shaded.org.codehaus.janino.Java$BinaryOperation,\
     org.apache.fury.shaded.org.codehaus.janino.Java$Crement,\
     org.apache.fury.shaded.org.codehaus.janino.Java$ReturnStatement,\
-    com.google.common.reflect.Types$ClassOwnership,\
     org.apache.fury.shaded.org.codehaus.janino.Java$WhileStatement,\
     org.apache.fury.shaded.org.codehaus.janino.Java$FunctionDeclarator,\
     org.apache.fury.shaded.org.codehaus.janino.Java$Atom,\
@@ -116,7 +111,6 @@ Args=--initialize-at-build-time=org.apache.fury.memory.MemoryBuffer,\
     org.apache.fury.shaded.org.codehaus.janino.IClass$2,\
     com.google.common.collect.RegularImmutableMap,\
     org.apache.fury.shaded.org.codehaus.janino.Descriptor,\
-    com.google.common.reflect.Types$NativeTypeVariableEquals,\
     org.apache.fury.shaded.org.codehaus.janino.Java$Located,\
     org.apache.fury.shaded.org.codehaus.janino.Java$ReferenceType,\
     org.apache.fury.shaded.org.codehaus.janino.Java$UnaryOperation,\
@@ -125,7 +119,6 @@ Args=--initialize-at-build-time=org.apache.fury.memory.MemoryBuffer,\
     org.apache.fury.shaded.org.codehaus.janino.Java$IntegerLiteral,\
     org.apache.fury.shaded.org.codehaus.janino.Java$Lvalue,\
     org.apache.fury.shaded.org.codehaus.janino.Java$PackageDeclaration,\
-    com.google.common.reflect.Types$JavaVersion$4,\
     org.apache.fury.shaded.org.codehaus.janino.Java$FieldAccess,\
     org.apache.fury.shaded.org.codehaus.janino.Java$Block,\
     org.apache.fury.builder.AccessorHelper,\
@@ -134,7 +127,6 @@ Args=--initialize-at-build-time=org.apache.fury.memory.MemoryBuffer,\
     org.apache.fury.shaded.org.codehaus.janino.Java$IfStatement,\
     com.google.common.collect.RegularImmutableBiMap,\
     org.apache.fury.shaded.org.codehaus.janino.Java$ConstructorDeclarator,\
-    com.google.common.reflect.Types$JavaVersion$3,\
     org.apache.fury.shaded.org.codehaus.janino.Java$SuperConstructorInvocation,\
     org.apache.fury.shaded.org.codehaus.janino.UnitCompiler$44,\
     org.apache.fury.shaded.org.codehaus.janino.Java$AmbiguousName,\
@@ -176,4 +168,5 @@ Args=--initialize-at-build-time=org.apache.fury.memory.MemoryBuffer,\
     org.apache.fury.meta.MetaString$Encoding,\
     org.apache.fury.reflect.Types$ClassOwnership,\
     org.apache.fury.reflect.Types$ClassOwnership$1,\
-    org.apache.fury.reflect.Types$ClassOwnership$2
+    org.apache.fury.reflect.Types$ClassOwnership$2,\
+    org.apache.fury.resolver.DisallowedList

--- a/java/fury-core/src/test/java/org/apache/fury/reflect/FieldAccessorTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/reflect/FieldAccessorTest.java
@@ -1,0 +1,32 @@
+package org.apache.fury.reflect;
+
+import lombok.AllArgsConstructor;
+import org.apache.fury.reflect.FieldAccessor.GeneratedAccessor;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class FieldAccessorTest {
+  @AllArgsConstructor
+  private static final class TestStruct {
+    private int f1;
+    private boolean f2;
+    private String f3;
+  }
+
+  @Test
+  public void testGeneratedAccessor() throws Exception {
+    TestStruct struct = new TestStruct(10, true, "str");
+    GeneratedAccessor f1 = new GeneratedAccessor(TestStruct.class.getDeclaredField("f1"));
+    Assert.assertEquals(f1.get(struct), 10);
+    f1.set(struct, 20);
+    Assert.assertEquals(f1.get(struct), 20);
+    GeneratedAccessor f2 = new GeneratedAccessor(TestStruct.class.getDeclaredField("f2"));
+    Assert.assertEquals(f2.get(struct), true);
+    f2.set(struct, false);
+    Assert.assertEquals(f2.get(struct), false);
+    GeneratedAccessor f3 = new GeneratedAccessor(TestStruct.class.getDeclaredField("f3"));
+    Assert.assertEquals(f3.get(struct), "str");
+    f3.set(struct, "a");
+    Assert.assertEquals(f3.get(struct), "a");
+  }
+}

--- a/java/fury-core/src/test/java/org/apache/fury/reflect/FieldAccessorTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/reflect/FieldAccessorTest.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.fury.reflect;
 
 import lombok.AllArgsConstructor;


### PR DESCRIPTION

## What does this PR do?

This PR supports compatible mode for graalvm by using `MethodHandle` to geenrate accessor at build time instead of using `Unsafe`

## Related issues

Closes #1555


## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/incubator-fury/issues/new/choose) describing the need to do so and update the document if necessary.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?


## Benchmark

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.
-->
