### PR TITLE
fix(java): subclass without fields will encode superclass

### DIFF
--- a/java/fury-core/src/main/java/org/apache/fury/meta/ClassDefEncoder.java
+++ b/java/fury-core/src/main/java/org/apache/fury/meta/ClassDefEncoder.java
@@ -199,6 +199,8 @@ class ClassDefEncoder {
       List<FieldInfo> fieldInfos = classFields.get(clz.getName());
       if (fieldInfos != null) {
         sortedClassFields.put(clz.getName(), fieldInfos);
+      } else if (type.getName().equals(clz.getName())) {
+        sortedClassFields.put(clz.getName(), new ArrayList<>());
       }
     }
     classFields = sortedClassFields;

--- a/java/fury-core/src/test/java/org/apache/fury/meta/ClassDefEncoderTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/meta/ClassDefEncoderTest.java
@@ -70,7 +70,6 @@ public class ClassDefEncoderTest {
     private int f1;
   }
 
-  @Data
   public static class Foo2 extends Foo1 {}
 
   @Test

--- a/java/fury-core/src/test/java/org/apache/fury/meta/ClassDefEncoderTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/meta/ClassDefEncoderTest.java
@@ -26,10 +26,8 @@ import java.util.HashMap;
 import java.util.List;
 import lombok.Data;
 import org.apache.fury.Fury;
-import org.apache.fury.config.CompatibleMode;
 import org.apache.fury.config.Language;
 import org.apache.fury.memory.MemoryBuffer;
-import org.apache.fury.resolver.MetaContext;
 import org.apache.fury.test.bean.BeanA;
 import org.apache.fury.test.bean.MapFields;
 import org.apache.fury.test.bean.Struct;
@@ -77,20 +75,12 @@ public class ClassDefEncoderTest {
 
   @Test
   public void testEmptySubClassSerializer() {
-    final Foo2 foo2 = new Foo2();
-    foo2.setF1(100);
+    Fury fury = Fury.builder().withLanguage(Language.JAVA).requireClassRegistration(true).build();
+    ClassDef classDef = ClassDef.buildClassDef(fury, Foo2.class);
+    ClassDef classDef1 =
+        ClassDef.readClassDef(
+            fury.getClassResolver(), MemoryBuffer.fromByteArray(classDef.getEncoded()));
 
-    Fury fury =
-        Fury.builder()
-            .withLanguage(Language.JAVA)
-            .requireClassRegistration(false)
-            .withCompatibleMode(CompatibleMode.COMPATIBLE)
-            .withMetaContextShare(true)
-            .build();
-    fury.getSerializationContext().setMetaContext(new MetaContext());
-    final byte[] serialize = fury.serialize(foo2);
-    fury.getSerializationContext().setMetaContext(new MetaContext());
-
-    Assert.assertEquals(foo2, fury.deserialize(serialize));
+    Assert.assertEquals(classDef, classDef1);
   }
 }

--- a/java/fury-core/src/test/java/org/apache/fury/serializer/MetaSharedCompatibleTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/serializer/MetaSharedCompatibleTest.java
@@ -704,11 +704,7 @@ public class MetaSharedCompatibleTest extends FuryTestBase {
     Object o1 = cls1.newInstance();
     for (Field field : ReflectionUtils.getFields(cls1, true)) {
       field.setAccessible(true);
-      if (field.getDeclaringClass() == DuplicateFieldsClass1.class) {
-        field.setInt(o1, 10);
-      } else {
-        field.setInt(o1, 100);
-      }
+      field.setInt(o1, 10);
     }
     Object o = serDeMetaShared(fury, o1);
     Assert.assertEquals(o.getClass(), o1.getClass());

--- a/java/fury-core/src/test/java/org/apache/fury/serializer/MetaSharedCompatibleTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/serializer/MetaSharedCompatibleTest.java
@@ -673,4 +673,45 @@ public class MetaSharedCompatibleTest extends FuryTestBase {
       }
     }
   }
+
+  @Test(dataProvider = "config1")
+  void testEmptySubClass(boolean referenceTracking, boolean compressNumber, boolean enableCodegen)
+      throws Exception {
+    String pkg = DuplicateFieldsClass1.class.getPackage().getName();
+    Class<?> cls1 =
+        loadClass(
+            pkg,
+            "DuplicateFieldsClass2",
+            ""
+                + "package "
+                + pkg
+                + ";\n"
+                + "import java.util.*;\n"
+                + "import java.math.*;\n"
+                + "public class DuplicateFieldsClass2 extends MetaSharedCompatibleTest.DuplicateFieldsClass1 {\n"
+                + "}");
+    Fury fury =
+        Fury.builder()
+            .withLanguage(Language.JAVA)
+            .withRefTracking(referenceTracking)
+            .withNumberCompressed(compressNumber)
+            .withCodegen(enableCodegen)
+            .withMetaContextShare(true)
+            .withCompatibleMode(CompatibleMode.COMPATIBLE)
+            .requireClassRegistration(false)
+            .withClassLoader(cls1.getClassLoader())
+            .build();
+    Object o1 = cls1.newInstance();
+    for (Field field : ReflectionUtils.getFields(cls1, true)) {
+      field.setAccessible(true);
+      if (field.getDeclaringClass() == DuplicateFieldsClass1.class) {
+        field.setInt(o1, 10);
+      } else {
+        field.setInt(o1, 100);
+      }
+    }
+    Object o = serDeMetaShared(fury, o1);
+    Assert.assertEquals(o.getClass(), o1.getClass());
+    Assert.assertTrue(ReflectionUtils.objectFieldsEquals(o, o1));
+  }
 }


### PR DESCRIPTION
<!--
**Thanks for contributing to Fury.**

**If this is your first time opening a PR on fury, you can refer to [CONTRIBUTING.md](https://github.com/apache/incubator-fury/blob/main/CONTRIBUTING.md).**

Contribution Checklist

    - The **Apache Fury (incubating)** community has restrictions on the naming of pr titles. You can also find instructions in [CONTRIBUTING.md](https://github.com/apache/incubator-fury/blob/main/CONTRIBUTING.md).

    - Fury has a strong focus on performance. If the PR you submit will have an impact on performance, please benchmark it first and provide the benchmark result here.
-->

## What does this PR do?

<!-- Describe the purpose of this PR. -->

when subclass without fields. `org.apache.fury.meta.ClassDefEncoder#getClassFields` will skip subclass so className will be superclass. however we should save class even fields is empty.

## Related issues

<!--
Is there any related issue? Please attach here.

- #xxxx0
- #xxxx1
- #xxxx2
-->


## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/incubator-fury/issues/new/choose) describing the need to do so and update the document if necessary.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?


## Benchmark

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.
-->
