### PR TITLE
perf(java): Reduce performance regression caused by deleteCharAt

### DIFF
--- a/java/fury-core/src/main/java/org/apache/fury/meta/MetaStringDecoder.java
+++ b/java/fury-core/src/main/java/org/apache/fury/meta/MetaStringDecoder.java
@@ -74,7 +74,7 @@ public class MetaStringDecoder {
     boolean stripLastChar = (data[0] & 0x80) != 0; // Check the first bit of the first byte
     int bitMask = 0b11111; // 5 bits for the mask
     int bitIndex = 1; // Start from the second bit
-    while (bitIndex + 5 <= totalBits) {
+    while (bitIndex + 5 <= totalBits && !(stripLastChar && (bitIndex + 2 * 5 > totalBits))) {
       int byteIndex = bitIndex / 8;
       int intraByteIndex = bitIndex % 8;
       // Extract the 5-bit character value across byte boundaries if needed
@@ -90,9 +90,6 @@ public class MetaStringDecoder {
       bitIndex += 5;
       decoded.append(decodeLowerSpecialChar(charValue));
     }
-    if (stripLastChar) {
-      decoded.deleteCharAt(decoded.length() - 1);
-    }
     return decoded.toString();
   }
 
@@ -103,7 +100,7 @@ public class MetaStringDecoder {
     boolean stripLastChar = (data[0] & 0x80) != 0; // Check the first bit of the first byte
     int bitMask = 0b111111; // 6 bits for mask
     int numBits = data.length * 8;
-    while (bitIndex + 6 <= numBits) {
+    while (bitIndex + 6 <= numBits && !(stripLastChar && (bitIndex + 2 * 6 > numBits))) {
       int byteIndex = bitIndex / 8;
       int intraByteIndex = bitIndex % 8;
 
@@ -119,9 +116,6 @@ public class MetaStringDecoder {
       }
       bitIndex += 6;
       decoded.append(decodeLowerUpperDigitSpecialChar(charValue));
-    }
-    if (stripLastChar) {
-      decoded.deleteCharAt(decoded.length() - 1);
     }
     return decoded.toString();
   }


### PR DESCRIPTION
<!--
**Thanks for contributing to Fury.**

**If this is your first time opening a PR on fury, you can refer to [CONTRIBUTING.md](https://github.com/apache/incubator-fury/blob/main/CONTRIBUTING.md).**

Contribution Checklist

    - The **Apache Fury (incubating)** community has restrictions on the naming of pr titles. You can also find instructions in [CONTRIBUTING.md](https://github.com/apache/incubator-fury/blob/main/CONTRIBUTING.md).

    - Fury has a strong focus on performance. If the PR you submit will have an impact on performance, please benchmark it first and provide the benchmark result here.
-->

## What does this PR do?

<!-- Describe the purpose of this PR. -->
This PR reduces the performance regression caused by StringBuilder#deleteCharAt, avoids using deleteCharAt, and makes early judgments in while.

## Related issues

<!--
Is there any related issue? Please attach here.

- #xxxx0
- #xxxx1
- #xxxx2
-->


## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/incubator-fury/issues/new/choose) describing the need to do so and update the document if necessary.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?


## Benchmark

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.
-->
before this PR
![image](https://github.com/apache/incubator-fury/assets/116876207/8f0b9429-c6c7-467b-8551-115a92355be0)


with this pr
![image](https://github.com/apache/incubator-fury/assets/116876207/19ff5fd2-044c-493e-8775-756da74feef5)

