### PR TITLE
feat(java): add set serializer for concurrent set

### DIFF
--- a/integration_tests/graalvm_tests/src/main/java/org/apache/fury/graalvm/Collection.java
+++ b/integration_tests/graalvm_tests/src/main/java/org/apache/fury/graalvm/Collection.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fury.graalvm;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.fury.Fury;
+import org.apache.fury.util.Preconditions;
+
+public class Collection {
+  static Fury fury;
+
+  static {
+    fury = Fury.builder().requireClassRegistration(true).build();
+  }
+
+  static void test(Fury fury) {
+    final Map<String, String> unmodifiableMap = Map.of("k1", "v1", "k2", "v2");
+    Preconditions.checkArgument(
+        unmodifiableMap.equals(fury.deserialize(fury.serialize(unmodifiableMap))));
+    System.out.println(unmodifiableMap);
+    final List<Integer> arrayasList = Arrays.asList(1, 2, 3);
+    Preconditions.checkArgument(arrayasList.equals(fury.deserialize(fury.serialize(arrayasList))));
+    System.out.println(arrayasList);
+    final Set<String> setFromMap = Collections.newSetFromMap(new ConcurrentHashMap<>());
+    setFromMap.add("a");
+    setFromMap.add("b");
+    setFromMap.add("c");
+    Preconditions.checkArgument(setFromMap.equals(fury.deserialize(fury.serialize(setFromMap))));
+    System.out.println(setFromMap);
+  }
+
+  public static void main(String[] args) {
+    test(fury);
+    System.out.println("Collection succeed");
+  }
+}

--- a/integration_tests/graalvm_tests/src/main/java/org/apache/fury/graalvm/CollectionExample.java
+++ b/integration_tests/graalvm_tests/src/main/java/org/apache/fury/graalvm/CollectionExample.java
@@ -28,7 +28,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.apache.fury.Fury;
 import org.apache.fury.util.Preconditions;
 
-public class Collection {
+public class CollectionExample {
   static Fury fury;
 
   static {

--- a/integration_tests/graalvm_tests/src/main/java/org/apache/fury/graalvm/Main.java
+++ b/integration_tests/graalvm_tests/src/main/java/org/apache/fury/graalvm/Main.java
@@ -34,5 +34,6 @@ public class Main {
     CompatibleThreadSafeExample.main(args);
     ProxyExample.main(args);
     Benchmark.main(args);
+    Collection.main(args);
   }
 }

--- a/integration_tests/graalvm_tests/src/main/java/org/apache/fury/graalvm/Main.java
+++ b/integration_tests/graalvm_tests/src/main/java/org/apache/fury/graalvm/Main.java
@@ -34,6 +34,6 @@ public class Main {
     CompatibleThreadSafeExample.main(args);
     ProxyExample.main(args);
     Benchmark.main(args);
-    Collection.main(args);
+    CollectionExample.main(args);
   }
 }

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/ArraySerializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/ArraySerializers.java
@@ -647,17 +647,20 @@ public class ArraySerializers {
     fury.registerSerializer(byte[].class, new ByteArraySerializer(fury));
     fury.registerSerializer(Byte[].class, new ObjectArraySerializer<>(fury, Byte[].class));
     fury.registerSerializer(char[].class, new CharArraySerializer(fury));
+    fury.registerSerializer(
+        Character[].class, new ObjectArraySerializer<>(fury, Character[].class));
     fury.registerSerializer(short[].class, new ShortArraySerializer(fury));
     fury.registerSerializer(Short[].class, new ObjectArraySerializer<>(fury, Short[].class));
     fury.registerSerializer(int[].class, new IntArraySerializer(fury));
     fury.registerSerializer(Integer[].class, new ObjectArraySerializer<>(fury, Integer[].class));
     fury.registerSerializer(long[].class, new LongArraySerializer(fury));
-    fury.registerSerializer(Float[].class, new ObjectArraySerializer<>(fury, Float[].class));
+    fury.registerSerializer(Long[].class, new ObjectArraySerializer<>(fury, Long[].class));
     fury.registerSerializer(float[].class, new FloatArraySerializer(fury));
-    fury.registerSerializer(Double[].class, new ObjectArraySerializer<>(fury, Double[].class));
+    fury.registerSerializer(Float[].class, new ObjectArraySerializer<>(fury, Float[].class));
     fury.registerSerializer(double[].class, new DoubleArraySerializer(fury));
-    fury.registerSerializer(Boolean[].class, new ObjectArraySerializer<>(fury, Boolean[].class));
+    fury.registerSerializer(Double[].class, new ObjectArraySerializer<>(fury, Double[].class));
     fury.registerSerializer(boolean[].class, new BooleanArraySerializer(fury));
+    fury.registerSerializer(Boolean[].class, new ObjectArraySerializer<>(fury, Boolean[].class));
     fury.registerSerializer(String[].class, new StringArraySerializer(fury));
   }
 

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/ArraySerializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/ArraySerializers.java
@@ -645,12 +645,18 @@ public class ArraySerializers {
     fury.registerSerializer(Object[].class, new ObjectArraySerializer<>(fury, Object[].class));
     fury.registerSerializer(Class[].class, new ObjectArraySerializer<>(fury, Class[].class));
     fury.registerSerializer(byte[].class, new ByteArraySerializer(fury));
+    fury.registerSerializer(Byte[].class, new ObjectArraySerializer<>(fury, Byte[].class));
     fury.registerSerializer(char[].class, new CharArraySerializer(fury));
     fury.registerSerializer(short[].class, new ShortArraySerializer(fury));
+    fury.registerSerializer(Short[].class, new ObjectArraySerializer<>(fury, Short[].class));
     fury.registerSerializer(int[].class, new IntArraySerializer(fury));
+    fury.registerSerializer(Integer[].class, new ObjectArraySerializer<>(fury, Integer[].class));
     fury.registerSerializer(long[].class, new LongArraySerializer(fury));
+    fury.registerSerializer(Float[].class, new ObjectArraySerializer<>(fury, Float[].class));
     fury.registerSerializer(float[].class, new FloatArraySerializer(fury));
+    fury.registerSerializer(Double[].class, new ObjectArraySerializer<>(fury, Double[].class));
     fury.registerSerializer(double[].class, new DoubleArraySerializer(fury));
+    fury.registerSerializer(Boolean[].class, new ObjectArraySerializer<>(fury, Boolean[].class));
     fury.registerSerializer(boolean[].class, new BooleanArraySerializer(fury));
     fury.registerSerializer(String[].class, new StringArraySerializer(fury));
   }

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/collection/CollectionSerializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/collection/CollectionSerializers.java
@@ -49,7 +49,6 @@ import org.apache.fury.exception.FuryException;
 import org.apache.fury.memory.MemoryBuffer;
 import org.apache.fury.memory.Platform;
 import org.apache.fury.reflect.ReflectionUtils;
-import org.apache.fury.resolver.ClassInfo;
 import org.apache.fury.resolver.ClassResolver;
 import org.apache.fury.serializer.ReplaceResolveSerializer;
 import org.apache.fury.serializer.Serializer;
@@ -419,10 +418,14 @@ public class CollectionSerializers {
 
     private static final long MAP_FIELD_OFFSET;
 
+    private static final long SET_FIELD_OFFSET;
+
     static {
       try {
         Field mapField = Class.forName("java.util.Collections$SetFromMap").getDeclaredField("m");
         MAP_FIELD_OFFSET = Platform.objectFieldOffset(mapField);
+        Field setField = Class.forName("java.util.Collections$SetFromMap").getDeclaredField("s");
+        SET_FIELD_OFFSET = Platform.objectFieldOffset(setField);
       } catch (final Exception e) {
         throw new RuntimeException(e);
       }
@@ -433,28 +436,18 @@ public class CollectionSerializers {
     }
 
     @Override
-    public Collection newCollection(MemoryBuffer buffer) {
-      int numElements = buffer.readVarUint32Small7();
-      setNumElements(numElements);
-      final ClassInfo mapClassInfo = fury.getClassResolver().readClassInfo(buffer);
-      final MethodHandle methodHandle = ReflectionUtils.getCtrHandle(mapClassInfo.getCls(), true);
-      Map map;
-      try {
-        map = (Map) methodHandle.invoke();
-      } catch (Throwable e) {
-        throw new RuntimeException(e);
-      }
-      final Set set = Collections.newSetFromMap(map);
-      fury.getRefResolver().reference(set);
-      return set;
+    public void write(MemoryBuffer buffer, Set value) {
+      final Map<?, Boolean> map = (Map<?, Boolean>) Platform.getObject(value, MAP_FIELD_OFFSET);
+      fury.writeRef(buffer, map);
     }
 
     @Override
-    public Collection onCollectionWrite(MemoryBuffer buffer, Set<?> value) {
-      buffer.writeVarUint32Small7(value.size());
-      final Map<?, Boolean> map = (Map<?, Boolean>) Platform.getObject(value, MAP_FIELD_OFFSET);
-      fury.getClassResolver().writeClassAndUpdateCache(buffer, map.getClass());
-      return value;
+    public Set<?> read(MemoryBuffer buffer) {
+      final Map<?, Boolean> map = (Map<?, Boolean>) fury.readRef(buffer);
+      final Set<?> set = Collections.newSetFromMap(Collections.emptyMap());
+      Platform.putObject(set, MAP_FIELD_OFFSET, map);
+      Platform.putObject(set, SET_FIELD_OFFSET, map.keySet());
+      return set;
     }
   }
 

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/collection/CollectionSerializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/collection/CollectionSerializers.java
@@ -448,7 +448,8 @@ public class CollectionSerializers {
     @Override
     public Collection onCollectionWrite(MemoryBuffer buffer, Set<?> value) {
       final Map<?, Boolean> map = (Map<?, Boolean>) Platform.getObject(value, MAP_FIELD_OFFSET);
-      fury.getClassResolver().writeClassAndUpdateCache(buffer, map.getClass());
+      final ClassInfo classInfo = fury.getClassResolver().getClassInfo(map.getClass());
+      fury.getClassResolver().writeClass(buffer, classInfo);
       // newMap will read num size first.
       buffer.writeVarUint32Small7(value.size());
       return value;

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/collection/CollectionSerializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/collection/CollectionSerializers.java
@@ -419,14 +419,10 @@ public class CollectionSerializers {
 
     private static final long MAP_FIELD_OFFSET;
 
-    private static final long SET_FIELD_OFFSET;
-
     static {
       try {
         Field mapField = Class.forName("java.util.Collections$SetFromMap").getDeclaredField("m");
         MAP_FIELD_OFFSET = Platform.objectFieldOffset(mapField);
-        Field setField = Class.forName("java.util.Collections$SetFromMap").getDeclaredField("s");
-        SET_FIELD_OFFSET = Platform.objectFieldOffset(setField);
       } catch (final Exception e) {
         throw new RuntimeException(e);
       }

--- a/java/fury-core/src/main/resources/META-INF/native-image/org.apache.fury/fury-core/native-image.properties
+++ b/java/fury-core/src/main/resources/META-INF/native-image/org.apache.fury/fury-core/native-image.properties
@@ -171,5 +171,4 @@ Args=--initialize-at-build-time=org.apache.fury.memory.MemoryBuffer,\
     org.apache.fury.reflect.Types$ClassOwnership,\
     org.apache.fury.reflect.Types$ClassOwnership$1,\
     org.apache.fury.reflect.Types$ClassOwnership$2,\
-    org.apache.fury.resolver.DisallowedList,\
-  org.apache.fury.util.LoaderBinding$1
+    org.apache.fury.resolver.DisallowedList,

--- a/java/fury-core/src/main/resources/META-INF/native-image/org.apache.fury/fury-core/native-image.properties
+++ b/java/fury-core/src/main/resources/META-INF/native-image/org.apache.fury/fury-core/native-image.properties
@@ -136,7 +136,7 @@ Args=--initialize-at-build-time=org.apache.fury.memory.MemoryBuffer,\
     org.apache.fury.memory.BoundsChecking,\
     org.apache.fury.shaded.org.codehaus.janino.Java$Package,\
     org.apache.fury.serializer.ArraySerializers,\
-    org.apache.fury.serializer.ArraySerializers.ObjectArraySerializer.ObjectArraySerializer,\
+    org.apache.fury.serializer.ArraySerializers$ObjectArraySerializer,\
     org.apache.fury.shaded.org.codehaus.janino.Java$AccessModifier,\
     org.apache.fury.util.ClassLoaderUtils$ParentClassLoader,\
     com.google.common.collect.RegularImmutableSortedSet,\

--- a/java/fury-core/src/main/resources/META-INF/native-image/org.apache.fury/fury-core/native-image.properties
+++ b/java/fury-core/src/main/resources/META-INF/native-image/org.apache.fury/fury-core/native-image.properties
@@ -136,6 +136,7 @@ Args=--initialize-at-build-time=org.apache.fury.memory.MemoryBuffer,\
     org.apache.fury.memory.BoundsChecking,\
     org.apache.fury.shaded.org.codehaus.janino.Java$Package,\
     org.apache.fury.serializer.ArraySerializers,\
+    org.apache.fury.serializer.ArraySerializers.ObjectArraySerializer.ObjectArraySerializer,\
     org.apache.fury.shaded.org.codehaus.janino.Java$AccessModifier,\
     org.apache.fury.util.ClassLoaderUtils$ParentClassLoader,\
     com.google.common.collect.RegularImmutableSortedSet,\

--- a/java/fury-core/src/main/resources/META-INF/native-image/org.apache.fury/fury-core/native-image.properties
+++ b/java/fury-core/src/main/resources/META-INF/native-image/org.apache.fury/fury-core/native-image.properties
@@ -171,4 +171,5 @@ Args=--initialize-at-build-time=org.apache.fury.memory.MemoryBuffer,\
     org.apache.fury.reflect.Types$ClassOwnership,\
     org.apache.fury.reflect.Types$ClassOwnership$1,\
     org.apache.fury.reflect.Types$ClassOwnership$2,\
-    org.apache.fury.resolver.DisallowedList
+    org.apache.fury.resolver.DisallowedList,\
+  org.apache.fury.util.LoaderBinding$1

--- a/java/fury-core/src/main/resources/META-INF/native-image/org.apache.fury/fury-core/native-image.properties
+++ b/java/fury-core/src/main/resources/META-INF/native-image/org.apache.fury/fury-core/native-image.properties
@@ -171,4 +171,4 @@ Args=--initialize-at-build-time=org.apache.fury.memory.MemoryBuffer,\
     org.apache.fury.reflect.Types$ClassOwnership,\
     org.apache.fury.reflect.Types$ClassOwnership$1,\
     org.apache.fury.reflect.Types$ClassOwnership$2,\
-    org.apache.fury.resolver.DisallowedList,
+    org.apache.fury.resolver.DisallowedList

--- a/java/fury-core/src/main/resources/META-INF/native-image/org.apache.fury/fury-core/native-image.properties
+++ b/java/fury-core/src/main/resources/META-INF/native-image/org.apache.fury/fury-core/native-image.properties
@@ -22,7 +22,7 @@ Args=--initialize-at-build-time=org.apache.fury.memory.MemoryBuffer,\
     org.apache.fury.serializer.collection.UnmodifiableSerializers$Offset,\
     org.apache.fury.serializer.collection.SynchronizedSerializers$Offset,\
     org.apache.fury.serializer.collection.CollectionSerializers$ArraysAsListSerializer,\
-    org.apache.fury.serializer.collection.CollectionSerializers$CopyOnWriteArrayListSerializer,\
+    org.apache.fury.serializer.collection.CollectionSerializers$SetFromMapSerializer,\
     org.apache.fury.serializer.collection.MapSerializers$EnumMapSerializer,\
     org.apache.fury.serializer.JdkProxySerializer,\
     org.apache.fury.serializer.StringSerializer$Offset,\

--- a/java/fury-core/src/test/java/org/apache/fury/serializer/collection/CollectionSerializersTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/serializer/collection/CollectionSerializersTest.java
@@ -276,13 +276,19 @@ public class CollectionSerializersTest extends FuryTestBase {
         CollectionSerializers.CopyOnWriteArrayListSerializer.class);
   }
 
-  @Test
-  public void testSetFromMap() {
+  @Test(dataProvider = "enableCodegen")
+  public void testSetFromMap(boolean enableCodegen) {
+    final Fury fury =
+        Fury.builder()
+            .withLanguage(Language.JAVA)
+            .requireClassRegistration(false)
+            .withCodegen(enableCodegen)
+            .build();
     final Set<String> set = Collections.newSetFromMap(Maps.newConcurrentMap());
     set.add("a");
     set.add("b");
     set.add("c");
-    Assert.assertEquals(set, serDe(getJavaFury(), set));
+    Assert.assertEquals(set, serDe(fury, set));
     Assert.assertEquals(
         getJavaFury().getClassResolver().getSerializerClass(set.getClass()),
         CollectionSerializers.SetFromMapSerializer.class);

--- a/java/fury-core/src/test/java/org/apache/fury/serializer/collection/CollectionSerializersTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/serializer/collection/CollectionSerializersTest.java
@@ -51,6 +51,7 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.Vector;
 import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -67,6 +68,7 @@ import org.apache.fury.serializer.collection.CollectionSerializers.JDKCompatible
 import org.apache.fury.type.GenericType;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+import org.testng.collections.Maps;
 
 public class CollectionSerializersTest extends FuryTestBase {
 
@@ -272,6 +274,30 @@ public class CollectionSerializersTest extends FuryTestBase {
     Assert.assertEquals(
         getJavaFury().getClassResolver().getSerializerClass(CopyOnWriteArrayList.class),
         CollectionSerializers.CopyOnWriteArrayListSerializer.class);
+  }
+
+  @Test
+  public void testSetFromMap() {
+    final Set<String> set = Collections.newSetFromMap(Maps.newConcurrentMap());
+    set.add("a");
+    set.add("b");
+    set.add("c");
+    Assert.assertEquals(set, serDe(getJavaFury(), set));
+    Assert.assertEquals(
+        getJavaFury().getClassResolver().getSerializerClass(set.getClass()),
+        CollectionSerializers.SetFromMapSerializer.class);
+  }
+
+  @Test
+  public void testConcurrentMapKeySetViewMap() {
+    final ConcurrentHashMap.KeySetView<Object, Boolean> set = ConcurrentHashMap.newKeySet();
+    set.add("a");
+    set.add("b");
+    set.add("c");
+    Assert.assertEquals(set, serDe(getJavaFury(), set));
+    Assert.assertEquals(
+        getJavaFury().getClassResolver().getSerializerClass(set.getClass()),
+        CollectionSerializers.ConcurrentHashMapKeySetView.class);
   }
 
   @Test


### PR DESCRIPTION
<!--
**Thanks for contributing to Fury.**

**If this is your first time opening a PR on fury, you can refer to [CONTRIBUTING.md](https://github.com/apache/incubator-fury/blob/main/CONTRIBUTING.md).**

Contribution Checklist

    - The **Apache Fury (incubating)** community has restrictions on the naming of pr titles. You can also find instructions in [CONTRIBUTING.md](https://github.com/apache/incubator-fury/blob/main/CONTRIBUTING.md).

    - Fury has a strong focus on performance. If the PR you submit will have an impact on performance, please benchmark it first and provide the benchmark result here.
-->

## What does this PR do?

<!-- Describe the purpose of this PR. -->

we use `Sets.newConcurrentHashSet()`  to create set, with lastest guava version it use `ConcurrentHashMapKeySetView` and old version it use `Collections.newSetFromMap(map)`. 

remove `CopyOnWriteArrayListSerializer` from native-image.properties.  #1614 forget delete.

## Related issues

<!--
Is there any related issue? Please attach here.

- #xxxx0
- #xxxx1
- #xxxx2
-->


## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/incubator-fury/issues/new/choose) describing the need to do so and update the document if necessary.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?


## Benchmark

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.
-->
