### PR TITLE
chore: bump release version to 0.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,19 +111,19 @@ Release version:
 <dependency>
   <groupId>org.apache.fury</groupId>
   <artifactId>fury-core</artifactId>
-  <version>0.5.0</version>
+  <version>0.5.1</version>
 </dependency>
 <!-- row/arrow format support -->
 <!-- <dependency>
   <groupId>org.apache.fury</groupId>
   <artifactId>fury-format</artifactId>
-  <version>0.5.0</version>
+  <version>0.5.1</version>
 </dependency> -->
 ```
 
 ### Scala
 ```sbt
-libraryDependencies += "org.apache.fury" % "fury-core" % "0.5.0"
+libraryDependencies += "org.apache.fury" % "fury-core" % "0.5.1"
 ```
 
 ### Python

--- a/ci/release.py
+++ b/ci/release.py
@@ -47,7 +47,7 @@ def prepare(v: str):
 
 
 def build(v: str):
-    """version format: 0.5.0"""
+    """version format: 0.5.1"""
     logger.info("Start to prepare release artifacts for version %s", v)
     _check_release_version(v)
     os.chdir(PROJECT_ROOT_DIR)

--- a/docs/guide/scala_guide.md
+++ b/docs/guide/scala_guide.md
@@ -16,7 +16,7 @@ Scala 2 and 3 are both supported.
 
 ## Install
 ```sbt
-libraryDependencies += "org.apache.fury" % "fury-core" % "0.5.0"
+libraryDependencies += "org.apache.fury" % "fury-core" % "0.5.1"
 ```
 
 ## Fury creation


### PR DESCRIPTION


## What does this PR do?

This PR bumps release version to 0.5.1 since fury 0.5.1 has been released

## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/incubator-fury/issues/new/choose) describing the need to do so and update the document if necessary.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?


## Benchmark

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.
-->
