### PR TITLE
refactor(java): Remove Guava's Concurrency utils usages

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -220,6 +220,7 @@ The text of each license is the standard Apache 2.0 license.
       java/fury-core/src/main/java/org/apache/fury/reflect/TypeParameter.java
       java/fury-core/src/main/java/org/apache/fury/reflect/Types.java
       java/fury-core/src/main/java/org/apache/fury/reflect/TypeRef.java
+      java/fury-core/src/main/java/org/apache/fury/util/concurrency/DirectExecutorService.java
 
 * spark (https://github.com/apache/spark)
     Files:

--- a/java/fury-core/src/main/java/org/apache/fury/util/concurrency/DirectExecutorService.java
+++ b/java/fury-core/src/main/java/org/apache/fury/util/concurrency/DirectExecutorService.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2007 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.fury.util.concurrency;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+
+// Mostly derived from Guava 32.1.2
+// com.google.common.util.concurrent.MoreExecutors.DirectExecutorService
+// https://github.com/google/guava/blob/9f6a3840/guava/src/com/google/common/util/concurrent/MoreExecutors.java
+public class DirectExecutorService extends AbstractExecutorService {
+  private final Object lock = new Object();
+  private int runningTasks = 0;
+  private boolean shutdown = false;
+
+  @Override
+  public void execute(Runnable command) {
+    synchronized (lock) {
+      if (shutdown) {
+        throw new RejectedExecutionException("Executor already shutdown");
+      }
+      runningTasks++;
+    }
+    try {
+      command.run();
+    } finally {
+      synchronized (lock) {
+        int numRunning = --runningTasks;
+        if (numRunning == 0) {
+          lock.notifyAll();
+        }
+      }
+    }
+  }
+
+  @Override
+  public boolean isShutdown() {
+    synchronized (lock) {
+      return shutdown;
+    }
+  }
+
+  @Override
+  public void shutdown() {
+    synchronized (lock) {
+      shutdown = true;
+      if (runningTasks == 0) {
+        lock.notifyAll();
+      }
+    }
+  }
+
+  @Override
+  public List<Runnable> shutdownNow() {
+    shutdown();
+    return Collections.emptyList();
+  }
+
+  @Override
+  public boolean isTerminated() {
+    synchronized (lock) {
+      return shutdown && runningTasks == 0;
+    }
+  }
+
+  @Override
+  public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+    long nanos = unit.toNanos(timeout);
+    synchronized (lock) {
+      while (true) {
+        if (shutdown && runningTasks == 0) {
+          return true;
+        } else if (nanos <= 0) {
+          return false;
+        } else {
+          long now = System.nanoTime();
+          TimeUnit.NANOSECONDS.timedWait(lock, nanos);
+          nanos -= System.nanoTime() - now; // subtract the actual time we waited
+        }
+      }
+    }
+  }
+}

--- a/java/fury-core/src/main/java/org/apache/fury/util/concurrency/FuryJitCompilerThreadFactory.java
+++ b/java/fury-core/src/main/java/org/apache/fury/util/concurrency/FuryJitCompilerThreadFactory.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fury.util.concurrency;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class FuryJitCompilerThreadFactory implements ThreadFactory {
+  private final ThreadFactory backingThreadFactory = Executors.defaultThreadFactory();
+  private final AtomicInteger threadNumber = new AtomicInteger(0);
+
+  @Override
+  public Thread newThread(Runnable task) {
+    Thread thread = backingThreadFactory.newThread(task);
+    thread.setName("fury-jit-compiler-" + threadNumber.incrementAndGet());
+    return thread;
+  }
+}

--- a/java/fury-core/src/main/resources/META-INF/LICENSE
+++ b/java/fury-core/src/main/resources/META-INF/LICENSE
@@ -220,6 +220,7 @@ The text of each license is the standard Apache 2.0 license.
       java/fury-core/src/main/java/org/apache/fury/reflect/TypeParameter.java
       java/fury-core/src/main/java/org/apache/fury/reflect/Types.java
       java/fury-core/src/main/java/org/apache/fury/reflect/TypeRef.java
+      java/fury-core/src/main/java/org/apache/fury/util/concurrency/DirectExecutorService.java
 
 * spark (https://github.com/apache/spark)
     Files:

--- a/licenserc.toml
+++ b/licenserc.toml
@@ -48,6 +48,7 @@ excludes = [
     "java/fury-core/src/main/java/org/apache/fury/reflect/Types.java",
     "java/fury-core/src/main/java/org/apache/fury/type/Generics.java",
     "java/fury-core/src/main/java/org/apache/fury/util/MurmurHash3.java",
+    "java/fury-core/src/main/java/org/apache/fury/util/concurrency/DirectExecutorService.java",
     "java/fury-core/src/main/java/org/apache/fury/memory/Platform.java",
     "java/fury-core/src/main/java/org/apache/fury/util/Preconditions.java",
     "java/fury-core/src/test/java/org/apache/fury/type/GenericsTest.java",


### PR DESCRIPTION
<!--
**Thanks for contributing to Fury.**

**If this is your first time opening a PR on fury, you can refer to [CONTRIBUTING.md](https://github.com/apache/incubator-fury/blob/main/CONTRIBUTING.md).**

Contribution Checklist

    - The **Apache Fury (incubating)** community has restrictions on the naming of pr titles. You can also find instructions in [CONTRIBUTING.md](https://github.com/apache/incubator-fury/blob/main/CONTRIBUTING.md).

    - Fury has a strong focus on performance. If the PR you submit will have an impact on performance, please benchmark it first and provide the benchmark result here.
-->

## What does this PR do?

Removes Guava's Concurrency utils usages

## Related issues

#1113


## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/incubator-fury/issues/new/choose) describing the need to do so and update the document if necessary.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?




<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.
-->
