### PR TITLE
feat(go/java): Add ASCII check before meta string encoding

### DIFF
--- a/go/fury/meta/meta_string_encoder.go
+++ b/go/fury/meta/meta_string_encoder.go
@@ -36,16 +36,13 @@ func NewEncoder(specialCh1 byte, specialCh2 byte) *Encoder {
 
 // Encode the input string to MetaString using adaptive encoding
 func (e *Encoder) Encode(input string) (MetaString, error) {
-	if !isASCII(input) {
-	    return MetaString{}, errors.New("non-ASCII characters in meta string are not allowed")
-	}
 	encoding := e.ComputeEncoding(input)
 	return e.EncodeWithEncoding(input, encoding)
 }
 
 // EncodeWithEncoding Encodes the input string to MetaString using specified encoding.
 func (e *Encoder) EncodeWithEncoding(input string, encoding Encoding) (MetaString, error) {
-	if !isASCII(input) {
+	if encoding != UTF_8 && !isASCII(input) {
 	    return MetaString{}, errors.New("non-ASCII characters in meta string are not allowed")
 	}
 	if len(input) > 32767 {

--- a/go/fury/meta/meta_string_encoder.go
+++ b/go/fury/meta/meta_string_encoder.go
@@ -36,12 +36,18 @@ func NewEncoder(specialCh1 byte, specialCh2 byte) *Encoder {
 
 // Encode the input string to MetaString using adaptive encoding
 func (e *Encoder) Encode(input string) (MetaString, error) {
+	if !isASCII(input) {
+	    return MetaString{}, errors.New("non-ASCII characters in meta string are not allowed")
+	}
 	encoding := e.ComputeEncoding(input)
 	return e.EncodeWithEncoding(input, encoding)
 }
 
 // EncodeWithEncoding Encodes the input string to MetaString using specified encoding.
 func (e *Encoder) EncodeWithEncoding(input string, encoding Encoding) (MetaString, error) {
+	if !isASCII(input) {
+	    return MetaString{}, errors.New("non-ASCII characters in meta string are not allowed")
+	}
 	if len(input) > 32767 {
 		return MetaString{}, errors.New("long meta string than 32767 is not allowed")
 	}
@@ -165,6 +171,15 @@ func (e *Encoder) ComputeEncoding(input string) Encoding {
 		return LOWER_UPPER_DIGIT_SPECIAL
 	}
 	return UTF_8
+}
+
+func isASCII(input string) bool {
+    for _, r := range input {
+        if r > 127 {
+			return false
+        }
+    }
+    return true
 }
 
 type stringStatistics struct {

--- a/java/fury-core/src/main/java/org/apache/fury/meta/MetaStringEncoder.java
+++ b/java/fury-core/src/main/java/org/apache/fury/meta/MetaStringEncoder.java
@@ -49,6 +49,9 @@ public class MetaStringEncoder {
    * @return A MetaString object representing the encoded string.
    */
   public MetaString encode(String input) {
+    if (!isASCII(input)) {
+      throw new IllegalArgumentException("Non-ASCII characters in meta string are not allowed");
+    }
     return encode(input, Encoding.values());
   }
 
@@ -70,6 +73,9 @@ public class MetaStringEncoder {
   public MetaString encode(String input, Encoding encoding) {
     Preconditions.checkArgument(
         input.length() < Short.MAX_VALUE, "Long meta string than 32767 is not allowed");
+    if (!isASCII(input)) {
+      throw new IllegalArgumentException("Non-ASCII characters in meta string are not allowed");
+    }
     if (input.isEmpty()) {
       return new MetaString(input, Encoding.UTF_8, specialChar1, specialChar2, new byte[0]);
     }
@@ -135,6 +141,10 @@ public class MetaStringEncoder {
       }
     }
     return Encoding.UTF_8;
+  }
+
+  private boolean isASCII(String input) {
+    return input.chars().allMatch(c -> c < 128);
   }
 
   private static class StringStatistics {

--- a/java/fury-core/src/main/java/org/apache/fury/meta/MetaStringEncoder.java
+++ b/java/fury-core/src/main/java/org/apache/fury/meta/MetaStringEncoder.java
@@ -23,6 +23,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import org.apache.fury.collection.Collections;
 import org.apache.fury.meta.MetaString.Encoding;
+import org.apache.fury.serializer.StringSerializer;
 import org.apache.fury.util.Preconditions;
 
 /** Encodes plain text strings into MetaString objects with specified encoding mechanisms. */
@@ -70,7 +71,7 @@ public class MetaStringEncoder {
   public MetaString encode(String input, Encoding encoding) {
     Preconditions.checkArgument(
         input.length() < Short.MAX_VALUE, "Long meta string than 32767 is not allowed");
-    if (encoding != Encoding.UTF_8 && !isASCII(input)) {
+    if (encoding != Encoding.UTF_8 && !StringSerializer.isLatin(input.toCharArray())) {
       throw new IllegalArgumentException("Non-ASCII characters in meta string are not allowed");
     }
     if (input.isEmpty()) {
@@ -138,10 +139,6 @@ public class MetaStringEncoder {
       }
     }
     return Encoding.UTF_8;
-  }
-
-  private boolean isASCII(String input) {
-    return input.chars().allMatch(c -> c < 128);
   }
 
   private static class StringStatistics {

--- a/java/fury-core/src/main/java/org/apache/fury/meta/MetaStringEncoder.java
+++ b/java/fury-core/src/main/java/org/apache/fury/meta/MetaStringEncoder.java
@@ -49,9 +49,6 @@ public class MetaStringEncoder {
    * @return A MetaString object representing the encoded string.
    */
   public MetaString encode(String input) {
-    if (!isASCII(input)) {
-      throw new IllegalArgumentException("Non-ASCII characters in meta string are not allowed");
-    }
     return encode(input, Encoding.values());
   }
 
@@ -73,7 +70,7 @@ public class MetaStringEncoder {
   public MetaString encode(String input, Encoding encoding) {
     Preconditions.checkArgument(
         input.length() < Short.MAX_VALUE, "Long meta string than 32767 is not allowed");
-    if (!isASCII(input)) {
+    if (encoding != Encoding.UTF_8 && !isASCII(input)) {
       throw new IllegalArgumentException("Non-ASCII characters in meta string are not allowed");
     }
     if (input.isEmpty()) {


### PR DESCRIPTION
<!--
**Thanks for contributing to Fury.**

**If this is your first time opening a PR on fury, you can refer to [CONTRIBUTING.md](https://github.com/apache/incubator-fury/blob/main/CONTRIBUTING.md).**

Contribution Checklist

    - The **Apache Fury (incubating)** community has restrictions on the naming of pr titles. You can also find instructions in [CONTRIBUTING.md](https://github.com/apache/incubator-fury/blob/main/CONTRIBUTING.md).

    - Fury has a strong focus on performance. If the PR you submit will have an impact on performance, please benchmark it first and provide the benchmark result here.
-->

## What does this PR do?

<!-- Describe the purpose of this PR. -->
This PR introduces a validation method to ensure that all input strings to the `MetaString` encoder are ASCII.

## Related issues

<!--
Is there any related issue? Please attach here.

- #1619 
- #xxxx1
- #xxxx2
-->


## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/incubator-fury/issues/new/choose) describing the need to do so and update the document if necessary.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?


## Benchmark

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.
-->
