### PR TITLE
perf(java): Lower the threshold for multi-byte reading

### DIFF
--- a/java/fury-core/src/main/java/org/apache/fury/memory/MemoryBuffer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/memory/MemoryBuffer.java
@@ -1625,7 +1625,7 @@ public final class MemoryBuffer {
     // noinspection Duplicates
     int readIdx = readerIndex;
     int result;
-    if (size - readIdx < 5) {
+    if (size - readIdx < 4) {
       result = (int) readVarUint36Slow();
     } else {
       long address = this.address;
@@ -1668,7 +1668,7 @@ public final class MemoryBuffer {
     // noinspection Duplicates
     int readIdx = readerIndex;
     int result;
-    if (size - readIdx < 5) {
+    if (size - readIdx < 4) {
       result = (int) readVarUint36Slow();
     } else {
       long address = this.address;
@@ -1706,7 +1706,7 @@ public final class MemoryBuffer {
     // Duplicate and manual inline for performance.
     // noinspection Duplicates
     int readIdx = readerIndex;
-    if (size - readIdx >= 9) {
+    if (size - readIdx >= 8) {
       long bulkValue = _unsafeGetInt64(readIdx++);
       // noinspection Duplicates
       long result = bulkValue & 0x7F;
@@ -1774,7 +1774,7 @@ public final class MemoryBuffer {
   /** Reads the 1-5 byte int part of a non-negative varint. */
   public int readVarUint32() {
     int readIdx = readerIndex;
-    if (size - readIdx < 5) {
+    if (size - readIdx < 4) {
       return (int) readVarUint36Slow();
     }
     // | 1bit + 7bits | 1bit + 7bits | 1bit + 7bits | 1bit + 7bits |
@@ -1829,7 +1829,7 @@ public final class MemoryBuffer {
    */
   public int readVarUint32Small14() {
     int readIdx = readerIndex;
-    if (size - readIdx >= 5) {
+    if (size - readIdx >= 4) {
       int fourByteValue = _unsafeGetInt32(readIdx++);
       int value = fourByteValue & 0x7F;
       // Duplicate and manual inline for performance.
@@ -1879,7 +1879,7 @@ public final class MemoryBuffer {
     // noinspection Duplicates
     int readIdx = readerIndex;
     long result;
-    if (size - readIdx < 9) {
+    if (size - readIdx < 8) {
       result = readVarUint64Slow();
     } else {
       long address = this.address;
@@ -1909,7 +1909,7 @@ public final class MemoryBuffer {
     // CHECKSTYLE.ON:MethodName
     int readIdx = readerIndex;
     long result;
-    if (size - readIdx < 9) {
+    if (size - readIdx < 8) {
       result = readVarUint64Slow();
     } else {
       long address = this.address;
@@ -1936,7 +1936,7 @@ public final class MemoryBuffer {
   /** Reads the 1-9 byte int part of a non-negative var long. */
   public long readVarUint64() {
     int readIdx = readerIndex;
-    if (size - readIdx < 9) {
+    if (size - readIdx < 8) {
       return readVarUint64Slow();
     }
     // varint are written using little endian byte order, so read by little endian byte order.


### PR DESCRIPTION
<!--
**Thanks for contributing to Fury.**

**If this is your first time opening a PR on fury, you can refer to [CONTRIBUTING.md](https://github.com/apache/incubator-fury/blob/main/CONTRIBUTING.md).**

Contribution Checklist

    - The **Apache Fury (incubating)** community has restrictions on the naming of pr titles. You can also find instructions in [CONTRIBUTING.md](https://github.com/apache/incubator-fury/blob/main/CONTRIBUTING.md).

    - Fury has a strong focus on performance. If the PR you submit will have an impact on performance, please benchmark it first and provide the benchmark result here.
-->

## What does this PR do?

<!-- Describe the purpose of this PR. -->
We only need to ensure that `_unsafeGetInt32` and `_unsafeGetInt64` can take out values, which can reduce the performance loss caused by multiple readBytes.


## Related issues

<!--
Is there any related issue? Please attach here.

- #xxxx0
- #xxxx1
- #xxxx2
-->


## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/incubator-fury/issues/new/choose) describing the need to do so and update the document if necessary.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?


## Benchmark

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.
-->
