### PR TITLE
fix(java): clear serializer for collection/map

### DIFF
--- a/java/fury-core/src/main/java/org/apache/fury/resolver/FieldResolver.java
+++ b/java/fury-core/src/main/java/org/apache/fury/resolver/FieldResolver.java
@@ -570,6 +570,9 @@ public class FieldResolver {
       CollectionSerializer collectionSerializer = (CollectionSerializer) classInfo.getSerializer();
       collectionSerializer.setElementSerializer(elementClassInfo.getSerializer());
       o = collectionSerializer.read(buffer);
+      // Some collectionSerializer may overwrite write/read method, then clear element serializer
+      // may not got invoked.
+      collectionSerializer.setElementSerializer(null);
     } else if (fieldType == FieldTypes.MAP_KV_FINAL) {
       ClassInfo keyClassInfo = classResolver.readClassInfo(buffer, classInfoHolder);
       ClassInfo valueClassInfo = classResolver.readClassInfo(buffer, classInfoHolder);
@@ -578,12 +581,19 @@ public class FieldResolver {
       mapSerializer.setKeySerializer(keyClassInfo.getSerializer());
       mapSerializer.setValueSerializer(valueClassInfo.getSerializer());
       o = mapSerializer.read(buffer);
+      // Some mmapSerializer may overwrite write/read method, then clear serializer
+      // may not got invoked.
+      mapSerializer.setKeySerializer(null);
+      mapSerializer.setValueSerializer(null);
     } else if (fieldType == FieldTypes.MAP_KEY_FINAL) {
       ClassInfo keyClassInfo = classResolver.readClassInfo(buffer, classInfoHolder);
       ClassInfo classInfo = classResolver.readClassInfo(buffer, classInfoHolder);
       MapSerializer mapSerializer = (MapSerializer) classInfo.getSerializer();
       mapSerializer.setKeySerializer(keyClassInfo.getSerializer());
       o = mapSerializer.read(buffer);
+      // Some mmapSerializer may overwrite write/read method, then clear serializer
+      // may not got invoked.
+      mapSerializer.setKeySerializer(null);
     } else {
       Preconditions.checkArgument(fieldType == FieldTypes.MAP_VALUE_FINAL);
       ClassInfo valueClassInfo = classResolver.readClassInfo(buffer, classInfoHolder);
@@ -591,6 +601,9 @@ public class FieldResolver {
       MapSerializer mapSerializer = (MapSerializer) classInfo.getSerializer();
       mapSerializer.setValueSerializer(valueClassInfo.getSerializer());
       o = mapSerializer.read(buffer);
+      // Some mmapSerializer may overwrite write/read method, then clear serializer
+      // may not got invoked.
+      mapSerializer.setValueSerializer(null);
     }
     return o;
   }
@@ -603,6 +616,9 @@ public class FieldResolver {
       CollectionSerializer collectionSerializer = (CollectionSerializer) classInfo.getSerializer();
       collectionSerializer.setElementSerializer(elementClassInfo.getSerializer());
       o = collectionSerializer.read(buffer);
+      // Some collectionSerializer may overwrite write/read method, then clear element serializer
+      // may not got invoked.
+      collectionSerializer.setElementSerializer(null);
     } else if (fieldType == FieldTypes.MAP_KV_FINAL) {
       ClassInfo keyClassInfo = classResolver.readClassInfo(buffer, classInfoHolder);
       ClassInfo valueClassInfo = classResolver.readClassInfo(buffer, classInfoHolder);
@@ -611,12 +627,19 @@ public class FieldResolver {
       mapSerializer.setKeySerializer(keyClassInfo.getSerializer());
       mapSerializer.setValueSerializer(valueClassInfo.getSerializer());
       o = mapSerializer.read(buffer);
+      // Some mmapSerializer may overwrite write/read method, then clear serializer
+      // may not got invoked.
+      mapSerializer.setKeySerializer(null);
+      mapSerializer.setValueSerializer(null);
     } else if (fieldType == FieldTypes.MAP_KEY_FINAL) {
       ClassInfo keyClassInfo = classResolver.readClassInfo(buffer, classInfoHolder);
       ClassInfo classInfo = classResolver.readClassInfo(buffer, fieldInfo.getClassInfoHolder());
       MapSerializer mapSerializer = (MapSerializer) classInfo.getSerializer();
       mapSerializer.setKeySerializer(keyClassInfo.getSerializer());
       o = mapSerializer.read(buffer);
+      // Some mmapSerializer may overwrite write/read method, then clear serializer
+      // may not got invoked.
+      mapSerializer.setKeySerializer(null);
     } else {
       Preconditions.checkArgument(fieldType == FieldTypes.MAP_VALUE_FINAL);
       ClassInfo valueClassInfo = classResolver.readClassInfo(buffer, classInfoHolder);
@@ -624,6 +647,9 @@ public class FieldResolver {
       MapSerializer mapSerializer = (MapSerializer) classInfo.getSerializer();
       mapSerializer.setValueSerializer(valueClassInfo.getSerializer());
       o = mapSerializer.read(buffer);
+      // Some mmapSerializer may overwrite write/read method, then clear serializer
+      // may not got invoked.
+      mapSerializer.setValueSerializer(null);
     }
     return o;
   }

--- a/java/fury-core/src/main/java/org/apache/fury/resolver/FieldResolver.java
+++ b/java/fury-core/src/main/java/org/apache/fury/resolver/FieldResolver.java
@@ -568,42 +568,54 @@ public class FieldResolver {
       ClassInfo elementClassInfo = classResolver.readClassInfo(buffer, classInfoHolder);
       ClassInfo classInfo = classResolver.readClassInfo(buffer, classInfoHolder);
       CollectionSerializer collectionSerializer = (CollectionSerializer) classInfo.getSerializer();
-      collectionSerializer.setElementSerializer(elementClassInfo.getSerializer());
-      o = collectionSerializer.read(buffer);
-      // Some collectionSerializer may overwrite write/read method, then clear element serializer
-      // may not got invoked.
-      collectionSerializer.setElementSerializer(null);
+      try {
+        collectionSerializer.setElementSerializer(elementClassInfo.getSerializer());
+        o = collectionSerializer.read(buffer);
+      } finally {
+        // Some collectionSerializer may overwrite write/read method, then clear element serializer
+        // may not got invoked.
+        collectionSerializer.setElementSerializer(null);
+      }
     } else if (fieldType == FieldTypes.MAP_KV_FINAL) {
       ClassInfo keyClassInfo = classResolver.readClassInfo(buffer, classInfoHolder);
       ClassInfo valueClassInfo = classResolver.readClassInfo(buffer, classInfoHolder);
       ClassInfo classInfo = classResolver.readClassInfo(buffer, classInfoHolder);
       MapSerializer mapSerializer = (MapSerializer) classInfo.getSerializer();
-      mapSerializer.setKeySerializer(keyClassInfo.getSerializer());
-      mapSerializer.setValueSerializer(valueClassInfo.getSerializer());
-      o = mapSerializer.read(buffer);
-      // Some mmapSerializer may overwrite write/read method, then clear serializer
-      // may not got invoked.
-      mapSerializer.setKeySerializer(null);
-      mapSerializer.setValueSerializer(null);
+      try {
+        mapSerializer.setKeySerializer(keyClassInfo.getSerializer());
+        mapSerializer.setValueSerializer(valueClassInfo.getSerializer());
+        o = mapSerializer.read(buffer);
+      } finally {
+        // Some mmapSerializer may overwrite write/read method, then clear serializer
+        // may not got invoked.
+        mapSerializer.setKeySerializer(null);
+        mapSerializer.setValueSerializer(null);
+      }
     } else if (fieldType == FieldTypes.MAP_KEY_FINAL) {
       ClassInfo keyClassInfo = classResolver.readClassInfo(buffer, classInfoHolder);
       ClassInfo classInfo = classResolver.readClassInfo(buffer, classInfoHolder);
       MapSerializer mapSerializer = (MapSerializer) classInfo.getSerializer();
-      mapSerializer.setKeySerializer(keyClassInfo.getSerializer());
-      o = mapSerializer.read(buffer);
-      // Some mmapSerializer may overwrite write/read method, then clear serializer
-      // may not got invoked.
-      mapSerializer.setKeySerializer(null);
+      try {
+        mapSerializer.setKeySerializer(keyClassInfo.getSerializer());
+        o = mapSerializer.read(buffer);
+      } finally {
+        // Some mmapSerializer may overwrite write/read method, then clear serializer
+        // may not got invoked.
+        mapSerializer.setKeySerializer(null);
+      }
     } else {
       Preconditions.checkArgument(fieldType == FieldTypes.MAP_VALUE_FINAL);
       ClassInfo valueClassInfo = classResolver.readClassInfo(buffer, classInfoHolder);
       ClassInfo classInfo = classResolver.readClassInfo(buffer, classInfoHolder);
       MapSerializer mapSerializer = (MapSerializer) classInfo.getSerializer();
-      mapSerializer.setValueSerializer(valueClassInfo.getSerializer());
-      o = mapSerializer.read(buffer);
-      // Some mmapSerializer may overwrite write/read method, then clear serializer
-      // may not got invoked.
-      mapSerializer.setValueSerializer(null);
+      try {
+        mapSerializer.setValueSerializer(valueClassInfo.getSerializer());
+        o = mapSerializer.read(buffer);
+      } finally {
+        // Some mmapSerializer may overwrite write/read method, then clear serializer
+        // may not got invoked.
+        mapSerializer.setValueSerializer(null);
+      }
     }
     return o;
   }
@@ -614,42 +626,54 @@ public class FieldResolver {
       ClassInfo elementClassInfo = classResolver.readClassInfo(buffer, classInfoHolder);
       ClassInfo classInfo = classResolver.readClassInfo(buffer, fieldInfo.getClassInfoHolder());
       CollectionSerializer collectionSerializer = (CollectionSerializer) classInfo.getSerializer();
-      collectionSerializer.setElementSerializer(elementClassInfo.getSerializer());
-      o = collectionSerializer.read(buffer);
-      // Some collectionSerializer may overwrite write/read method, then clear element serializer
-      // may not got invoked.
-      collectionSerializer.setElementSerializer(null);
+      try {
+        collectionSerializer.setElementSerializer(elementClassInfo.getSerializer());
+        o = collectionSerializer.read(buffer);
+        // Some collectionSerializer may overwrite write/read method, then clear element serializer
+        // may not got invoked.
+      } finally {
+        collectionSerializer.setElementSerializer(null);
+      }
     } else if (fieldType == FieldTypes.MAP_KV_FINAL) {
       ClassInfo keyClassInfo = classResolver.readClassInfo(buffer, classInfoHolder);
       ClassInfo valueClassInfo = classResolver.readClassInfo(buffer, classInfoHolder);
       ClassInfo classInfo = classResolver.readClassInfo(buffer, fieldInfo.getClassInfoHolder());
       MapSerializer mapSerializer = (MapSerializer) classInfo.getSerializer();
-      mapSerializer.setKeySerializer(keyClassInfo.getSerializer());
-      mapSerializer.setValueSerializer(valueClassInfo.getSerializer());
-      o = mapSerializer.read(buffer);
-      // Some mmapSerializer may overwrite write/read method, then clear serializer
-      // may not got invoked.
-      mapSerializer.setKeySerializer(null);
-      mapSerializer.setValueSerializer(null);
+      try {
+        mapSerializer.setKeySerializer(keyClassInfo.getSerializer());
+        mapSerializer.setValueSerializer(valueClassInfo.getSerializer());
+        o = mapSerializer.read(buffer);
+      } finally {
+        // Some mmapSerializer may overwrite write/read method, then clear serializer
+        // may not got invoked.
+        mapSerializer.setKeySerializer(null);
+        mapSerializer.setValueSerializer(null);
+      }
     } else if (fieldType == FieldTypes.MAP_KEY_FINAL) {
       ClassInfo keyClassInfo = classResolver.readClassInfo(buffer, classInfoHolder);
       ClassInfo classInfo = classResolver.readClassInfo(buffer, fieldInfo.getClassInfoHolder());
       MapSerializer mapSerializer = (MapSerializer) classInfo.getSerializer();
-      mapSerializer.setKeySerializer(keyClassInfo.getSerializer());
-      o = mapSerializer.read(buffer);
-      // Some mmapSerializer may overwrite write/read method, then clear serializer
-      // may not got invoked.
-      mapSerializer.setKeySerializer(null);
+      try {
+        mapSerializer.setKeySerializer(keyClassInfo.getSerializer());
+        o = mapSerializer.read(buffer);
+        // Some mmapSerializer may overwrite write/read method, then clear serializer
+        // may not got invoked.
+      } finally {
+        mapSerializer.setKeySerializer(null);
+      }
     } else {
       Preconditions.checkArgument(fieldType == FieldTypes.MAP_VALUE_FINAL);
       ClassInfo valueClassInfo = classResolver.readClassInfo(buffer, classInfoHolder);
       ClassInfo classInfo = classResolver.readClassInfo(buffer, fieldInfo.getClassInfoHolder());
       MapSerializer mapSerializer = (MapSerializer) classInfo.getSerializer();
-      mapSerializer.setValueSerializer(valueClassInfo.getSerializer());
-      o = mapSerializer.read(buffer);
-      // Some mmapSerializer may overwrite write/read method, then clear serializer
-      // may not got invoked.
-      mapSerializer.setValueSerializer(null);
+      try {
+        mapSerializer.setValueSerializer(valueClassInfo.getSerializer());
+        o = mapSerializer.read(buffer);
+        // Some mmapSerializer may overwrite write/read method, then clear serializer
+        // may not got invoked.
+      } finally {
+        mapSerializer.setValueSerializer(null);
+      }
     }
     return o;
   }
@@ -994,5 +1018,10 @@ public class FieldResolver {
     public Class<?> getValueType() {
       return valueType;
     }
+  }
+
+  public static void main(String[] args) {
+    System.out.println(computeStringHash("list0") << 2);
+    System.out.println(computeStringHash("serializeListLast") << 2);
   }
 }

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/CompatibleSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/CompatibleSerializer.java
@@ -242,11 +242,14 @@ public final class CompatibleSerializer<T> extends CompatibleSerializerBase<T> {
     ClassInfo classInfo = fieldInfo.getClassInfo(fieldValue.getClass());
     classResolver.writeClass(buffer, classInfo);
     CollectionSerializer collectionSerializer = (CollectionSerializer) classInfo.getSerializer();
-    collectionSerializer.setElementSerializer(elementClassInfo.getSerializer());
-    collectionSerializer.write(buffer, fieldValue);
-    // Some collectionSerializer may overwrite write/read method, then clear element serializer
-    // may not got invoked.
-    collectionSerializer.setElementSerializer(null);
+    try {
+      collectionSerializer.setElementSerializer(elementClassInfo.getSerializer());
+      collectionSerializer.write(buffer, fieldValue);
+    } finally {
+      // Some collectionSerializer may overwrite write/read method, then clear element serializer
+      // may not got invoked.
+      collectionSerializer.setElementSerializer(null);
+    }
   }
 
   private void writeMapKVFinal(
@@ -259,13 +262,16 @@ public final class CompatibleSerializer<T> extends CompatibleSerializerBase<T> {
     ClassInfo classInfo = fieldInfo.getClassInfo(fieldValue.getClass());
     classResolver.writeClass(buffer, classInfo);
     MapSerializer mapSerializer = (MapSerializer) classInfo.getSerializer();
-    mapSerializer.setKeySerializer(keyClassInfo.getSerializer());
-    mapSerializer.setValueSerializer(valueClassInfo.getSerializer());
-    mapSerializer.write(buffer, fieldValue);
-    // Some mmapSerializer may overwrite write/read method, then clear serializer
-    // may not got invoked.
-    mapSerializer.setKeySerializer(null);
-    mapSerializer.setValueSerializer(null);
+    try {
+      mapSerializer.setKeySerializer(keyClassInfo.getSerializer());
+      mapSerializer.setValueSerializer(valueClassInfo.getSerializer());
+      mapSerializer.write(buffer, fieldValue);
+    } finally {
+      // Some mmapSerializer may overwrite write/read method, then clear serializer
+      // may not got invoked.
+      mapSerializer.setKeySerializer(null);
+      mapSerializer.setValueSerializer(null);
+    }
   }
 
   private void writeMapKeyFinal(
@@ -276,11 +282,14 @@ public final class CompatibleSerializer<T> extends CompatibleSerializerBase<T> {
     ClassInfo classInfo = fieldInfo.getClassInfo(fieldValue.getClass());
     classResolver.writeClass(buffer, classInfo);
     MapSerializer mapSerializer = (MapSerializer) classInfo.getSerializer();
-    mapSerializer.setKeySerializer(keyClassInfo.getSerializer());
-    mapSerializer.write(buffer, fieldValue);
-    // Some mmapSerializer may overwrite write/read method, then clear serializer
-    // may not got invoked.
-    mapSerializer.setKeySerializer(null);
+    try {
+      mapSerializer.setKeySerializer(keyClassInfo.getSerializer());
+      mapSerializer.write(buffer, fieldValue);
+    } finally {
+      // Some mmapSerializer may overwrite write/read method, then clear serializer
+      // may not got invoked.
+      mapSerializer.setKeySerializer(null);
+    }
   }
 
   private void writeMapValueFinal(
@@ -291,11 +300,14 @@ public final class CompatibleSerializer<T> extends CompatibleSerializerBase<T> {
     ClassInfo classInfo = fieldInfo.getClassInfo(fieldValue.getClass());
     classResolver.writeClass(buffer, classInfo);
     MapSerializer mapSerializer = (MapSerializer) classInfo.getSerializer();
-    mapSerializer.setValueSerializer(valueClassInfo.getSerializer());
-    mapSerializer.write(buffer, fieldValue);
-    // Some mmapSerializer may overwrite write/read method, then clear serializer
-    // may not got invoked.
-    mapSerializer.setValueSerializer(null);
+    try {
+      mapSerializer.setValueSerializer(valueClassInfo.getSerializer());
+      mapSerializer.write(buffer, fieldValue);
+    } finally {
+      // Some mmapSerializer may overwrite write/read method, then clear serializer
+      // may not got invoked.
+      mapSerializer.setValueSerializer(null);
+    }
   }
 
   @SuppressWarnings("unchecked")

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/CompatibleSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/CompatibleSerializer.java
@@ -244,6 +244,9 @@ public final class CompatibleSerializer<T> extends CompatibleSerializerBase<T> {
     CollectionSerializer collectionSerializer = (CollectionSerializer) classInfo.getSerializer();
     collectionSerializer.setElementSerializer(elementClassInfo.getSerializer());
     collectionSerializer.write(buffer, fieldValue);
+    // Some collectionSerializer may overwrite write/read method, then clear element serializer
+    // may not got invoked.
+    collectionSerializer.setElementSerializer(null);
   }
 
   private void writeMapKVFinal(
@@ -259,6 +262,10 @@ public final class CompatibleSerializer<T> extends CompatibleSerializerBase<T> {
     mapSerializer.setKeySerializer(keyClassInfo.getSerializer());
     mapSerializer.setValueSerializer(valueClassInfo.getSerializer());
     mapSerializer.write(buffer, fieldValue);
+    // Some mmapSerializer may overwrite write/read method, then clear serializer
+    // may not got invoked.
+    mapSerializer.setKeySerializer(null);
+    mapSerializer.setValueSerializer(null);
   }
 
   private void writeMapKeyFinal(
@@ -271,6 +278,9 @@ public final class CompatibleSerializer<T> extends CompatibleSerializerBase<T> {
     MapSerializer mapSerializer = (MapSerializer) classInfo.getSerializer();
     mapSerializer.setKeySerializer(keyClassInfo.getSerializer());
     mapSerializer.write(buffer, fieldValue);
+    // Some mmapSerializer may overwrite write/read method, then clear serializer
+    // may not got invoked.
+    mapSerializer.setKeySerializer(null);
   }
 
   private void writeMapValueFinal(
@@ -283,6 +293,9 @@ public final class CompatibleSerializer<T> extends CompatibleSerializerBase<T> {
     MapSerializer mapSerializer = (MapSerializer) classInfo.getSerializer();
     mapSerializer.setValueSerializer(valueClassInfo.getSerializer());
     mapSerializer.write(buffer, fieldValue);
+    // Some mmapSerializer may overwrite write/read method, then clear serializer
+    // may not got invoked.
+    mapSerializer.setValueSerializer(null);
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION

## What does this PR do?
Some collectionSerializer may overwrite write/read method, then clear element serializer may not got invoked.

This PR clears serializer for collection/map to avoid container use wrong serializer for nested elements.

## Related issues

#1558
https://github.com/apache/incubator-fury/issues/1455, https://github.com/apache/incubator-fury/issues/1325 and https://github.com/apache/incubator-fury/issues/1176.

## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/incubator-fury/issues/new/choose) describing the need to do so and update the document if necessary.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?


## Benchmark

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.
-->
