### PR TITLE
feat(java): register old version guava collect

### DIFF
--- a/java/fury-core/src/main/java/org/apache/fury/serializer/collection/GuavaCollectionSerializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/collection/GuavaCollectionSerializers.java
@@ -421,7 +421,7 @@ public class GuavaCollectionSerializers {
       class GuavaEmptyBiMap {}
 
       cls = GuavaEmptyBiMap.class;
-      fury.registerSerializer(cls, new ImmutableSetSerializer(fury, cls));
+      fury.registerSerializer(cls, new ImmutableMapSerializer(fury, cls));
     }
     if (checkClassExist(pkg + ".EmptyImmutableSortedSet")) {
       cls = loadClass(pkg + ".EmptyImmutableSortedSet", ImmutableSortedSet.of().getClass());
@@ -430,7 +430,7 @@ public class GuavaCollectionSerializers {
       class GuavaEmptySortedSet {}
 
       cls = GuavaEmptySortedSet.class;
-      fury.registerSerializer(cls, new ImmutableSetSerializer(fury, cls));
+      fury.registerSerializer(cls, new ImmutableSortedSetSerializer(fury, cls));
     }
     if (checkClassExist(pkg + ".EmptyImmutableSortedMap")) {
       cls = loadClass(pkg + ".EmptyImmutableSortedMap", ImmutableSortedMap.of().getClass());
@@ -439,7 +439,7 @@ public class GuavaCollectionSerializers {
       class GuavaEmptySortedMap {}
 
       cls = GuavaEmptySortedMap.class;
-      fury.registerSerializer(cls, new ImmutableSetSerializer(fury, cls));
+      fury.registerSerializer(cls, new ImmutableSortedMapSerializer(fury, cls));
     }
   }
 

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/collection/GuavaCollectionSerializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/collection/GuavaCollectionSerializers.java
@@ -373,6 +373,7 @@ public class GuavaCollectionSerializers {
   // guava/TreeMultimapSerializer - serializer for guava-libraries' TreeMultimap
   // guava/UnmodifiableNavigableSetSerializer - serializer for guava-libraries'
   // UnmodifiableNavigableSet
+
   public static void registerDefaultSerializers(Fury fury) {
     // Note: Guava common types are not public API, don't register by `ImmutableXXX.of()`,
     // since different guava version may return different type objects, which make class
@@ -403,22 +404,42 @@ public class GuavaCollectionSerializers {
 
     // Guava version before 19.0, of() return
     // EmptyImmutableSet/EmptyImmutableBiMap/EmptyImmutableSortedMap/EmptyImmutableSortedSet
-    // we register if class exist
+    // we register if class exist or register empty to deserialize.
     if (checkClassExist(pkg + ".EmptyImmutableSet")) {
       cls = loadClass(pkg + ".EmptyImmutableSet", ImmutableSet.of().getClass());
+      fury.registerSerializer(cls, new ImmutableSetSerializer(fury, cls));
+    } else {
+      class GuavaEmptySet {}
+
+      cls = GuavaEmptySet.class;
       fury.registerSerializer(cls, new ImmutableSetSerializer(fury, cls));
     }
     if (checkClassExist(pkg + ".EmptyImmutableBiMap")) {
       cls = loadClass(pkg + ".EmptyImmutableBiMap", ImmutableBiMap.of().getClass());
       fury.registerSerializer(cls, new ImmutableMapSerializer(fury, cls));
+    } else {
+      class GuavaEmptyBiMap {}
+
+      cls = GuavaEmptyBiMap.class;
+      fury.registerSerializer(cls, new ImmutableSetSerializer(fury, cls));
     }
     if (checkClassExist(pkg + ".EmptyImmutableSortedSet")) {
       cls = loadClass(pkg + ".EmptyImmutableSortedSet", ImmutableSortedSet.of().getClass());
       fury.registerSerializer(cls, new ImmutableSortedSetSerializer(fury, cls));
+    } else {
+      class GuavaEmptySortedSet {}
+
+      cls = GuavaEmptySortedSet.class;
+      fury.registerSerializer(cls, new ImmutableSetSerializer(fury, cls));
     }
     if (checkClassExist(pkg + ".EmptyImmutableSortedMap")) {
       cls = loadClass(pkg + ".EmptyImmutableSortedMap", ImmutableSortedMap.of().getClass());
       fury.registerSerializer(cls, new ImmutableSortedMapSerializer(fury, cls));
+    } else {
+      class GuavaEmptySortedMap {}
+
+      cls = GuavaEmptySortedMap.class;
+      fury.registerSerializer(cls, new ImmutableSetSerializer(fury, cls));
     }
   }
 

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/collection/GuavaCollectionSerializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/collection/GuavaCollectionSerializers.java
@@ -380,17 +380,17 @@ public class GuavaCollectionSerializers {
     // inconsistent if peers load different version of guava.
     // For example: guava 20 return ImmutableBiMap for ImmutableMap.of(), but guava 27 return
     // ImmutableMap.
-    Class cls = loadClass(pkg + ".RegularImmutableBiMap", ImmutableBiMap.of().getClass());
+    Class cls = loadClass(pkg + ".RegularImmutableBiMap", ImmutableBiMap.of("k1", 1, "k2", 4).getClass());
     fury.registerSerializer(cls, new ImmutableBiMapSerializer(fury, cls));
     cls = loadClass(pkg + ".SingletonImmutableBiMap", ImmutableBiMap.of(1, 2).getClass());
     fury.registerSerializer(cls, new ImmutableBiMapSerializer(fury, cls));
-    cls = loadClass(pkg + ".RegularImmutableMap", ImmutableMap.of().getClass());
+    cls = loadClass(pkg + ".RegularImmutableMap", ImmutableMap.of("k1", 1, "k2", 2).getClass());
     fury.registerSerializer(cls, new ImmutableMapSerializer(fury, cls));
     cls = loadClass(pkg + ".RegularImmutableList", ImmutableList.of().getClass());
     fury.registerSerializer(cls, new RegularImmutableListSerializer(fury, cls));
     cls = loadClass(pkg + ".SingletonImmutableList", ImmutableList.of(1).getClass());
     fury.registerSerializer(cls, new ImmutableListSerializer(fury, cls));
-    cls = loadClass(pkg + ".RegularImmutableSet", ImmutableSet.of().getClass());
+    cls = loadClass(pkg + ".RegularImmutableSet", ImmutableSet.of(1, 2).getClass());
     fury.registerSerializer(cls, new ImmutableSetSerializer(fury, cls));
     cls = loadClass(pkg + ".SingletonImmutableSet", ImmutableSet.of(1).getClass());
     fury.registerSerializer(cls, new ImmutableSetSerializer(fury, cls));
@@ -399,6 +399,26 @@ public class GuavaCollectionSerializers {
     fury.registerSerializer(cls, new ImmutableSortedSetSerializer<>(fury, cls));
     cls = loadClass(pkg + ".ImmutableSortedMap", ImmutableSortedMap.of(1, 2).getClass());
     fury.registerSerializer(cls, new ImmutableSortedMapSerializer<>(fury, cls));
+
+    // Guava version before 19.0, of() return
+    // EmptyImmutableSet/EmptyImmutableBiMap/EmptyImmutableSortedMap/EmptyImmutableSortedSet
+    // we register if class exist
+    if (checkClassExist(pkg + ".EmptyImmutableSet")) {
+      cls = loadClass(pkg + ".EmptyImmutableSet", ImmutableSet.of().getClass());
+      fury.registerSerializer(cls, new ImmutableSetSerializer(fury, cls));
+    }
+    if (checkClassExist(pkg + ".EmptyImmutableBiMap")) {
+      cls = loadClass(pkg + ".EmptyImmutableBiMap", ImmutableBiMap.of().getClass());
+      fury.registerSerializer(cls, new ImmutableMapSerializer(fury, cls));
+    }
+    if (checkClassExist(pkg + ".EmptyImmutableSortedSet")) {
+      cls = loadClass(pkg + ".EmptyImmutableSortedSet", ImmutableSortedSet.of().getClass());
+      fury.registerSerializer(cls, new ImmutableSortedSetSerializer(fury, cls));
+    }
+    if (checkClassExist(pkg + ".EmptyImmutableSortedMap")) {
+      cls = loadClass(pkg + ".EmptyImmutableSortedMap", ImmutableSortedMap.of().getClass());
+      fury.registerSerializer(cls, new ImmutableSortedMapSerializer(fury, cls));
+    }
   }
 
   static Class<?> loadClass(String className, Class<?> cache) {
@@ -411,5 +431,14 @@ public class GuavaCollectionSerializers {
         throw new RuntimeException(e);
       }
     }
+  }
+
+  static boolean checkClassExist(String className) {
+    try {
+      Class.forName(className);
+    } catch (ClassNotFoundException e) {
+      return false;
+    }
+    return true;
   }
 }

--- a/java/fury-core/src/main/java/org/apache/fury/serializer/collection/GuavaCollectionSerializers.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/collection/GuavaCollectionSerializers.java
@@ -380,7 +380,8 @@ public class GuavaCollectionSerializers {
     // inconsistent if peers load different version of guava.
     // For example: guava 20 return ImmutableBiMap for ImmutableMap.of(), but guava 27 return
     // ImmutableMap.
-    Class cls = loadClass(pkg + ".RegularImmutableBiMap", ImmutableBiMap.of("k1", 1, "k2", 4).getClass());
+    Class cls =
+        loadClass(pkg + ".RegularImmutableBiMap", ImmutableBiMap.of("k1", 1, "k2", 4).getClass());
     fury.registerSerializer(cls, new ImmutableBiMapSerializer(fury, cls));
     cls = loadClass(pkg + ".SingletonImmutableBiMap", ImmutableBiMap.of(1, 2).getClass());
     fury.registerSerializer(cls, new ImmutableBiMapSerializer(fury, cls));


### PR DESCRIPTION
<!--
**Thanks for contributing to Fury.**

**If this is your first time opening a PR on fury, you can refer to [CONTRIBUTING.md](https://github.com/apache/incubator-fury/blob/main/CONTRIBUTING.md).**

Contribution Checklist

    - The **Apache Fury (incubating)** community has restrictions on the naming of pr titles. You can also find instructions in [CONTRIBUTING.md](https://github.com/apache/incubator-fury/blob/main/CONTRIBUTING.md).

    - Fury has a strong focus on performance. If the PR you submit will have an impact on performance, please benchmark it first and provide the benchmark result here.
-->

## What does this PR do?

<!-- Describe the purpose of this PR. -->

before guava 19.0, of() return EmptyImmutableSet/EmptyImmutableBiMap/EmptyImmutableSortedMap/EmptyImmutableSortedSet. check class and register serializer for them.

## Related issues

<!--
Is there any related issue? Please attach here.

- #xxxx0
- #xxxx1
- #xxxx2
-->


## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/incubator-fury/issues/new/choose) describing the need to do so and update the document if necessary.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?


## Benchmark

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.
-->
