### PR TITLE
fix(java): Fix header offset issue in MetaStringBytes hashcode

### DIFF
--- a/java/fury-core/src/main/java/org/apache/fury/resolver/MetaStringBytes.java
+++ b/java/fury-core/src/main/java/org/apache/fury/resolver/MetaStringBytes.java
@@ -28,6 +28,7 @@ import org.apache.fury.util.MurmurHash3;
 @Internal
 final class MetaStringBytes {
   static final short DEFAULT_DYNAMIC_WRITE_STRING_ID = -1;
+  private final int HEADER_MASK = 0xff;
 
   final byte[] bytes;
   final long hashCode;
@@ -55,7 +56,7 @@ final class MetaStringBytes {
       hashCode += 256; // last byte is reserved for header.
     }
     hashCode &= 0xffffffffffffff00L;
-    int header = metaString.getEncoding().getValue();
+    int header = metaString.getEncoding().getValue() & HEADER_MASK;
     this.hashCode = hashCode | header;
   }
 
@@ -64,9 +65,8 @@ final class MetaStringBytes {
   }
 
   public String decode(MetaStringDecoder decoder) {
-    int header = (int) (hashCode & 0xff);
-    int encodingFlags = header & 0b111;
-    MetaString.Encoding encoding = MetaString.Encoding.values()[encodingFlags];
+    int header = (int) (hashCode & HEADER_MASK);
+    MetaString.Encoding encoding = MetaString.Encoding.values()[header];
     return decoder.decode(bytes, encoding);
   }
 

--- a/java/fury-core/src/main/java/org/apache/fury/resolver/MetaStringBytes.java
+++ b/java/fury-core/src/main/java/org/apache/fury/resolver/MetaStringBytes.java
@@ -28,7 +28,7 @@ import org.apache.fury.util.MurmurHash3;
 @Internal
 final class MetaStringBytes {
   static final short DEFAULT_DYNAMIC_WRITE_STRING_ID = -1;
-  private final int HEADER_MASK = 0xff;
+  private static final int HEADER_MASK = 0xff;
 
   final byte[] bytes;
   final long hashCode;


### PR DESCRIPTION
<!--
**Thanks for contributing to Fury.**

**If this is your first time opening a PR on fury, you can refer to [CONTRIBUTING.md](https://github.com/apache/incubator-fury/blob/main/CONTRIBUTING.md).**

Contribution Checklist

    - The **Apache Fury (incubating)** community has restrictions on the naming of pr titles. You can also find instructions in [CONTRIBUTING.md](https://github.com/apache/incubator-fury/blob/main/CONTRIBUTING.md).

    - Fury has a strong focus on performance. If the PR you submit will have an impact on performance, please benchmark it first and provide the benchmark result here.
-->

## What does this PR do?

<!-- Describe the purpose of this PR. -->
MetaStringBytes `hashcode & 0xff`, that is, header, represents the encoding

## Related issues

<!--
Is there any related issue? Please attach here.

- #xxxx0
- #xxxx1
- #xxxx2
-->


## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/incubator-fury/issues/new/choose) describing the need to do so and update the document if necessary.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?


## Benchmark

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.
-->
