### PR TITLE
fix(java): meta string strip last char && check empty encoded string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ javascript/**/node_modules/
 javascript/**/build
 MODULE.bazel
 MODULE.bazel.lock
+.DS_Store
+**/.DS_Store

--- a/java/fury-core/src/main/java/org/apache/fury/meta/MetaString.java
+++ b/java/fury-core/src/main/java/org/apache/fury/meta/MetaString.java
@@ -79,7 +79,7 @@ public class MetaString {
     this.bytes = bytes;
     if (encoding != Encoding.UTF_8) {
       Preconditions.checkArgument(bytes.length > 0);
-      this.stripLastChar = (bytes[0] & 0b1) != 0;
+      this.stripLastChar = (bytes[0] & 0x80) != 0;
     } else {
       this.stripLastChar = false;
     }

--- a/java/fury-core/src/main/java/org/apache/fury/meta/MetaStringDecoder.java
+++ b/java/fury-core/src/main/java/org/apache/fury/meta/MetaStringDecoder.java
@@ -48,6 +48,9 @@ public class MetaStringDecoder {
    * @return Decoded string.
    */
   public String decode(byte[] encodedData, Encoding encoding) {
+    if (encodedData.length == 0) {
+      return "";
+    }
     switch (encoding) {
       case LOWER_SPECIAL:
         return decodeLowerSpecial(encodedData);

--- a/java/fury-core/src/test/java/org/apache/fury/meta/MetaStringTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/meta/MetaStringTest.java
@@ -20,7 +20,9 @@
 package org.apache.fury.meta;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotSame;
+import static org.testng.Assert.assertTrue;
 import static org.testng.AssertJUnit.assertSame;
 
 import org.apache.fury.util.StringUtils;
@@ -187,5 +189,29 @@ public class MetaStringTest {
     String decodedString =
         decoder.decode(encodedMetaString.getBytes(), encodedMetaString.getEncoding());
     assertEquals(decodedString, testString);
+  }
+
+  @Test
+  public void testStripLastChar() {
+    String testString = "abc"; // encoded as 1|00000|00, 001|00010, exactly two bytes
+    MetaStringEncoder encoder = new MetaStringEncoder('_', '$');
+    MetaString encodedMetaString = encoder.encode(testString);
+    assertFalse(encodedMetaString.stripLastChar());
+
+    testString =
+        "abcde"; // encoded as 1|00000|00, 001|00010, 00011|001, 00xxxxxx, stripped last char
+    encodedMetaString = encoder.encode(testString);
+    assertTrue(encodedMetaString.stripLastChar());
+  }
+
+  @Test
+  public void testEmptyString() {
+    MetaStringEncoder encoder = new MetaStringEncoder('_', '$');
+    MetaString metaString = encoder.encode("");
+    assertEquals(metaString.getBytes(), new byte[0]);
+
+    MetaStringDecoder decoder = new MetaStringDecoder('_', '$');
+    String decoded = decoder.decode(metaString.getBytes(), metaString.getEncoding());
+    assertEquals(decoded, "");
   }
 }


### PR DESCRIPTION
## What does this PR do?
Fix two bugs:
+ fix method `MetaString.stripLastChar()` logical error
+ add empty encoded bytes check in `MetaStringDecoder.decode()`


## Related issues
- #1565 


## Does this PR introduce any user-facing change?
- [No] Does this PR introduce any public API change?
- [No] Does this PR introduce any binary protocol compatibility change?